### PR TITLE
Add bot.destroy() to prevent memory leaks

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -12,6 +12,8 @@ module.exports = function(botkit, config) {
         api: slackWebApi(botkit, config || {})
     };
 
+    var pingIntervalId = null, lastPong = 0;
+
     /**
      * Set up API to send incoming webhook
      */
@@ -46,9 +48,26 @@ module.exports = function(botkit, config) {
         return bot;
     };
 
-    bot.closeRTM = function() {
-        if (bot.rtm)
+    bot.closeRTM = function(err) {
+        if (bot.rtm) {
+            bot.rtm.removeAllListeners()
             bot.rtm.close();
+        }
+
+        if (pingIntervalId) {
+            clearInterval(pingIntervalId);
+        }
+
+        lastPong = 0
+        botkit.trigger('rtm_close', [bot, err]);
+    };
+
+    /**
+     * Shutdown and cleanup the spawned worker
+     */
+    bot.destroy = function() {
+        bot.closeRTM()
+        botkit.shutdown()
     };
 
     bot.startRTM = function(cb) {
@@ -86,10 +105,22 @@ module.exports = function(botkit, config) {
             bot.rtm = new Ws(res.url, null, {agent: agent});
             bot.msgcount = 1;
 
-            var pingIntervalId = null;
+            bot.rtm.on('pong', function (obj) {
+                lastPong = Date.now()
+                botkit.debug('PONG received');
+            })
+
             bot.rtm.on('open', function() {
 
                 pingIntervalId = setInterval(function() {
+                    if (lastPong && lastPong + 12000 < Date.now()) {
+                        var err = new Error('Stale RTM connection, closing RTM')
+                        botkit.log.error(err);
+                        bot.closeRTM(err)
+                        return
+                    }
+
+                    botkit.debug('PING sent');
                     bot.rtm.ping(null, null, true);
                 }, 5000);
 
@@ -121,6 +152,9 @@ module.exports = function(botkit, config) {
 
             bot.rtm.on('error', function(err) {
                 botkit.log.error('RTM websocket error!', err);
+                if (pingIntervalId) {
+                    clearInterval(pingIntervalId);
+                }
                 botkit.trigger('rtm_close', [bot, err]);
             });
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -115,7 +115,6 @@ module.exports = function(botkit, config) {
                 pingIntervalId = setInterval(function() {
                     if (lastPong && lastPong + 12000 < Date.now()) {
                         var err = new Error('Stale RTM connection, closing RTM')
-                        botkit.log.error(err);
                         bot.closeRTM(err)
                         return
                     }

--- a/readme.md
+++ b/readme.md
@@ -227,7 +227,35 @@ bot.startRTM(function(err,bot,payload) {
   if (err) {
     throw new Error('Could not connect to Slack');
   }
+
+  // close the RTM for the sake of it in 5 seconds
+  setTimeout(function() {
+      bot.closeRTM();
+  }, 5000);
 });
+```
+
+#### bot.destroy()
+
+Completely shutdown and cleanup the spawned worker. Use `bot.closeRTM()` only to disconnect
+but not completely tear down the worker.
+
+
+```javascript
+var Botkit = require('Botkit');
+var controller = Botkit.slackbot();
+var bot = controller.spawn({
+  token: my_slack_bot_token
+})
+
+bot.startRTM(function(err, bot, payload) {
+  if (err) {
+    throw new Error('Could not connect to Slack');
+  }
+});
+
+// some time later (e.g. 10s) when finished with the RTM connection and worker
+setTimeout(bot.destroy.bind(bot), 10000)
 ```
 
 ### Responding to events


### PR DESCRIPTION
Currently there is no way to properly cleanup a spawned worker. This PR adds `bot.destroy()` to cleanup a worker. `destroy()` was added instead of overloading `bot.closeRTM()` since `spawn` is distinct from `bot.startRTM()` and you may want to close and RTM connection and reconnect without tearing down the worker.

![leak](https://cloud.githubusercontent.com/assets/30455/13907263/ef139ac8-eeaf-11e5-96a3-86ef92875edd.gif)

Update: I also added logic to detect stale connections if no `PONG` messages have been received.
