### PR TITLE
Adds bot.replyIntent()

### DIFF
--- a/examples/intent-chatamize-bot.js
+++ b/examples/intent-chatamize-bot.js
@@ -24,27 +24,13 @@ This bot demonstrates use of the chatamize.com api.
 
   Find your bot inside Slack to send it a direct message.
 
-  Say: "Hello"
+  Say: "hi"
 
-  The bot will reply "Hello!"
-
-  Say: "Attach"
-
-  The bot will send a message with a multi-field attachment.
-
-  Send: "dm"
-
-  The bot will reply with a direct message.
-
-  Make sure to invite your bot into other channels using /invite @<my bot>!
+  The bot will reply with one of the greetings that you set on chatamize.com
 
 # EXTEND THE BOT:
 
-  Botkit is has many features for building cool and useful bots!
-
-  Read all about it here:
-
-    -> http://howdy.ai/botkit
+  Add more intents and messages to chatamize.com and you can use them here!
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 

--- a/examples/intent-chatamize-bot.js
+++ b/examples/intent-chatamize-bot.js
@@ -1,0 +1,75 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ______     ______     ______   __  __     __     ______
+          /\  == \   /\  __ \   /\__  _\ /\ \/ /    /\ \   /\__  _\
+          \ \  __<   \ \ \/\ \  \/_/\ \/ \ \  _"-.  \ \ \  \/_/\ \/
+          \ \_____\  \ \_____\    \ \_\  \ \_\ \_\  \ \_\    \ \_\
+           \/_____/   \/_____/     \/_/   \/_/\/_/   \/_/     \/_/
+
+
+This is a sample Slack bot built with Botkit.
+
+This bot demonstrates use of the chatamize.com api.
+
+# RUN THE BOT:
+
+  Get a Bot token from Slack:
+
+    -> http://my.slack.com/services/new/bot
+
+  Run your bot from the command line:
+
+    token=<MY TOKEN> node demo_bot.js
+
+# USE THE BOT:
+
+  Find your bot inside Slack to send it a direct message.
+
+  Say: "Hello"
+
+  The bot will reply "Hello!"
+
+  Say: "Attach"
+
+  The bot will send a message with a multi-field attachment.
+
+  Send: "dm"
+
+  The bot will reply with a direct message.
+
+  Make sure to invite your bot into other channels using /invite @<my bot>!
+
+# EXTEND THE BOT:
+
+  Botkit is has many features for building cool and useful bots!
+
+  Read all about it here:
+
+    -> http://howdy.ai/botkit
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+var Botkit = require('../lib/Botkit.js');
+
+
+if (!process.env.token) {
+  console.log('Error: Specify token in environment');
+  process.exit(1);
+}
+
+var controller = Botkit.slackbot({
+ debug: false
+});
+
+controller.spawn({
+  token: process.env.token,
+  token_chatamize: process.env.token_chatamize
+}).startRTM(function(err) {
+  if (err) {
+    throw new Error(err);
+  }
+});
+
+
+controller.hears(['hello','hi'],['direct_message','direct_mention','mention'],function(bot,message) {
+    bot.replyIntent(message, "greeting");
+});

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -769,7 +769,6 @@ function Botkit(configuration) {
             botkit.debug('REPLY: ', resp);
         };
 
-
         this.findConversation = function(message, cb) {
             botkit.debug('DEFAULT FIND CONVO');
             cb(null);

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -358,6 +358,45 @@ module.exports = function(botkit, config) {
         bot.say(msg, cb);
     };
 
+    bot.replyIntent = function(src, intent, cb) {
+        if (!bot.config.token_chatamize) {
+            console.log('Please set token_chatamize in controller.spawn().');
+            return;
+        }
+
+        dataString = '';
+        dataString += 'api_key=' + bot.config.token_chatamize;
+        dataString += '&intent=' + intent;
+
+        // see https://docs.nodejitsu.com/articles/HTTP/clients/how-to-create-a-HTTP-request
+        var http = require('http');
+
+        var options = {
+            host: 'www.chatamize.com',
+            path: '/api/v1/message?' + dataString
+        };
+
+        console.log(options.path);
+
+        callback = function(response) {
+            var str = '';
+
+            //another chunk of data has been recieved, so append it to `str`
+            response.on('data', function(chunk) {
+                str += chunk;
+            });
+
+            //the whole response has been recieved, so we just print it out here
+            response.on('end', function() {
+                response = JSON.parse(str);
+                bot.reply(src, response.message, cb);
+            });
+        };
+
+        console.log('sending request');
+        http.request(options, callback).end();
+    };
+
     /**
      * sends a typing message to the source channel
      *


### PR DESCRIPTION
Usage:

`bot.replyIntent(message, "greeting");`

Will hit `http://www.chatamize.com/api/v1/intent?api_key=[your api key]&intent=greeting` and will reply with the message returned. See `chatamize.com` to manage your messages.

As of `73374c0`, `intents-chatamize` passes all tests with `npm test`.
```
Test
    ✓ should have a token
    ✓ should have Botkit instance

  Botkit
info: ** No persistent storage method specified! Data may be lost when process shuts down.
info: ** Setting up custom handlers for processing Slack messages
info: ** API CALL: https://slack.com/api/rtm.start
notice: ** BOT ID:  intent-wit-bot  ...attempting to connect to RTM!
    ✓ should start and then stop (1782ms)
info: ** No persistent storage method specified! Data may be lost when process shuts down.
info: ** Setting up custom handlers for processing Slack messages
info: ** API CALL: https://slack.com/api/rtm.start
    ✓ should have fail with false token (171ms)

  Log
    ✓ should use an external logging provider (177ms)


  5 passing (2s)
```