### PR TITLE
demo-bot: update comments for dm usage

### DIFF
--- a/examples/demo_bot.js
+++ b/examples/demo_bot.js
@@ -37,7 +37,7 @@ This bot demonstrates many of the core features of Botkit:
 
   The bot will send a message with a multi-field attachment.
 
-  Send: "dm"
+  Send: "dm me"
 
   The bot will reply with a direct message.
 


### PR DESCRIPTION
Was testing out examples, looks like the bot is listening for `dm me`, not `dm`