### PR TITLE
Add remove method for redis_storage.js

### DIFF
--- a/lib/storage/redis_storage.js
+++ b/lib/storage/redis_storage.js
@@ -34,6 +34,9 @@ module.exports = function(config) {
                         return cb(new Error('The given object must have an id property'), {});
                     client.hset(config.namespace + ':' + hash, object.id, JSON.stringify(object), cb);
                 },
+                remove: function(id, cb){
+                    client.hdel(config.namespace + ':' + hash, [id], cb);
+                },
                 all: function(cb, options) {
                     client.hgetall(config.namespace + ':' + hash, function(err, res) {
                         if (err)

--- a/lib/storage/storage_test.js
+++ b/lib/storage/storage_test.js
@@ -37,7 +37,17 @@ var testStorageMethod = function(storageMethod) {
                     data[0].foo === testObj0.foo && data[1].foo === testObj1.foo ||
                     data[0].foo === testObj1.foo && data[1].foo === testObj0.foo
                 );
+
+                if(storageMethod.remove){
+                    storageMethod.remove(testObj0.id, function(err, data) {
+                        test.assert(!err);
+                        console.log(data);
+                        test.assert(data === 1);
+                    });
+                }
             });
+
+            
         });
     });
 };


### PR DESCRIPTION
I needed the ability to remove teams/users from Redis. I added the method to the example file here, but didn't add it for the other types of storage (simple and firebase). I can explore adding it to the other methods to make this pull request complete if there is enough interest. I wasn't sure why it wasn't included in the first case so I could be missing some context. Open to thoughts/suggestions/improvements. 