### PR TITLE
Fix issue ReferenceError: match is not defined

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -728,7 +728,8 @@ function Botkit(configuration) {
                     test = tests[t];
                 }
 
-                if (match = message.text.match(test)) {
+                var match = message.text.match(test);
+                if (message.text.match(test)) {
                     message.match = match;
                     return true;
                 }


### PR DESCRIPTION
botkit/lib/CoreBot.js:731 if (match = message.text.match(test)) {
ReferenceError: match is not defined