### PR TITLE
Add websocket ping

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -78,10 +78,17 @@ module.exports = function(botkit, config) {
             bot.rtm = new Ws(res.url);
             bot.msgcount = 1;
 
+            var pingIntervalId = null;
             bot.rtm.on('open', function() {
+
+                pingIntervalId = setInterval(function() {
+                    bot.rtm.ping(null, null, true);
+                }, 5000);
+
                 botkit.trigger('rtm_open', [this]);
 
                 bot.rtm.on('message', function(data, flags) {
+
                     var message = JSON.parse(data);
 
                     /**
@@ -105,7 +112,11 @@ module.exports = function(botkit, config) {
             });
 
             bot.rtm.on('close', function() {
+                if (pingIntervalId) {
+                    clearInterval(pingIntervalId);
+                }
                 botkit.trigger('rtm_close', [bot]);
+
             });
         });
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -88,7 +88,6 @@ module.exports = function(botkit, config) {
                 botkit.trigger('rtm_open', [this]);
 
                 bot.rtm.on('message', function(data, flags) {
-
                     var message = JSON.parse(data);
 
                     /**
@@ -116,7 +115,6 @@ module.exports = function(botkit, config) {
                     clearInterval(pingIntervalId);
                 }
                 botkit.trigger('rtm_close', [bot]);
-
             });
         });
 


### PR DESCRIPTION
Slack's RTM documentation (https://api.slack.com/rtm) recommends sending a ping every few seconds.  I've encountered an issue with being disconnected while running behind a proxy but others (#104) seemed to have encountered this as well. 