### PR TITLE
Allow custom logger

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -615,7 +615,7 @@ function Botkit(configuration) {
             for (var k = 0; k < arguments.length; k++) {
                 args.push(arguments[k]);
             }
-            console.log.apply(null,args);
+            botkit.logger.log.apply(null,args);
         }
     };
 
@@ -788,6 +788,17 @@ function Botkit(configuration) {
     };
 
     botkit.config = configuration;
+
+    if (configuration.logger) {
+        if (!configuration.logger.log || !(typeof configuration.logger.log === 'function')) {
+            throw new Error('Logger object must implement a `log` method!');
+        }
+
+        botkit.logger = configuration.logger;
+        botkit.log('** Using custom logger system.');
+    } else {
+        botkit.logger = console;
+    }
 
     if (configuration.storage) {
         if (

--- a/readme.md
+++ b/readme.md
@@ -932,6 +932,26 @@ var controller = Botkit.slackbot({
 })
 ```
 
+## Logging
+
+Slackbot uses `log` and `debug` methods to logs things. By default, its uses `console.log`.
+You can implement your own logging mechanism by giving a custom logger:
+
+```javascript
+var controller = Botkit.slackbot({
+  logger: my_logger_provider
+})
+```
+
+Your logger provider must implement a single `provider.log` method. Example with [winston](https://www.npmjs.com/package/winston):
+
+```javascript
+var logger = require('winston');
+
+var controller = Botkit.slackbot({
+  logger: logger
+})
+```
 
 ## Use the Slack Button
 


### PR DESCRIPTION
Hi there,

I recently found useful to have powerful logs, and quickly had a need to use winston to send my logs to my log provider. I find Botkit logs interesting and searched a way to send them with my application logs.

I came here with a way to give Botkit a custom log service, like it is already done with storage. It would be great if you could have a look and tell me if it's something you could merge one day and if something miss here on this PR to be then merged.

Thanks a bunch