### PR TITLE
Add loglevels and an extension point for an external logging provider

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -801,11 +801,11 @@ function Botkit(configuration) {
 
   if (!configuration.logLevel) {
     if (configuration.debug) {
-      configuration.logLevel = 'DEBUG';
+      configuration.logLevel = 'debug';
     } else if (configuration.log === false) {
-      configuration.logLevel = 'ERROR';
+      configuration.logLevel = 'error';
     } else {
-      configuration.logLevel = 'INFO';
+      configuration.logLevel = 'info';
     }
   }
 

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -5,7 +5,6 @@ var mustache = require('mustache');
 var simple_storage = require(__dirname+'/storage/simple_storage.js');
 var ConsoleLogger = require(__dirname+'/console_logger.js');
 var LogLevels = ConsoleLogger.LogLevels;
-var slice = Array.prototype.slice;
 
 function Botkit(configuration) {
 
@@ -386,7 +385,7 @@ function Botkit(configuration) {
 
                 this.task.bot.say(message,function(err) {
                   if(err) {
-                    botkit.logerror('An error occurred while sending a message: ',err);
+                    botkit.log.error('An error occurred while sending a message: ',err);
                   }
                 });
               }
@@ -451,7 +450,7 @@ function Botkit(configuration) {
       var convo = new Conversation(this,message);
       convo.id = botkit.convoCount++;
 
-      botkit.lognotice('>   [Start] ',convo.id,' Conversation with ',message.user,'in',message.channel);
+      botkit.log.notice('>   [Start] ',convo.id,' Conversation with ',message.user,'in',message.channel);
 
       convo.activate();
       this.convos.push(convo);
@@ -461,7 +460,7 @@ function Botkit(configuration) {
 
     this.conversationEnded = function(convo) {
 
-      botkit.lognotice('>   [End] ',convo.id,' Conversation with ',convo.source_message.user,'in',convo.source_message.channel);
+      botkit.log.notice('>   [End] ',convo.id,' Conversation with ',convo.source_message.user,'in',convo.source_message.channel);
       this.trigger('conversationEnded',[convo]);
       convo.trigger('end',[convo]);
       var actives = 0;
@@ -478,7 +477,7 @@ function Botkit(configuration) {
 
     this.taskEnded = function() {
 
-      botkit.lognotice('[End] ',this.id,' Task for ',this.source_message.user,'in',this.source_message.channel);
+      botkit.log.notice('[End] ',this.id,' Task for ',this.source_message.user,'in',this.source_message.channel);
 
       this.status='completed';
       this.trigger('end',[this]);
@@ -568,7 +567,7 @@ function Botkit(configuration) {
         cb(null,botkit.memory_store['teams'][team_id]);
       },
       save: function(team,cb) {
-        botkit.logwarning('Using temporary storage. Data will be lost when process restarts.')
+        botkit.log.warning('Using temporary storage. Data will be lost when process restarts.')
         if (team.id) {
           botkit.memory_store['teams'][team.id] = team;
           cb(null,team.id);
@@ -585,7 +584,7 @@ function Botkit(configuration) {
         cb(null,botkit.memory_store['users'][user_id]);
       },
       save: function(user,cb) {
-        botkit.logwarning('Using temporary storage. Data will be lost when process restarts.')
+        botkit.log.warning('Using temporary storage. Data will be lost when process restarts.')
 
         if (user.id) {
           botkit.memory_store['users'][user.id] = user;
@@ -603,7 +602,7 @@ function Botkit(configuration) {
         cb(null,botkit.memory_store['channels'][channel_id]);
       },
       save: function(channel,cb) {
-        botkit.logwarning('Using temporary storage. Data will be lost when process restarts.')
+        botkit.log.warning('Using temporary storage. Data will be lost when process restarts.')
         if (channel.id) {
           botkit.memory_store['channels'][channel.id] = channel;
           cb(null,channel.id);
@@ -616,17 +615,6 @@ function Botkit(configuration) {
       }
     }
   }
-
-  Object.keys(LogLevels).forEach(function(level) {
-    botkit['log' + level] = function() {
-      botkit.logger.log.apply(
-        botkit.logger,
-        [level].concat(slice.call(arguments))
-      );
-    };
-  });
-  botkit.log = botkit.loginfo;
-  botkit.debug = botkit.logdebug;
 
   botkit.hears = function(keywords,events,cb) {
     if (typeof(keywords)=='string') {
@@ -818,6 +806,15 @@ function Botkit(configuration) {
   } else {
     botkit.logger = ConsoleLogger(console, configuration.logLevel);
   }
+
+  botkit.log = function() {
+    botkit.log.info.apply(botkit.log, arguments);
+  };
+  Object.keys(LogLevels).forEach(function(level) {
+    botkit.log[level] = botkit.logger.log.bind(botkit.logger, level);
+  });
+  botkit.debug = botkit.log.debug;
+
 
   if (configuration.storage) {
     if (

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -3,6 +3,9 @@
 /* These messages are expected to match Slack's message format. */
 var mustache = require('mustache');
 var simple_storage = require(__dirname+'/storage/simple_storage.js');
+var ConsoleLogger = require(__dirname+'/console_logger.js');
+var LogLevels = ConsoleLogger.LogLevels;
+var slice = Array.prototype.slice;
 
 function Botkit(configuration) {
 
@@ -383,7 +386,7 @@ function Botkit(configuration) {
 
                 this.task.bot.say(message,function(err) {
                   if(err) {
-                    botkit.log('An error occurred while sending a message: ',err);
+                    botkit.logerror('An error occurred while sending a message: ',err);
                   }
                 });
               }
@@ -448,7 +451,7 @@ function Botkit(configuration) {
       var convo = new Conversation(this,message);
       convo.id = botkit.convoCount++;
 
-      botkit.log('>   [Start] ',convo.id,' Conversation with ',message.user,'in',message.channel);
+      botkit.lognotice('>   [Start] ',convo.id,' Conversation with ',message.user,'in',message.channel);
 
       convo.activate();
       this.convos.push(convo);
@@ -458,7 +461,7 @@ function Botkit(configuration) {
 
     this.conversationEnded = function(convo) {
 
-      botkit.log('>   [End] ',convo.id,' Conversation with ',convo.source_message.user,'in',convo.source_message.channel);
+      botkit.lognotice('>   [End] ',convo.id,' Conversation with ',convo.source_message.user,'in',convo.source_message.channel);
       this.trigger('conversationEnded',[convo]);
       convo.trigger('end',[convo]);
       var actives = 0;
@@ -475,7 +478,7 @@ function Botkit(configuration) {
 
     this.taskEnded = function() {
 
-      botkit.log('[End] ',this.id,' Task for ',this.source_message.user,'in',this.source_message.channel);
+      botkit.lognotice('[End] ',this.id,' Task for ',this.source_message.user,'in',this.source_message.channel);
 
       this.status='completed';
       this.trigger('end',[this]);
@@ -565,7 +568,7 @@ function Botkit(configuration) {
         cb(null,botkit.memory_store['teams'][team_id]);
       },
       save: function(team,cb) {
-        botkit.log('Warning: using temporary storage. Data will be lost when process restarts.')
+        botkit.logwarning('Using temporary storage. Data will be lost when process restarts.')
         if (team.id) {
           botkit.memory_store['teams'][team.id] = team;
           cb(null,team.id);
@@ -582,7 +585,7 @@ function Botkit(configuration) {
         cb(null,botkit.memory_store['users'][user_id]);
       },
       save: function(user,cb) {
-        botkit.log('Warning: using temporary storage. Data will be lost when process restarts.')
+        botkit.logwarning('Using temporary storage. Data will be lost when process restarts.')
 
         if (user.id) {
           botkit.memory_store['users'][user.id] = user;
@@ -600,7 +603,7 @@ function Botkit(configuration) {
         cb(null,botkit.memory_store['channels'][channel_id]);
       },
       save: function(channel,cb) {
-        botkit.log('Warning: using temporary storage. Data will be lost when process restarts.')
+        botkit.logwarning('Using temporary storage. Data will be lost when process restarts.')
         if (channel.id) {
           botkit.memory_store['channels'][channel.id] = channel;
           cb(null,channel.id);
@@ -614,25 +617,16 @@ function Botkit(configuration) {
     }
   }
 
-  botkit.debug = function() {
-    if (configuration.debug) {
-      var args=[];
-      for (var k = 0; k < arguments.length; k++) {
-        args.push(arguments[k]);
-      }
-      console.log.apply(null,args);
-    }
-  }
-
-  botkit.log = function() {
-    if (configuration.log || configuration.log === undefined) { //default to true
-      var args=[];
-      for (var k = 0; k < arguments.length; k++) {
-        args.push(arguments[k]);
-      }
-      console.log.apply(null,args);
-    }
-  }
+  Object.keys(LogLevels).forEach(function(level) {
+    botkit['log' + level] = function() {
+      botkit.logger.log.apply(
+        botkit.logger,
+        [level].concat(slice.call(arguments))
+      );
+    };
+  });
+  botkit.log = botkit.loginfo;
+  botkit.debug = botkit.logdebug;
 
   botkit.hears = function(keywords,events,cb) {
     if (typeof(keywords)=='string') {
@@ -804,6 +798,26 @@ function Botkit(configuration) {
   }
 
   botkit.config = configuration;
+
+  if (!configuration.logLevel) {
+    if (configuration.debug) {
+      configuration.logLevel = 'DEBUG';
+    } else if (configuration.log === false) {
+      configuration.logLevel = 'ERROR';
+    } else {
+      configuration.logLevel = 'INFO';
+    }
+  }
+
+  if (configuration.logger) {
+    if (typeof configuration.logger.log === 'function') {
+      botkit.logger = configuration.logger;
+    } else {
+      throw new Error('Logger object does not have a `log` method!');
+    }
+  } else {
+    botkit.logger = ConsoleLogger(console, configuration.logLevel);
+  }
 
   if (configuration.storage) {
     if (

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -78,7 +78,7 @@ function Slackbot(configuration) {
           // this won't work for single team bots because the team info
           // might not be in a db
           if (err || !team) {
-            slack_botkit.logerror('Received slash command, but could not load team');
+            slack_botkit.log.error('Received slash command, but could not load team');
 
           } else {
             message.type='slash_command';
@@ -118,7 +118,7 @@ function Slackbot(configuration) {
           // this won't work for single team bots because the team info
           // might not be in a db
           if (err || !team) {
-            slack_botkit.logerror('Received outgoing webhook but could not load team');
+            slack_botkit.log.error('Received outgoing webhook but could not load team');
           } else {
             message.type='outgoing_webhook';
 
@@ -351,7 +351,7 @@ function Slackbot(configuration) {
 
                   slack_botkit.saveTeam(team,function(err,id) {
                     if (err) {
-                      slack_botkit.logerror('An error occurred while saving a team: ',err);
+                      slack_botkit.log.error('An error occurred while saving a team: ',err);
                       if (callback) {
                         callback(err,req,res);
                       } else {
@@ -380,7 +380,7 @@ function Slackbot(configuration) {
                         slack_botkit.storage.users.save(user,function(err,id) {
 
                           if (err) {
-                            slack_botkit.logerror('An error occurred while saving a user: ',err);
+                            slack_botkit.log.error('An error occurred while saving a user: ',err);
                             if (callback) {
                               callback(err,req,res);
                             } else {

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -78,7 +78,7 @@ function Slackbot(configuration) {
           // this won't work for single team bots because the team info
           // might not be in a db
           if (err || !team) {
-            slack_botkit.log('Received slash command, but could not load team');
+            slack_botkit.logerror('Received slash command, but could not load team');
 
           } else {
             message.type='slash_command';
@@ -118,7 +118,7 @@ function Slackbot(configuration) {
           // this won't work for single team bots because the team info
           // might not be in a db
           if (err || !team) {
-            slack_botkit.log('Received outgoing webhook but could not load team');
+            slack_botkit.logerror('Received outgoing webhook but could not load team');
           } else {
             message.type='outgoing_webhook';
 
@@ -351,7 +351,7 @@ function Slackbot(configuration) {
 
                   slack_botkit.saveTeam(team,function(err,id) {
                     if (err) {
-                      slack_botkit.log('An error occurred while saving a team: ',err);
+                      slack_botkit.logerror('An error occurred while saving a team: ',err);
                       if (callback) {
                         callback(err,req,res);
                       } else {
@@ -380,7 +380,7 @@ function Slackbot(configuration) {
                         slack_botkit.storage.users.save(user,function(err,id) {
 
                           if (err) {
-                            slack_botkit.log('An error occurred while saving a user: ',err);
+                            slack_botkit.logerror('An error occurred while saving a user: ',err);
                             if (callback) {
                               callback(err,req,res);
                             } else {

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -82,7 +82,7 @@ module.exports = function(botkit,config) {
         // res.bots
         // these could be stored and cached for later use!
 
-        botkit.log("** BOT ID: ", bot.identity.name," ...attempting to connect to RTM!");
+        botkit.lognotice("** BOT ID: ", bot.identity.name," ...attempting to connect to RTM!");
 
         bot.rtm = new ws(res.url);
         bot.msgcount = 1;
@@ -111,7 +111,7 @@ module.exports = function(botkit,config) {
         })
 
          bot.rtm.on('error',function(err) {
-           botkit.log("RTM websocket error!",err)
+           botkit.logerror("RTM websocket error!",err)
            botkit.trigger('rtm_close',[bot,err]);
          });
 
@@ -284,7 +284,7 @@ module.exports = function(botkit,config) {
       request.post(src.response_url,function(err,resp,body) {
         // do something?
         if (err) {
-          botkit.log('Error sending slash command response:',err);
+          botkit.logerror('Error sending slash command response:',err);
           if (cb) { cb(err); }
         } else {
           if (cb) { cb(null); }
@@ -337,7 +337,7 @@ module.exports = function(botkit,config) {
       request.post(src.response_url,function(err,resp,body) {
         // do something?
         if (err) {
-          botkit.log('Error sending slash command response:',err);
+          botkit.logerror('Error sending slash command response:',err);
           if (cb) { cb(err) }
         } else {
           if (cb) { cb(null) }

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -82,7 +82,7 @@ module.exports = function(botkit,config) {
         // res.bots
         // these could be stored and cached for later use!
 
-        botkit.lognotice("** BOT ID: ", bot.identity.name," ...attempting to connect to RTM!");
+        botkit.log.notice("** BOT ID: ", bot.identity.name," ...attempting to connect to RTM!");
 
         bot.rtm = new ws(res.url);
         bot.msgcount = 1;
@@ -111,7 +111,7 @@ module.exports = function(botkit,config) {
         })
 
          bot.rtm.on('error',function(err) {
-           botkit.logerror("RTM websocket error!",err)
+           botkit.log.error("RTM websocket error!",err)
            botkit.trigger('rtm_close',[bot,err]);
          });
 
@@ -284,7 +284,7 @@ module.exports = function(botkit,config) {
       request.post(src.response_url,function(err,resp,body) {
         // do something?
         if (err) {
-          botkit.logerror('Error sending slash command response:',err);
+          botkit.log.error('Error sending slash command response:',err);
           if (cb) { cb(err); }
         } else {
           if (cb) { cb(null); }
@@ -337,7 +337,7 @@ module.exports = function(botkit,config) {
       request.post(src.response_url,function(err,resp,body) {
         // do something?
         if (err) {
-          botkit.logerror('Error sending slash command response:',err);
+          botkit.log.error('Error sending slash command response:',err);
           if (cb) { cb(err) }
         } else {
           if (cb) { cb(null) }

--- a/lib/console_logger.js
+++ b/lib/console_logger.js
@@ -38,10 +38,12 @@ function ConsoleLogger(_console, maxLevel, defaultLevel) {
         normalizedLevel = defaultLevel;
       }
       var levelName = levels[normalizedLevel];
-      _console.log.apply(
-        _console,
-        [levelName + ': ' + message].concat(slice.call(arguments, 2))
-      );
+      if (normalizedLevel <= maxLevel) {
+        _console.log.apply(
+          _console,
+          [levelName + ': ' + message].concat(slice.call(arguments, 2))
+        );
+      }
     }
   }
 }

--- a/lib/console_logger.js
+++ b/lib/console_logger.js
@@ -1,0 +1,51 @@
+var slice = Array.prototype.slice;
+// RFC 5424 syslog severity levels, see
+// https://tools.ietf.org/html/rfc5424#section-6.2.1
+var levels = [
+  'emergency',
+  'alert',
+  'critical',
+  'error',
+  'warning',
+  'notice',
+  'info',
+  'debug'
+];
+var levelsByName = levels.reduce(function(out, name, index) {
+  out[name] = index;
+  return out;
+}, {});
+
+function normalizeLogLevel(level) {
+  if (typeof level === 'string') {
+    level = levelsByName[level]
+  }
+  if (typeof level === "number" && level >= 0 && level < levels.length) {
+    return level;
+  }
+  return false;
+}
+
+function ConsoleLogger(_console, maxLevel, defaultLevel) {
+  _console = _console || console;
+  maxLevel = normalizeLogLevel(maxLevel) || 6;
+  defaultLevel = normalizeLogLevel(defaultLevel) || 6;
+  return {
+    log: function(level, message) {
+      var normalizedLevel = normalizeLogLevel(level);
+      if (!normalizedLevel) {
+        message = level;
+        normalizedLevel = defaultLevel;
+      }
+      var levelName = levels[normalizedLevel];
+      _console.log.apply(
+        _console,
+        [levelName + ': ' + message].concat(slice.call(arguments, 2))
+      );
+    }
+  }
+}
+
+ConsoleLogger.LogLevels = levelsByName;
+
+module.exports = ConsoleLogger;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "devDependencies": {
     "node-env-file": "^0.1.8",
     "tap-spec": "^4.1.1",
-    "tape": "^4.2.2"
+    "tape": "^4.2.2",
+    "winston": "^2.1.1"
   },
   "scripts": {
     "test": "node test/*-test.js | tap-spec"

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,7 @@ var Botkit = require('botkit');
 var controller = Botkit.slackbot({
   debug: false
   //include "log: false" to disable logging
+  //or a "logLevel" integer from 0 to 7 to adjust logging verbosity
 });
 
 // connect the bot to a stream of messages
@@ -932,6 +933,33 @@ var controller = Botkit.slackbot({
 })
 ```
 
+### Writing your own logging module
+
+By default, your bot will log to the standard JavaScript `console` object
+available in Node.js. This will synchronously print logging messages to stdout
+of the running process.
+
+There may be some cases, such as remote debugging or rotating of large logs,
+where you may want a more sophisticated logging solution. You can write your
+own logging module that uses a third-party tool, like
+[winston](https://github.com/winstonjs/winston) or
+[Bristol](https://github.com/TomFrost/Bristol). Just create an object with a
+`log` method. That method should take a severity level (such as `'error'` or 
+`'debug'`) as its first argument, and then any number of other arguments that
+will be logged as messages. (Both Winston and Bristol create objects of this
+description; it's a common interface.)
+
+Then, use it when you create your bot:
+```javascript
+var controller = Botkit.slackbot({
+  logger: new winston.Logger({
+    transports: [
+      new (winston.transports.Console)(),
+      new (winston.transports.File)({ filename: './bot.log' })
+    ]
+  })
+});
+```
 
 ## Use the Slack Button
 


### PR DESCRIPTION
 - Added a configuration option `logger`, which expects an object with a `log` method. 
   - The `log` method expects its first argument to be either a string or an integer representing one of the RFC 5424 syslog levels.
   - The `log` method accepts a variable number of additional arguments and should try to inspect and log all of them.

 - If a `logger` is not supplied to `botkit.slackbot()`, then the default implementation, `ConsoleLogger`, will be used.
  - `ConsoleLogger` implements much the same behavior as before, with the addition of log levels.
  - `ConsoleLogger` will honor a configuration option `logLevel` supplied to `botkit.slackbot()`. It can be either a string or an integer representing one of the RFC 5424 syslog levels. Any message with a higher log level than the `logLevel` will not be logged.

- Added helper methods to `botkit.log` for each of the RFC 5424 syslog levels. They call the configured `logger` with the appropriate log level as first argument. They are:
  - `botkit.log.emergency()`
  - `botkit.log.alert()`
  - `botkit.log.critical()`
  - `botkit.log.error()`
  - `botkit.log.warning()`
  - `botkit.log.notice()`
  - `botkit.log.info()`
  - `botkit.log.debug()`

- Went through existing codebase and replaced log messages that seemed to clearly be errors, warnings, and notices with calls to the appropriate method. No lower log levels seemed to be called for (such as `emergency`, `alert`, or `critical`).

- The existing methods `botkit.log()` and `botkit.debug()`, and their behavior, are preserved, with the addition of log levels (they are now aliases to `botkit.log.info()` and `botkit.log.debug()`, respectively).

- The existing configuration options `log === false` and `debug`, and their behavior, are preserved and applied to `ConsoleLogger`. They are translated into `logLevel` configurations (`error` and `debug`, respectively). If a `logLevel` configuration is also supplied, then it will override these options.