### PR TITLE
Fix falsy unfurl_links or unfurl_media

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -189,8 +189,8 @@ module.exports = function(botkit, config) {
             link_names: message.link_names || null,
             attachments: message.attachments ?
                 JSON.stringify(message.attachments) : null,
-            unfurl_links: message.unfurl_links || null,
-            unfurl_media: message.unfurl_media || null,
+            unfurl_links: typeof message.unfurl_links !== "undefined" ? message.unfurl_links : null,
+            unfurl_media: typeof message.unfurl_media !== "undefined" ? message.unfurl_media : null,
             icon_url: message.icon_url || null,
             icon_emoji: message.icon_emoji || null,
         };


### PR DESCRIPTION
It was impossible to specify `unfurl_links: false` or `unfurl_media: false` because they'd get turned into `null` which would result in the default behavior (which was often `true`).