### PR TITLE
Use correct name of example bot in readme-slack.md

### DIFF
--- a/readme-slack.md
+++ b/readme-slack.md
@@ -38,7 +38,7 @@ Copy the API token that Slack gives you. You'll need it.
 4) Run the example bot app, using the token you just copied:
 ​
 ```
-token=REPLACE_THIS_WITH_YOUR_TOKEN node bot.js
+token=REPLACE_THIS_WITH_YOUR_TOKEN node slack_bot.js
 ```
 ​
 5) Your bot should be online! Within Slack, send it a quick direct message to say hello. It should say hello back!


### PR DESCRIPTION
Following the instructions in `readme-slack.md` results in the following error:

```
module.js:338
    throw err;
          ^
Error: Cannot find module '/Users/danielbird/Development/botkit/bot.js'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3
```

Change `token=REPLACE_THIS_WITH_YOUR_TOKEN node bot.js` to `token=REPLACE_THIS_WITH_YOUR_TOKEN node slack_bot.js`.