### PR TITLE
Make identity available to the user of the OAuth endpoint.

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -308,6 +308,7 @@ function Slackbot(configuration) {
                             slack_botkit.trigger('oauth_error', [err]);
 
                         } else {
+                            req.identity = identity;
 
                             // we need to deal with any team-level provisioning info
                             // like incoming webhooks and bot users


### PR DESCRIPTION
When a user gets redirected back to my app from slack I want to redirect them to a URL called `/team/:team-id`, but I don't have access to the team id. This adds the identity to the request object so that I can access it in the callback.