### PR TITLE
Add pattern match to message object in convos

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -84,9 +84,10 @@ function Botkit(configuration) {
                 } else {
                     // handle might be a mapping of keyword to callback.
                     // lets see if the message matches any of the keywords
-                    var patterns = this.handler;
+                    var match, patterns = this.handler;
                     for (var p = 0; p < patterns.length; p++) {
-                        if (patterns[p].pattern && message.text.match(patterns[p].pattern)) {
+                        if (patterns[p].pattern && (match = message.text.match(patterns[p].pattern))) {
+                            message.match = match;
                             patterns[p].callback(message, this);
                             return;
                         }


### PR DESCRIPTION
Adds the pattern matches to the `message` object when handling responses in conversations.

This information is passed along with the message much like it is done with pattern matching in `hears`, saving one additional call to `message.text.match()` when we want to know what exactly were the matching groups (when using regexes).