### PR TITLE
Allows user to specify message id

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -179,7 +179,6 @@ module.exports = function(botkit, config) {
         /**
          * Construct a valid slack message.
          */
-        bot.msgcount++;
         var slack_message = {
             id: message.id || bot.msgcount,
             type: message.type || 'message',
@@ -195,6 +194,7 @@ module.exports = function(botkit, config) {
             icon_url: message.icon_url || null,
             icon_emoji: message.icon_emoji || null,
         };
+        bot.msgcount++;
 
         if (message.icon_url || message.icon_emoji || message.username) {
             slack_message.as_user = false;

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -179,8 +179,9 @@ module.exports = function(botkit, config) {
         /**
          * Construct a valid slack message.
          */
+        bot.msgcount++;
         var slack_message = {
-            id: message.id || bot.msgcount++,
+            id: message.id || bot.msgcount,
             type: message.type || 'message',
             channel: message.channel,
             text: message.text || null,

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -180,7 +180,7 @@ module.exports = function(botkit, config) {
          * Construct a valid slack message.
          */
         var slack_message = {
-            id: bot.msgcount++,
+            id: message.id || bot.msgcount++,
             type: message.type || 'message',
             channel: message.channel,
             text: message.text || null,


### PR DESCRIPTION
`npm test` gives me `jscs: not found`.