### PR TITLE
Added multi-part file upload to files.upload

### DIFF
--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -6,25 +6,39 @@ module.exports = function(bot, config) {
     var slack_api = {
         api_url: 'https://slack.com/api/',
         // this is a simple function used to call the slack web API
-        callAPI: function(command, options, cb) {
-            bot.log('** API CALL: ' + slack_api.api_url + command);
-            if (!options.token) {
-                options.token = config.token;
+        callAPIWithoutToken: function (command, options, formData, cb) {
+          bot.log('** API CALL: ' + slack_api.api_url + command);
+          bot.debug(command, options);
+          request.post({
+            url: this.api_url + command,
+            form: options,
+            formData: formData
+          }, function (error, response, body) {
+            bot.debug('Got response', error, body);
+            if (!error && response.statusCode == 200) {
+              var json = JSON.parse(body);
+              if (json.ok) {
+                if (cb) cb(null, json);
+              } else {
+                if (cb) cb(json.error, json);
+              }
+            } else {
+              if (cb) cb(error);
             }
-            bot.debug(command, options);
-            request.post(this.api_url + command, function(error, response, body) {
-                bot.debug('Got response', error, body);
-                if (!error && response.statusCode == 200) {
-                    var json = JSON.parse(body);
-                    if (json.ok) {
-                        if (cb) cb(null, json);
-                    } else {
-                        if (cb) cb(json.error, json);
-                    }
-                } else {
-                    if (cb) cb(error);
-                }
-            }).form(options);
+          });
+        },
+        callAPI: function (command, options, cb) {
+            if (!options.token) {
+              options.token = config.token;
+            }
+            slack_api.callAPIWithoutToken(command, options, null, cb);
+        },
+        callAPImultiPart: function (command, options, cb) {
+            bot.log('**API CALL with multi-part data');
+            if (!options.token) {
+              options.token = config.token;
+            }
+            slack_api.callAPIWithoutToken(command, null, options, cb);
         },
         auth: {
             test: function(options, cb) {
@@ -33,7 +47,7 @@ module.exports = function(bot, config) {
         },
         oauth: {
             access: function(options, cb) {
-                slack_api.callAPIWithoutToken('oauth.access', options, cb);
+                slack_api.callAPIWithoutToken('oauth.access', options, null, cb);
             }
         },
         channels: {
@@ -107,8 +121,8 @@ module.exports = function(bot, config) {
                 slack_api.callAPI('files.list', options, cb);
             },
             upload: function(options, cb) {
-                slack_api.callAPI('files.upload', options, cb);
-            },
+                slack_api.callAPImultiPart('files.upload', options, cb);
+            }
         },
         groups: {
             archive: function(options, cb) {
@@ -158,7 +172,7 @@ module.exports = function(bot, config) {
             },
             unarchive: function(options, cb) {
                 slack_api.callAPI('groups.unarchive', options, cb);
-            },
+            }
         },
         im: {
             close: function(options, cb) {
@@ -206,12 +220,12 @@ module.exports = function(bot, config) {
             },
             remove: function(options, cb) {
                 slack_api.callAPI('reactions.remove', options, cb);
-            },
+            }
         },
         rtm: {
             start: function(options, cb) {
                 slack_api.callAPI('rtm.start', options, cb);
-            },
+            }
         },
         search: {
             all: function(options, cb) {
@@ -222,12 +236,12 @@ module.exports = function(bot, config) {
             },
             messages: function(options, cb) {
                 slack_api.callAPI('search.messages', options, cb);
-            },
+            }
         },
         stars: {
             list: function(options, cb) {
                 slack_api.callAPI('stars.list', options, cb);
-            },
+            }
         },
         team: {
             accessLogs: function(options, cb) {
@@ -235,7 +249,7 @@ module.exports = function(bot, config) {
             },
             info: function(options, cb) {
                 slack_api.callAPI('team.info', options, cb);
-            },
+            }
         },
         users: {
             getPresence: function(options, cb) {
@@ -252,7 +266,7 @@ module.exports = function(bot, config) {
             },
             setPresence: function(options, cb) {
                 slack_api.callAPI('users.setPresence', options, cb);
-            },
+            }
         }
     };
 


### PR DESCRIPTION
Slight refactor of lib/Slack_web_api.js to include the ability to post data to Slack API as a multi-part upload to allow binary files to be updated.

The use is as follows:

```js
    bot.api.files.upload({
        file: fs.createReadStream('/tmp/dramacat.gif'),
        channels: 'C024BE91L,#general'
    }, function (error, done) {
        console.log(JSON.stringify(error));
        console.log(JSON.stringify(done));
    });
```

Is the same as (from [slack web api examples](https://api.slack.com/methods/files.upload#Examples))

```shell
curl -F file=@dramacat.gif -F channels=C024BE91L,#general -F token=xxxx-xxxxxxxxx-xxxx https://slack.com/api/files.upload
```

This fixes issue #29.