### PR TITLE
Only provide slack_message.id if using the RTM API

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -180,7 +180,6 @@ module.exports = function(botkit, config) {
          * Construct a valid slack message.
          */
         var slack_message = {
-            id: message.id || bot.msgcount,
             type: message.type || 'message',
             channel: message.channel,
             text: message.text || null,
@@ -224,6 +223,7 @@ module.exports = function(botkit, config) {
         } else {
             if (!bot.rtm)
                 throw new Error('Cannot use the RTM API to send messages.');
+            slack_message.id= message.id || bot.msgcount;
 
             try {
                 bot.rtm.send(JSON.stringify(slack_message), function(err) {


### PR DESCRIPTION
When set with postMessage, the id seems to prevent 
posting messages with the same id (e.g. after slackbot restart)