### PR TITLE
Save users auth and team even if it is not new

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -315,16 +315,13 @@ function Slackbot(configuration) {
 
                             slack_botkit.findTeamById(identity.team_id, function(err, team) {
 
-                                var isnew = false;
-                                if (!team) {
-                                    isnew = true;
-                                    team = {
-                                        id: identity.team_id,
-                                        createdBy: identity.user_id,
-                                        url: identity.url,
-                                        name: identity.team,
-                                    };
-                                }
+                                var isnew = !!team;
+                                team = team || {};
+
+                                team.id = identity.team_id;
+                                team.createdBy = identity.user_id;
+                                team.url = identity.url;
+                                team.name = identity.team;
 
                                 var bot = slack_botkit.spawn(team);
 
@@ -363,17 +360,15 @@ function Slackbot(configuration) {
                                         }
 
                                         slack_botkit.storage.users.get(identity.user_id, function(err, user) {
-                                            isnew = false;
-                                            if (!user) {
-                                                isnew = true;
-                                                user = {
-                                                    id: identity.user_id,
-                                                    access_token: auth.access_token,
-                                                    scopes: scopes,
-                                                    team_id: identity.team_id,
-                                                    user: identity.user,
-                                                };
-                                            }
+                                            isnew = !!user;
+                                            user = user || {};
+
+                                            user.id = identity.user_id;
+                                            user.access_token = auth.access_token;
+                                            user.scopes = scopes;
+                                            user.team_id = identity.team_id;
+                                            user.user = identity.user;
+
                                             slack_botkit.storage.users.save(user, function(err, id) {
 
                                                 if (err) {


### PR DESCRIPTION
We just ran into a "thing" (it's not really a bug I suppose), where the users auth token wouldn't be saved if the user already existed in the storage.

The `auth_token`, `scopes`, and others can safely be updated when the user is updated. So this PR takes care of that.

In our case what happens was that: bot saves all the users in the storage upon connecting to the `rtm` to save on api calls to slack and minimize latency, so if a user removes our app (is there an event for that even?) and we haven't removed the slack data before another user of the same team adds the app again, the access_token and scope list will be missing from the user who authenticated the app last.
