### PR TITLE
Remove unused variable in CoreBot.js

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -109,7 +109,7 @@ function Botkit(configuration) {
                 } else {
                     // handle might be a mapping of keyword to callback.
                     // lets see if the message matches any of the keywords
-                    var match, patterns = this.handler;
+                    var patterns = this.handler;
                     for (var p = 0; p < patterns.length; p++) {
                         if (patterns[p].pattern && botkit.hears_test([patterns[p].pattern], message)) {
                             patterns[p].callback(message, this);


### PR DESCRIPTION
Remove an unused variable from the `handle` method in CoreBot.js