### PR TITLE
allow for matching on any nickname mention

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -483,6 +483,7 @@ function Slackbot(configuration) {
 
                     var direct_mention = new RegExp('^\<\@' + bot.identity.id + '\>', 'i');
                     var mention = new RegExp('\<\@' + bot.identity.id + '\>', 'i');
+                    var broad_mention = new RegExp(bot.identity.name, 'i');
 
                     if (message.text.match(direct_mention)) {
                         // this is a direct mention
@@ -495,6 +496,10 @@ function Slackbot(configuration) {
                     } else if (message.text.match(mention)) {
                         message.event = 'mention';
                         slack_botkit.trigger('mention', [bot, message]);
+                        return false;
+                    } else if (message.text.match(broad_mention)) {
+                        message.event = 'broad_mention';
+                        slack_botkit.trigger('broad_mention', [bot, message]);
                         return false;
                     } else {
                         message.event = 'ambient';


### PR DESCRIPTION
sometimes we like to alert in channel with just the nick, without a proper `@nickname` mention, this allows for a broader match for any mention of the nick such as `nickname: message` this patch adds a `broad_mention` message event type which catches those instances