### PR TITLE
Add pins methods to web_api

### DIFF
--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -197,6 +197,17 @@ module.exports = function(bot, config) {
                 slack_api.callAPI('mpim.open', options, cb);
             }
         },
+        pins: {
+            add: function(options, cb) {
+                slack_api.callAPI('pins.add', options, cb);
+            },
+            list: function(options, cb) {
+                slack_api.callAPI('pins.list', options, cb);
+            },
+            remove: function(options, cb) {
+                slack_api.callAPI('pins.remove', options, cb);
+            }
+        },
         reactions: {
             add: function(options, cb) {
                 slack_api.callAPI('reactions.add', options, cb);


### PR DESCRIPTION
I sent an email to Slack asking why none of the pins methods were available to bots. Couple days later, they discovered it was a bug and it is now fixed.

So, I thought I'd add those methods to the web api in botkit.