### PR TITLE
Add proxy support for web socket connection

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -1,6 +1,8 @@
 var Ws = require('ws');
 var request = require('request');
 var slackWebApi = require(__dirname + '/Slack_web_api.js');
+var HttpsProxyAgent = require('https-proxy-agent');
+
 
 module.exports = function(botkit, config) {
     var bot = {
@@ -75,7 +77,13 @@ module.exports = function(botkit, config) {
 
             botkit.log.notice('** BOT ID:', bot.identity.name, '...attempting to connect to RTM!');
 
-            bot.rtm = new Ws(res.url);
+            var agent = null;
+            var proxyUrl = process.env.https_proxy || process.env.http_proxy;
+            if (proxyUrl) {
+                agent = new HttpsProxyAgent(proxyUrl);
+            }
+
+            bot.rtm = new Ws(res.url, null, {agent: agent});
             bot.msgcount = 1;
 
             bot.rtm.on('open', function() {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "jfs": "^0.2.6",
     "mustache": "^2.2.1",
     "request": "^2.67.0",
-    "ws": "^1.0.1"
+    "ws": "^1.0.1",
+    "https-proxy-agent": "^1.0.0"
   },
   "devDependencies": {
     "jscs": "^2.7.0",


### PR DESCRIPTION
botkit doesn't work behind a proxy.  The initial call start the RTM session works because the request library automatically checks for HTTP Proxy environment variables.  The websocket library does not do the same thing.  This pull request uses the http-proxy-agent library to add proxy support to the websocket call.  This pull request is for issues #21 (which was closed) and #145.