### PR TITLE
Define callAPIWithoutToken method on slack_api to call oauth.access

### DIFF
--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -26,6 +26,31 @@ module.exports = function(bot, config) {
                 }
             }).form(options);
         },
+        callAPIWithoutToken: function(command, options, cb) {
+            bot.log('** API CALL: ' + slack_api.api_url + command);
+            if (!options.client_id) {
+                options.client_id = bot.config.clientId;
+            }
+            if (!options.client_secret) {
+                options.client_secret = bot.config.clientSecret;
+            }
+            if (!options.redirect_uri) {
+                options.redirect_uri = bot.config.redirectUri;
+            }
+            request.post(this.api_url + command, function(error, response, body) {
+                bot.debug('Got response', error, body);
+                if (!error && response.statusCode == 200) {
+                    var json = JSON.parse(body);
+                    if (json.ok) {
+                        if (cb) cb(null, json);
+                    } else {
+                        if (cb) cb(json.error, json);
+                    }
+                } else {
+                    if (cb) cb(error);
+                }
+            }).form(options);
+        },
         auth: {
             test: function(options, cb) {
                 slack_api.callAPI('auth.test', options, cb);


### PR DESCRIPTION
# Problem

Whan call [oauth.access](https://api.slack.com/methods/oauth.access) during [OAuth process](https://api.slack.com/docs/oauth), `slack_api` try to call `callAPIWithoutToken` ([ref](https://github.com/howdyai/botkit/blob/master/lib/Slack_web_api.js#L36)) method but `slack_api` doesn't have such a method (and not defined anywhere).
So I got an error below:

```
TypeError: slack_api.callAPIWithoutToken is not a function
   at Object.module.exports.slack_api.oauth.access ...
```

# Solution

* Defined `callAPIWithoutToken` on `slack_api`
* `slack_botkit.config` has `clientId` or these parameters, so if these parameters were not passed to the method, compose option from `bot.config` by default.

Then, we can call `oauth.access` method as following:

    bot.api.oauth.access({code: the_code_passed_to_callback_of_authorize}, function (err, response) {
      // ...
    });
