### PR TITLE
Move "MESSAGE HOOK" message into debug output.

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -116,7 +116,7 @@ function Facebookbot(configuration) {
             'webhooks at: http://MY_HOST:' + facebook_botkit.config.port + '/facebook/receive');
         webserver.post('/facebook/receive', function(req, res) {
 
-            console.log('GOT A MESSAGE HOOK');
+            facebook_botkit.debug('GOT A MESSAGE HOOK');
             var obj = req.body;
             if (obj.entry) {
                 for (var e = 0; e < obj.entry.length; e++) {


### PR DESCRIPTION
no issue
- Move "GOT A MESSAGE HOOK" message into debug output instead of console.log.