### PR TITLE
adds support for <@userId|username> syntax for mentions and direct_mentions

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -416,6 +416,9 @@ function Slackbot(configuration) {
 
         slack_botkit.log('** Setting up custom handlers for processing Slack messages');
         slack_botkit.on('message_received', function(bot, message) {
+            var mentionSyntax = '<@' + bot.identity.id + '(\\|' + bot.identity.name + ')?>';
+            var mention = new RegExp(mentionSyntax, 'i');
+            var direct_mention = new RegExp('^' + mentionSyntax, 'i');
 
 
             if (message.ok != undefined) {
@@ -463,7 +466,6 @@ function Slackbot(configuration) {
                     }
 
                     // remove direct mention so the handler doesn't have to deal with it
-                    var direct_mention = new RegExp('^\<\@' + bot.identity.id + '\>', 'i');
                     message.text = message.text.replace(direct_mention, '')
                     .replace(/^\s+/, '').replace(/^\:\s+/, '').replace(/^\s+/, '');
 
@@ -480,9 +482,6 @@ function Slackbot(configuration) {
                         // message without text is probably an edit
                         return false;
                     }
-
-                    var direct_mention = new RegExp('^\<\@' + bot.identity.id + '\>', 'i');
-                    var mention = new RegExp('\<\@' + bot.identity.id + '\>', 'i');
 
                     if (message.text.match(direct_mention)) {
                         // this is a direct mention

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -416,7 +416,7 @@ function Slackbot(configuration) {
 
         slack_botkit.log('** Setting up custom handlers for processing Slack messages');
         slack_botkit.on('message_received', function(bot, message) {
-            var mentionSyntax = '<@' + bot.identity.id + '(\\|' + bot.identity.name + ')?>';
+            var mentionSyntax = '<@' + bot.identity.id + '(\\|' + bot.identity.name.replace('.', '\\.') + ')?>';
             var mention = new RegExp(mentionSyntax, 'i');
             var direct_mention = new RegExp('^' + mentionSyntax, 'i');
 


### PR DESCRIPTION
For Slack, the RegExp for mentions and direct_mentions does not match if the message uses the valid <@userId|username> syntax. This PR updates the regex so that botkit will emit mention and direct_mention events if the username is included.

Note: usernames can only be in the set [a-z0-9] so there won't be any special characters that could cause problems constructing a regex including usernames. See https://get.slack.help/hc/en-us/articles/216360827-Changing-your-username