### PR TITLE
Fix hear

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -610,31 +610,52 @@ function Botkit(configuration) {
     };
 
     botkit.hears = function(keywords, events, cb) {
-        if (typeof(keywords) == 'string') {
-            keywords = [keywords];
-        }
-        if (typeof(events) == 'string') {
-            events = events.split(/\,/g);
-        }
+        var matchFn;
+        var theRule;
 
-        var match;
-        for (var k = 0; k < keywords.length; k++) {
-            var keyword = keywords[k];
-            for (var e = 0; e < events.length; e++) {
-                (function(keyword) {
-                    botkit.on(events[e], function(bot, message) {
-                        if (message.text) {
-                            if (match = message.text.match(new RegExp(keyword, 'i'))) {
-                                botkit.debug('I HEARD ', keyword);
-                                message.match = match;
-                                cb.apply(this, [bot, message]);
-                                return false;
-                            }
-                        }
-                    });
-                })(keyword);
+        // Compile
+        if (typeof(keywords) == 'function') {
+            matchFn = keywords;
+            // Store first line of the fuction
+            theRule = (function strText(functionText){
+                return functionText.substr(0, functionText.indexOf("\n"));
+            })(keywords);
+        } else {
+            if (Array.isArray(keywords)){
+              // One regEx for multiple keywords would have be more effiecient but retriving the match groups is messy
+              // i.e: needle = "((" + keywords.join( ')|(' ) + "))";
+
+              // Then the best we can do is pre-compiled all the RegEx.
+              var re = [];
+              keywords.forEach(function(keyword){
+                 re.push(new RegExp(keyword, 'i'))
+              });
+
+              theRule = "['" + keywords.join( "','")+ "']";
+              matchFn = function (str) {
+                for (var i = 0; i < re.length; i++) {
+                  var match = str.match(re[i]);
+                  if (match) return match;
+                }
+              }
+            } else {
+              var re =  new RegExp(keywords, 'i');
+
+              theRule = keywords;
+              matchFn =  function (str) { return str.match(re); }
             }
         }
+
+        botkit.on(events, function(bot, message) {
+            if (message.text) {
+                var match = matchFn(message.text);
+                if (match) {
+                    botkit.debug('I HEARD ', match, ' -- Rule "', theRule, '" matched.');
+                    message.match = match;
+                    if (cb) cb.apply(this, [bot, message]);
+                }
+            }
+        });
         return this;
     };
 


### PR DESCRIPTION
More performant `hears` function.
It only listen to one event for each hear.
Precompile regEx.
Add the option to have a match function instead of a string
With debug on, we show the rule that matched.  