### PR TITLE
Allow a configurable directory to serve static files for Facebook based bots

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -216,12 +216,17 @@ function Facebookbot(configuration) {
             throw new Error('Specified port is not a valid number');
         }
 
+        var static_dir =  __dirname + '/public';
+
+        if (facebook_botkit.config && facebook_botkit.config.webserver && facebook_botkit.config.webserver.static_dir)
+            static_dir = facebook_botkit.config.webserver.static_dir;
+
         facebook_botkit.config.port = port;
 
         facebook_botkit.webserver = express();
         facebook_botkit.webserver.use(bodyParser.json());
         facebook_botkit.webserver.use(bodyParser.urlencoded({ extended: true }));
-        facebook_botkit.webserver.use(express.static(__dirname + '/public'));
+        facebook_botkit.webserver.use(express.static(static_dir));
 
         var server = facebook_botkit.webserver.listen(
             facebook_botkit.config.port,


### PR DESCRIPTION
Allows you to pass a static dir to serve files from for bot using Facebook as well.