### PR TITLE
add middleware entry point to preprocess messages

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -1,5 +1,6 @@
 var Botkit = require(__dirname + '/CoreBot.js');
 var request = require('request');
+var ware = require('ware');
 var express = require('express');
 var bodyParser = require('body-parser');
 
@@ -37,6 +38,10 @@ function Slackbot(configuration) {
         return slack_botkit;
 
     };
+
+    // add preprocessing middleware
+    slack_botkit.preprocessor = ware();
+    slack_botkit.preprocessor.use(configuration.preprocessor || []);
 
     // set up a web route that is a landing page
     slack_botkit.createHomepageEndpoint = function(webserver) {
@@ -417,7 +422,6 @@ function Slackbot(configuration) {
         slack_botkit.log('** Setting up custom handlers for processing Slack messages');
         slack_botkit.on('message_received',function(bot, message) {
 
-
             if (message.ok != undefined) {
                 // this is a confirmation of something we sent.
                 return false;
@@ -469,7 +473,10 @@ function Slackbot(configuration) {
 
                     message.event = 'direct_message';
 
-                    slack_botkit.trigger('direct_message',[bot,message]);
+                    slack_botkit.preprocessor.run(bot, message, function(err, bot, message) {
+                        slack_botkit.trigger(message.event, [bot, message]);
+                    });
+
                     return false;
 
                 } else {
@@ -489,19 +496,17 @@ function Slackbot(configuration) {
                         message.text = message.text.replace(direct_mention,'')
                         .replace(/^\s+/,'').replace(/^\:\s+/,'').replace(/^\s+/,'');
                         message.event = 'direct_mention';
-
-                        slack_botkit.trigger('direct_mention',[bot,message]);
-                        return false;
                     } else if (message.text.match(mention)) {
                         message.event = 'mention';
-                        slack_botkit.trigger('mention',[bot,message]);
-                        return false;
                     } else {
                         message.event = 'ambient';
-                        slack_botkit.trigger('ambient',[bot,message]);
-                        return false;
-
                     }
+
+                    slack_botkit.preprocessor.run(bot, message, function(err, bot, message) {
+                        slack_botkit.trigger(message.event, [bot, message]);
+                    });
+
+                    return false;
                 }
             } else {
                 // this is a non-message object, so trigger a custom event based on the type

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "jfs": "^0.2.6",
     "mustache": "^2.2.1",
     "request": "^2.67.0",
+    "ware": "^1.3.0",
     "ws": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
@benbrown i've been using this in my fork of botkit and I think at lot of people would find it useful. it introduces a middleware layer before triggering the direct_message, ambient, direction_mention and mention events. This allows for message normalization/preprocessing. for example I could write something like this: 

```js
const normalize = (bot, message, next) => {
  message.text = message.text.replace('gonna', 'going to')
  next()
}

const BotController = Botkit.slackbot({
  // can be an array of functions
  middleware: normalize
})
```

that's a pretty simple example but i can imagine people writing middleware to normalize common typos, slang, contractions, etc. What do you think? I'll write up the documentation and provide a solid example if you're into it.