### PR TITLE
Fix problem with json parameter for middleware call

### DIFF
--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -18,7 +18,7 @@ module.exports = function(bot, config) {
                     if (!error && response.statusCode == 200) {
                         var json = JSON.parse(body);
                         if (json.ok) {
-                            bot.middleware.post_api.run(command, options, cb, json, function(err, command, options, json) {
+                            bot.middleware.post_api.run(command, options, cb, json, function(err, command, options, cb, json) {
                                 if (cb) cb(null, json);
                             });
                         } else {


### PR DESCRIPTION
Fix lack of the `cb` parameter on `bot.middleware.post_api` call.