### PR TITLE
fix incorrect variable when checking id

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -601,7 +601,7 @@ function Botkit(configuration) {
       },
       save: function(channel,cb) {
         botkit.log('Warning: using temporary storage. Data will be lost when process restarts.')
-        if (user.id) {
+        if (channel.id) {
           botkit.memory_store['channels'][channel.id] = channel;
           cb(null,channel.id);
         } else {


### PR DESCRIPTION
Noticed that this checks for the presence of a user id rather than a channel id. :)