### PR TITLE
Inject RegExp match into message

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -640,14 +640,16 @@ function Botkit(configuration) {
       events = events.split(/\,/g);
     }
 
+    var match;
     for (var k = 0; k < keywords.length; k++) {
       var keyword = keywords[k];
       for (var e = 0; e < events.length; e++) {
         (function(keyword) {
           botkit.on(events[e],function(bot,message) {
             if (message.text) {
-              if (message.text.match(new RegExp(keyword,'i'))) {
+              if (match = message.text.match(new RegExp(keyword,'i'))) {
                 botkit.debug("I HEARD ",keyword);
+                message.match = match;
                 cb.apply(this,[bot,message]);
                 return false;
               }

--- a/readme.md
+++ b/readme.md
@@ -222,7 +222,7 @@ for more information about listening for and responding to messages.
 
 It is also possible to bind event handlers directly to any of the enormous number of native Slack events, as well as a handful of custom events emitted by Botkit.
 
-You can receive and handle any of the [native events thrown by slack](https://api.slack.com/events).  
+You can receive and handle any of the [native events thrown by slack](https://api.slack.com/events).
 
 ```javascript
 controller.on('channel_joined',function(bot,message) {
@@ -333,6 +333,16 @@ controller.hears(['keyword','^pattern$'],['direct_message','direct_mention','men
   // https://api.slack.com/events/message
   bot.reply(message,'You used a keyword!');
 
+});
+```
+
+```javascript
+controller.hears('open the (.*) doors',['direct_message','direct_mention','mention','ambient'],function(bot,message) {
+  var doorType = message.match[1];
+  if (doorType === 'back') {
+    return bot.reply(message, 'I cannot do that');
+  }
+  return bot.reply(message, 'Okay');
 });
 ```
 
@@ -522,7 +532,7 @@ controller.hears(['question me'],['direct_message','direct_mention','mention','a
         pattern: 'done',
         callback: function(response,convo) {
           convo.say('OK you are done!');
-          convo.next();          
+          convo.next();
         }
       },
       {


### PR DESCRIPTION
Another PR here! :p

I used to code on Hubot before trying Botkit and lack a feature I did not found (and maybe missed?) which is accessing the data matching the capturing `RegExp` in the `hears()` function, like [here in Hubot](https://hubot.github.com/docs/scripting/#capturing-data)

This PR inject the `match` object into `message` to deal with it more easily in the callback. Maybe I'll add some documentation in the README.

Best