### PR TITLE
Do not try/catch the callback and then call it again

### DIFF
--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -15,15 +15,17 @@ module.exports = function(bot, config) {
             request.post(this.api_url + command, function(error, response, body) {
                 bot.debug('Got response', error, body);
                 if (!error && response.statusCode == 200) {
+                    var json;
                     try {
-                        var json = JSON.parse(body);
-                        if (json.ok) {
-                            if (cb) cb(null, json);
-                        } else {
-                            if (cb) cb(json.error, json);
-                        }
+                        json = JSON.parse(body);
                     } catch (err) {
-                        if (cb) cb(err);
+                        return cb(err);
+                    }
+
+                    if (json.ok) {
+                        if (cb) cb(null, json);
+                    } else {
+                        if (cb) cb(json.error, json);
                     }
                 } else {
                     if (cb) cb(error || 'Invalid response');
@@ -44,15 +46,17 @@ module.exports = function(bot, config) {
             request.post(this.api_url + command, function(error, response, body) {
                 bot.debug('Got response', error, body);
                 if (!error && response.statusCode == 200) {
+                    var json;
                     try {
-                        var json = JSON.parse(body);
-                        if (json.ok) {
-                            if (cb) cb(null, json);
-                        } else {
-                            if (cb) cb(json.error, json);
-                        }
+                        json = JSON.parse(body);
                     } catch (err) {
-                        if (cb) cb(error || 'Invalid response');
+                        return cb(err);
+                    }
+
+                    if (json.ok) {
+                        if (cb) cb(null, json);
+                    } else {
+                        if (cb) cb(json.error, json);
                     }
                 } else {
                     if (cb) cb(error);


### PR DESCRIPTION
The problem here arises in many places, but in our case it happened like this:

1. We called `bot.api.channels.history({..}, someFunction)`. In `someFunction()` there was an error and it throws.
2. In https://github.com/howdyai/botkit/blob/master/lib/Slack_web_api.js#L80 the `.callAPI()` function is called with the callback (someFunction).
3. For some reason there's a try/catch clause around the callback invocation. Now what happens is that `someFunction` throws an error, then `callAPI` catches it, but then calls it again.

You should not wrap a callback invocation with a try/catch.