### PR TITLE
Add handling of undefined message object text in conversation.tick

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -332,7 +332,7 @@ function Botkit(configuration) {
                             this.lastActive = new Date();
 
                             if (message.text || message.attachments) {
-                                message.text = this.replaceTokens(message.text);
+                                message.text = message.text && this.replaceTokens(message.text) || "";
                                 if (this.messages.length && !message.handler) {
                                     message.continue_typing = true;
                                 }


### PR DESCRIPTION
When using conversation.say with a message object that had no text but did have an attachment, the undefined text property was still passed to mustache for rendering, throwing a TypeError.

This change adds a simple check that the text exists before attempting to render it, otherwise setting message.text to an empty string (which does not appear in slack output at all - not even a blank line)