### PR TITLE
Webserver static dir can be configured through configuration

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -171,7 +171,7 @@ function Slackbot(configuration) {
         slack_botkit.webserver = express();
         slack_botkit.webserver.use(bodyParser.json());
         slack_botkit.webserver.use(bodyParser.urlencoded({ extended: true }));
-        slack_botkit.webserver.use(express.static(__dirname + '/public'));
+        slack_botkit.webserver.use(express.static(slack_botkit.config.webserver.static_dir || __dirname + '/public'));
 
         var server = slack_botkit.webserver.listen(
             slack_botkit.config.port,


### PR DESCRIPTION
The idea is to make it possible to configure the webserver static dir.
The variable `__dirname` points to the directory where the SlackBot.js file resides which is usually inside `node_modules`.

```
var controller = Botkit.slackbot({
      webserver: {
        static_dir: __dirname + '/public'
      }
    });
```
An alternative (which actually seems better) is to add a new parameter to the `setupWebserver` function. 