### PR TITLE
Correct a formatting issue in readme-facebook.md

### DIFF
--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -43,7 +43,7 @@ Try:
   * who are you?
   * call me Bob
   * shutdown
-​
+
 ### Things to note
 
 Since Facebook delivers messages via web hook, your application must be available at a public internet address.  Additionally, Facebook requires this address to use SSL.  Luckily, you can use [LocalTunnel](https://localtunnel.me/) to make a process running locally or in your dev environment available in a Facebook-friendly way.


### PR DESCRIPTION
no issue
- Resolves a weird markdown nesting issue when readme-facebook.md is viewed on GitHub.