### PR TITLE
use bot returned by startRTM

### DIFF
--- a/examples/slackbutton_bot.js
+++ b/examples/slackbutton_bot.js
@@ -127,7 +127,7 @@ controller.storage.teams.all(function(err,teams) {
   // connect all teams with bots up to slack!
   for (var t  in teams) {
     if (teams[t].bot) {
-      var bot = controller.spawn(teams[t]).startRTM(function(err) {
+      controller.spawn(teams[t]).startRTM(function(err, bot) {
         if (err) {
           console.log('Error connecting bot to Slack:',err);
         } else {


### PR DESCRIPTION
If you inspect _bots object the old code, it ends up with only a single key. Using the bot returned by startRTM stores all the bots in _bots correctly.