### PR TITLE
Custom OAuth clientRedirectUri handling

### DIFF
--- a/examples/slackbutton_incomingwebhooks.js
+++ b/examples/slackbutton_incomingwebhooks.js
@@ -23,7 +23,7 @@ This bot demonstrates many of the core features of Botkit:
 
   Run your bot from the command line:
 
-    clientId=<my client id> clientSecret=<my client secret> port=3000 node bot.js
+    clientId=<my client id> clientSecret=<my client secret> clientRedirectUri=<my client redirect uri> port=3000 node bot.js
 
 # USE THE APP
 
@@ -51,7 +51,7 @@ This bot demonstrates many of the core features of Botkit:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 var Botkit = require('../lib/Botkit.js');
 
-if (!process.env.clientId || !process.env.clientSecret || !process.env.port) {
+if (!process.env.clientId || !process.env.clientSecret || !process.env.port || !process.env.clientRedirectUri) {
   console.log('Error: Specify clientId clientSecret and port in environment');
   process.exit(1);
 }
@@ -62,6 +62,7 @@ var controller = Botkit.slackbot({
   {
     clientId: process.env.clientId,
     clientSecret: process.env.clientSecret,
+    clientRedirectUri: process.env.clientRedirectUri,
     scopes: ['incoming-webhook'],
   }
 );

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -25,6 +25,11 @@ function Slackbot(configuration) {
     } else {
       slack_botkit.config.clientId = slack_app_config.clientId;
       slack_botkit.config.clientSecret = slack_app_config.clientSecret;
+
+      if (slack_app_config.clientRedirectUri) {
+        slack_botkit.config.clientRedirectUri = slack_app_config.clientRedirectUri;
+      }
+
       if (typeof(slack_app_config.scopes)=='string') {
         slack_botkit.config.scopes = slack_app_config.scopes.split(/\,/);
       } else {
@@ -257,14 +262,17 @@ function Slackbot(configuration) {
 
     webserver.get('/oauth',function(req,res) {
 
-      var code = req.query.code;
-      var state = req.query.state;
-
-      oauth_access({
+      var credentials = {
         client_id: slack_botkit.config.clientId,
         client_secret: slack_botkit.config.clientSecret,
-        code: code
-      },function(err,auth) {
+        code: req.query.code
+      };
+
+      if (slack_botkit.config.clientRedirectUri) {
+        credentials.redirect_uri = slack_botkit.config.clientRedirectUri;
+      }
+
+      oauth_access(credentials,function(err,auth) {
 
         if (err) {
           if (callback) {

--- a/readme.md
+++ b/readme.md
@@ -222,7 +222,7 @@ for more information about listening for and responding to messages.
 
 It is also possible to bind event handlers directly to any of the enormous number of native Slack events, as well as a handful of custom events emitted by Botkit.
 
-You can receive and handle any of the [native events thrown by slack](https://api.slack.com/events).  
+You can receive and handle any of the [native events thrown by slack](https://api.slack.com/events).
 
 ```javascript
 controller.on('channel_joined',function(bot,message) {
@@ -522,7 +522,7 @@ controller.hears(['question me'],['direct_message','direct_mention','mention','a
         pattern: 'done',
         callback: function(response,convo) {
           convo.say('OK you are done!');
-          convo.next();          
+          convo.next();
         }
       },
       {
@@ -960,7 +960,7 @@ See the [included examples](#included-examples) for several ready to use example
 
 | Argument | Description
 |---  |---
-| config | configuration object containing clientId, clientSecret, redirect_uri and scopes
+| config | configuration object containing clientId, clientSecret, clientRedirectUri and scopes
 
 Configure Botkit to work with a Slack application.
 
@@ -971,7 +971,7 @@ Configuration must include:
 
 * clientId - Application clientId from Slack
 * clientSecret - Application clientSecret from Slack
-* redirect_uri - the base url of your application
+* clientRedirectUri - the base url of your application
 * scopes - an array of oauth permission scopes
 
 Slack has [_many, many_ oauth scopes](https://api.slack.com/docs/oauth-scopes)
@@ -998,7 +998,7 @@ var controller = Botkit.slackbot();
 controller.configureSlackApp({
   clientId: process.env.clientId,
   clientSecret: process.env.clientSecret,
-  redirect_uri: 'http://localhost:3002',
+  clientRedirectUri: 'http://localhost:3002',
   scopes: ['incoming-webhook','team:read','users:read','channels:read','im:read','im:write','groups:read','emoji:read','chat:write:bot']
 });
 


### PR DESCRIPTION
As seen in `#27`, I did not find a way to pass a custom redirect uri (my app have many) to Botkit. This small PR add this capability.
