### PR TITLE
Support multiple message types

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -183,10 +183,10 @@ module.exports = function(botkit,config) {
     // construct a valid slack message
     var slack_message = {
       id: bot.msgcount++,
-      type: 'message',
+      type: message.type||'message',
 
       channel: message.channel,
-      text: message.text,
+      text: message.text||null,
       username: message.username||null,
       parse: message.parse||null,
       link_names: message.link_names||null,


### PR DESCRIPTION
This enables support for multiple message types.

For example, the following will now work;
```
bot.reply(message, {"type": "typing"});

setTimeout(function() {
    bot.reply(message, "Hello there!");
}, 2000);
```
which will show the bot as typing before sending a response. This is particularly useful when you have to perform some computation before replying after a few seconds.