### PR TITLE
Post JSON to response URL, not form encoded

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -280,7 +280,12 @@ module.exports = function(botkit, config) {
             msg.channel = src.channel;
 
             msg.response_type = 'in_channel';
-            request.post(src.response_url, function(err, resp, body) {
+            var requestOptions = {
+              uri: src.response_url,
+              method: 'POST',
+              json: msg
+            };
+            request(requestOptions, function(err, resp, body) {
                 /**
                  * Do something?
                  */
@@ -290,7 +295,7 @@ module.exports = function(botkit, config) {
                 } else {
                     cb && cb();
                 }
-            }).form(JSON.stringify(msg));
+            });
         }
     };
 
@@ -330,7 +335,13 @@ module.exports = function(botkit, config) {
             msg.channel = src.channel;
 
             msg.response_type = 'ephemeral';
-            request.post(src.response_url, function(err, resp, body) {
+
+            var requestOptions = {
+              uri: src.response_url,
+              method: 'POST',
+              json: msg
+            };
+            request(requestOptions, function(err, resp, body) {
                 /**
                  * Do something?
                  */
@@ -340,7 +351,7 @@ module.exports = function(botkit, config) {
                 } else {
                     cb && cb();
                 }
-            }).form(JSON.stringify(msg));
+            });
         }
     };
 


### PR DESCRIPTION
The slash command `response_url` takes a JSON body, not a form-encoded one. Form encoding will URL encode special characters in the message you're trying to send.