### PR TITLE
fixes slash_command and outgoing webhook functions

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -89,7 +89,7 @@ function Slackbot(configuration) {
 
             res.status(200);
 
-            var bot = botkit.spawn(team);
+            var bot = slack_botkit.spawn(team);
 
             bot.team_info = team;
             bot.res = res;
@@ -124,7 +124,7 @@ function Slackbot(configuration) {
 
             res.status(200);
 
-            var bot = botkit.spawn(team);
+            var bot = slack_botkit.spawn(team);
             bot.res = res;
             bot.team_info = team;
 


### PR DESCRIPTION
This PR addresses the `botkit is undefined` error when attempting to implement custom slash-commands. Changing it to `slack_botkit` allows it to work again and I'm assuming that's what was meant to be there.