### PR TITLE
Fix bug that causes `postMessage` to silently fail

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -223,6 +223,7 @@ module.exports = function(botkit, config) {
         } else {
             if (!bot.rtm)
                 throw new Error('Cannot use the RTM API to send messages.');
+            slack_message.id= message.id || bot.msgcount;
 
             try {
                 bot.rtm.send(JSON.stringify(slack_message), function(err) {

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -180,7 +180,6 @@ module.exports = function(botkit, config) {
          * Construct a valid slack message.
          */
         var slack_message = {
-            id: message.id || bot.msgcount,
             type: message.type || 'message',
             channel: message.channel,
             text: message.text || null,


### PR DESCRIPTION
Botkit sends an id with each message sent via `postMessage`. This id is reset after botkit is restarted. Because we were including the message id with the same message, slack would discard these messages with `{ok => true}` because it had just seen an identical message with an identical id. This PR removes the id from the message being sent via `postMessage` so that slack will post each message.

Thanks to @benbrown for tipping me off to this!