### PR TITLE
Add Slack Bot Reconnect Capability

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -12,6 +12,8 @@ module.exports = function(botkit, config) {
         api: slackWebApi(botkit, config || {})
     };
 
+    var pingIntervalId = null, lastPong = 0;
+
     /**
      * Set up API to send incoming webhook
      */
@@ -46,9 +48,26 @@ module.exports = function(botkit, config) {
         return bot;
     };
 
-    bot.closeRTM = function() {
-        if (bot.rtm)
+    bot.closeRTM = function(err) {
+        if (bot.rtm) {
+            bot.rtm.removeAllListeners()
             bot.rtm.close();
+        }
+
+        if (pingIntervalId) {
+            clearInterval(pingIntervalId);
+        }
+
+        lastPong = 0
+        botkit.trigger('rtm_close', [bot, err]);
+    };
+
+    /**
+     * Shutdown and cleanup the spawned worker
+     */
+    bot.destroy = function() {
+        bot.closeRTM()
+        botkit.shutdown()
     };
 
     bot.startRTM = function(cb) {
@@ -86,10 +105,22 @@ module.exports = function(botkit, config) {
             bot.rtm = new Ws(res.url, null, {agent: agent});
             bot.msgcount = 1;
 
-            var pingIntervalId = null;
+            bot.rtm.on('pong', function (obj) {
+                lastPong = Date.now()
+                botkit.debug('PONG received');
+            })
+
             bot.rtm.on('open', function() {
 
                 pingIntervalId = setInterval(function() {
+                    if (lastPong && lastPong + 12000 < Date.now()) {
+                        var err = new Error('Stale RTM connection, closing RTM')
+                        botkit.log.error(err);
+                        bot.closeRTM(err)
+                        return
+                    }
+
+                    botkit.debug('PING sent');
                     bot.rtm.ping(null, null, true);
                 }, 5000);
 
@@ -121,6 +152,9 @@ module.exports = function(botkit, config) {
 
             bot.rtm.on('error', function(err) {
                 botkit.log.error('RTM websocket error!', err);
+                if (pingIntervalId) {
+                    clearInterval(pingIntervalId);
+                }
                 botkit.trigger('rtm_close', [bot, err]);
             });
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -2,6 +2,7 @@ var Ws = require('ws');
 var request = require('request');
 var slackWebApi = require(__dirname + '/Slack_web_api.js');
 var HttpsProxyAgent = require('https-proxy-agent');
+var Back = require('back');
 
 
 module.exports = function(botkit, config) {
@@ -12,7 +13,13 @@ module.exports = function(botkit, config) {
         api: slackWebApi(botkit, config || {})
     };
 
-    var pingIntervalId = null, lastPong = 0;
+    var pingIntervalId = null;
+    var lastPong = 0;
+    var retryBackoff = null;
+
+    // config.retry, can be Infinity too
+    var retryEnabled = bot.config.retry ? true : false;
+    var maxRetry = isNaN(bot.config.retry) || bot.config.retry <= 0 ? 3 : bot.config.retry;
 
     /**
      * Set up API to send incoming webhook
@@ -60,12 +67,48 @@ module.exports = function(botkit, config) {
 
         lastPong = 0
         botkit.trigger('rtm_close', [bot, err]);
+
+        // only retry, if enabled, when there was an error
+        if (err && retryEnabled) {
+            reconnect();
+        }
     };
+
+
+    function reconnect(err) {
+        var options = {
+            minDelay: 1000,
+            maxDelay: 30000,
+            retries: maxRetry
+        }
+        var back = retryBackoff || (retryBackoff = new Back(options));
+        return back.backoff(function (fail) {
+            if (fail) {
+                botkit.log.error('** BOT ID:', bot.identity.name, '...reconnect failed after #' +
+                    back.settings.attempt + ' attempts and ' + back.settings.timeout + 'ms')
+                botkit.trigger('rtm_reconnect_failed', [bot, err]);
+                return;
+            }
+
+            botkit.log.notice('** BOT ID:', bot.identity.name, '...reconnect attempt #' +
+                back.settings.attempt + ' of ' + options.retries + ' being made after ' + back.settings.timeout + 'ms')
+            bot.startRTM(function(err) {
+                if (err) {
+                    return reconnect(err);
+                }
+                retryBackoff = null;
+            });
+        });
+    }
 
     /**
      * Shutdown and cleanup the spawned worker
      */
     bot.destroy = function() {
+        if (retryBackoff) {
+            retryBackoff.close();
+            retryBackoff = null;
+        }
         bot.closeRTM()
         botkit.shutdown()
     };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "mustache": "^2.2.1",
     "request": "^2.67.0",
     "ws": "^1.0.1",
-    "https-proxy-agent": "^1.0.0"
+    "https-proxy-agent": "^1.0.0",
+    "back": "^1.0.1"
   },
   "devDependencies": {
     "jscs": "^2.7.0",

--- a/readme.md
+++ b/readme.md
@@ -227,7 +227,35 @@ bot.startRTM(function(err,bot,payload) {
   if (err) {
     throw new Error('Could not connect to Slack');
   }
+
+  // close the RTM for the sake of it in 5 seconds
+  setTimeout(function() {
+      bot.closeRTM();
+  }, 5000);
 });
+```
+
+#### bot.destroy()
+
+Completely shutdown and cleanup the spawned worker. Use `bot.closeRTM()` only to disconnect
+but not completely tear down the worker.
+
+
+```javascript
+var Botkit = require('Botkit');
+var controller = Botkit.slackbot();
+var bot = controller.spawn({
+  token: my_slack_bot_token
+})
+
+bot.startRTM(function(err, bot, payload) {
+  if (err) {
+    throw new Error('Could not connect to Slack');
+  }
+});
+
+// some time later (e.g. 10s) when finished with the RTM connection and worker
+setTimeout(bot.destroy.bind(bot), 10000)
 ```
 
 ### Responding to events

--- a/readme.md
+++ b/readme.md
@@ -180,10 +180,18 @@ Spawn an instance of your bot and connect it to Slack.
 This function takes a configuration object which should contain
 at least one method of talking to the Slack API.
 
-To use the real time / bot user API, pass in a token, preferably via
-an environment variable.
+To use the real time / bot user API, pass in a token.
 
 Controllers can also spawn bots that use [incoming webhooks](#incoming-webhooks).
+
+Spawn `config` object accepts these properties:
+
+| Name | Value | Description
+|--- |---
+| token | String | Slack bot token
+| retry | Positive integer or `Infinity` | Maximum number of reconnect attempts after failed connection to Slack's real time messaging API. Retry is disabled by default
+
+
 
 #### bot.startRTM()
 | Argument | Description
@@ -318,6 +326,7 @@ a [few additional events](#using-the-slack-button).
 |--- |---
 | rtm_open | a connection has been made to the RTM api
 | rtm_close | a connection to the RTM api has closed
+| rtm_reconnect_failed | if retry enabled, retry attempts have been exhausted
 
 
 ## Receiving Messages


### PR DESCRIPTION
Websocket connections to the Slack RTM API can fail for many reasons. This PR implements exponential backoff retry logic for failed connections if the `retry` property is passed as config to `controller.spawn`. `retry` is the max number of reconnection attempts. It maybe `Infiity` or even `true`. If `true`, it defaults to 3 retry attempts.

NOTE: this PR is based on #157 and should be merged after.

![retry](https://cloud.githubusercontent.com/assets/30455/14027730/b4bdd3b8-f1be-11e5-893f-1b25acc1d165.gif)
