### PR TITLE
add reply with typing + start typing

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -358,6 +358,38 @@ module.exports = function(botkit, config) {
         bot.say(msg,cb);
     };
 
+    /**
+     * sends a typing message to the source channel
+     * @param {Object} message source
+     */
+    bot.startTyping = function(src) {
+        bot.reply(src, { type: 'typing' })
+    }
+
+    /**
+     * replies with message after typing delay
+     * @param {Object} message source
+     * @param {(string|Object)} response string or object
+     * @param {function} optional request callback
+     */
+    bot.replyWithTyping = function(src, resp, cb) {
+        var text;
+
+        if (typeof(resp) == 'string') {
+            text = resp;
+        } else {
+            text = resp.text;
+        }
+
+        var typingLength = 1200 / 60 * text.length;
+        typingLength = typingLength > 2000 ? 2000 : typingLength;
+
+        bot.startTyping(src)
+
+        setTimeout(function() {
+            bot.reply(src, resp, cb)
+        }, typingLength)
+    }
 
     /**
      * This handles the particulars of finding an existing conversation or


### PR DESCRIPTION
I felt that the bot's replies were pretty jarring / abrupt. I think introducing a slight delay and adding a typing indicator will provide a much smoother and natural user experience. 

I added a method to reply with typing delay based on how long the message is. I also added a method to simply start typing which is useful when calling out to third party apis. 

Let me know what you think.