### PR TITLE
Adding morgan

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -1,6 +1,7 @@
 var Botkit = require(__dirname + '/CoreBot.js');
 var request = require('request');
 var express = require('express');
+var morgan = require('morgan');
 var bodyParser = require('body-parser');
 
 function Slackbot(configuration) {
@@ -169,9 +170,11 @@ function Slackbot(configuration) {
         slack_botkit.config.port = port;
 
         slack_botkit.webserver = express();
+        slack_botkit.webserver.use(morgan('dev'));
         slack_botkit.webserver.use(bodyParser.json());
         slack_botkit.webserver.use(bodyParser.urlencoded({ extended: true }));
         slack_botkit.webserver.use(express.static(__dirname + '/public'));
+
 
         var server = slack_botkit.webserver.listen(
             slack_botkit.config.port,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "body-parser": "^1.14.2",
     "express": "^4.13.3",
     "jfs": "^0.2.6",
+    "morgan": "1.6.1",
     "mustache": "^2.2.1",
     "request": "^2.67.0",
     "ws": "^1.0.0"


### PR DESCRIPTION
I was trying to make https://github.com/howdyai/botkit/blob/master/examples/slackbutton_bot.js works as an app. The `oauth` was not working. It took a while to find out what was going on. In general it is not a bad idea to be able to see what hit the express endpoints. morgan helps to log that.