### PR TITLE
Allow capture_key to be 0

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -67,7 +67,7 @@ function Botkit(configuration) {
                 response.text = '';
             }
 
-            if (this.capture_options.key) {
+            if (this.capture_options.key || this.capture_options.key === 0) {
                 capture_key = this.capture_options.key;
             }
 


### PR DESCRIPTION
I'm doing something like this:

``` javascript
for (var i = 0; i < questions.length; i++) {
  convo.ask(questions[i], callback, { key: i });
}
```

and noticed that I'm missing "0" in my responses. This PR allows `0` to be a valid `capture_key`
