### PR TITLE
Support handling Multiple Facebook pages

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -242,6 +242,9 @@ function Botkit(configuration) {
             } else {
                 message.channel = this.source_message.channel;
             }
+            if (this.source_message.page_id) {
+                message.page_id = this.source_message.page_id;
+            }
 
             if (!this.topics[topic]) {
                 this.topics[topic] = [];

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -242,9 +242,6 @@ function Botkit(configuration) {
             } else {
                 message.channel = this.source_message.channel;
             }
-            if (this.source_message.page_id) {
-                message.page_id = this.source_message.page_id;
-            }
 
             if (!this.topics[topic]) {
                 this.topics[topic] = [];

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -9,6 +9,13 @@ function Facebookbot(configuration) {
     if (!configuration.access_token && !configuration.access_tokens) {
         throw new Error('One of access_token or access_tokens must be set.');
     }
+    // Backwards compatibility with the access_token configration setting.
+    if (!configuration.access_tokens) {
+        configuration.access_tokens = [{
+            page_id: 'default',
+            access_token: configuration.access_token,
+        }];
+    }
 
     // Create a core botkit bot
     var facebook_botkit = Botkit(configuration || {});
@@ -251,11 +258,8 @@ function Facebookbot(configuration) {
                 if (cb) { cb(null, facebook_botkit.webserver); }
             });
 
-        if (!configuration.access_tokens) {
-            configuration.access_tokens = { 'default': configuration.access_token };
-        }
-        for (var page_id of Object.keys(configuration.access_tokens)) {
-            request.post('https://graph.facebook.com/me/subscribed_apps?access_token=' + configuration.access_tokens[page_id],
+        for (var i = 0; i++; i < configuration.access_tokens.length; i++) {
+            request.post('https://graph.facebook.com/me/subscribed_apps?access_token=' + configuration.access_tokens[i].access_token,
               function (err, res, body) {
                   if (err) {
                       facebook_botkit.log('Could not subscribe to page messages');
@@ -271,14 +275,14 @@ function Facebookbot(configuration) {
     };
 
     facebook_botkit.getAccessTokenFromMessage = function(message) {
-        if (configuration.access_tokens && message.page_id) {
-            for (var page_id of Object.keys(configuration.access_tokens)) {
-                if (page_id == message.page_id) {
-                    return configuration.access_tokens[page_id];
+        if (configuration.access_tokens && configuration.access_tokens.length > 1 && message.page_id) {
+            for (var i = 0; i < configuration.access_tokens.length; i++) {
+                if (configuration.access_tokens[i].page_id == message.page_id) {
+                    return configuration.access_tokens[i].page_id;
                 }
             }
         } else {
-            return configuration.access_token;
+            return configuration.access_tokens[0].access_token;
         }
     }
 

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -263,7 +263,7 @@ function Facebookbot(configuration) {
     };
 
     facebook_botkit.getAccessTokenFromMessage = function(message) {
-        if (typeof configuration.access_tokens == 'object') {
+        if (configuration.access_tokens && typeof configuration.access_tokens == 'object') {
             if (message.page_id) {
                 for (var page_id of Object.keys(configuration.access_tokens)) {
                     if (page_id == message.page_id) {
@@ -272,7 +272,7 @@ function Facebookbot(configuration) {
                 }
             }
         } else {
-            return configuration.access_tokens;
+            return configuration.access_token;
         }
     }
 

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -246,6 +246,9 @@ function Facebookbot(configuration) {
                 if (cb) { cb(null, facebook_botkit.webserver); }
             });
 
+        if (!configuration.access_tokens) {
+            configuration.access_tokens = { 'default': configuration.access_token };
+        }
         for (var page_id of Object.keys(configuration.access_tokens)) {
             request.post('https://graph.facebook.com/me/subscribed_apps?access_token=' + configuration.access_tokens[page_id],
               function (err, res, body) {
@@ -263,12 +266,10 @@ function Facebookbot(configuration) {
     };
 
     facebook_botkit.getAccessTokenFromMessage = function(message) {
-        if (configuration.access_tokens && typeof configuration.access_tokens == 'object') {
-            if (message.page_id) {
-                for (var page_id of Object.keys(configuration.access_tokens)) {
-                    if (page_id == message.page_id) {
-                        return configuration.access_tokens[page_id];
-                    }
+        if (configuration.access_tokens && message.page_id) {
+            for (var page_id of Object.keys(configuration.access_tokens)) {
+                if (page_id == message.page_id) {
+                    return configuration.access_tokens[page_id];
                 }
             }
         } else {

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -33,6 +33,10 @@ function Facebookbot(configuration) {
         };
 
         bot.send = function(message, cb) {
+            var access_token = facebook_botkit.getAccessTokenFromMessage(message);
+
+            botkit.debug('SEND MESSAGE', message);
+            botkit.debug('ACCESS_TOKEN', access_token);
 
             var facebook_message = {
                 recipient: {},
@@ -53,7 +57,7 @@ function Facebookbot(configuration) {
                 facebook_message.message.attachment = message.attachment;
             }
 
-            request.post('https://graph.facebook.com/me/messages?access_token=' + configuration.access_token,
+            request.post('https://graph.facebook.com/me/messages?access_token=' + access_token,
                 function(err, res, body) {
                     if (err) {
                         botkit.debug('WEBHOOK ERROR', err);
@@ -143,6 +147,7 @@ function Facebookbot(configuration) {
                                 seq: facebook_message.message.seq,
                                 mid: facebook_message.message.mid,
                                 attachments: facebook_message.message.attachments,
+                                page_id: facebook_message.recipient.id,
                             };
 
                             facebook_botkit.receiveMessage(bot, message);
@@ -156,6 +161,7 @@ function Facebookbot(configuration) {
                                 user: facebook_message.sender.id,
                                 channel: facebook_message.sender.id,
                                 timestamp: facebook_message.timestamp,
+                                page_id: facebook_message.recipient.id,
                             };
 
                             facebook_botkit.trigger('facebook_postback', [bot, message]);
@@ -165,6 +171,7 @@ function Facebookbot(configuration) {
                                 user: facebook_message.sender.id,
                                 channel: facebook_message.sender.id,
                                 timestamp: facebook_message.timestamp,
+                                page_id: facebook_message.recipient.id,
                             };
 
                             facebook_botkit.receiveMessage(bot, message);
@@ -176,6 +183,7 @@ function Facebookbot(configuration) {
                                 user: facebook_message.sender.id,
                                 channel: facebook_message.sender.id,
                                 timestamp: facebook_message.timestamp,
+                                page_id: facebook_message.recipient.id,
                             };
 
                             facebook_botkit.trigger('facebook_optin', [bot, message]);
@@ -186,6 +194,7 @@ function Facebookbot(configuration) {
                                 user: facebook_message.sender.id,
                                 channel: facebook_message.sender.id,
                                 timestamp: facebook_message.timestamp,
+                                page_id: facebook_message.recipient.id,
                             };
 
                             facebook_botkit.trigger('message_delivered', [bot, message]);
@@ -246,20 +255,35 @@ function Facebookbot(configuration) {
                 if (cb) { cb(null, facebook_botkit.webserver); }
             });
 
-
-        request.post('https://graph.facebook.com/me/subscribed_apps?access_token=' + configuration.access_token,
-            function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not subscribe to page messages');
-                } else {
-                    facebook_botkit.debug('Successfully subscribed to Facebook events:', body);
-                    facebook_botkit.startTicking();
-                }
-            });
+        for (var page_id of Object.keys(configuration.access_tokens)) {
+            request.post('https://graph.facebook.com/me/subscribed_apps?access_token=' + configuration.access_tokens[page_id],
+              function (err, res, body) {
+                  if (err) {
+                      facebook_botkit.log('Could not subscribe to page messages');
+                  } else {
+                      facebook_botkit.debug('Successfully subscribed to Facebook events:', body);
+                      facebook_botkit.startTicking();
+                  }
+              });
+        }
 
         return facebook_botkit;
 
     };
+
+    facebook_botkit.getAccessTokenFromMessage = function(message) {
+        if (typeof configuration.access_tokens == 'object') {
+            if (message.page_id) {
+                for (var page_id of Object.keys(configuration.access_tokens)) {
+                    if (page_id == message.page_id) {
+                        return configuration.access_tokens[page_id];
+                    }
+                }
+            }
+        } else {
+            return configuration.access_tokens;
+        }
+    }
 
     return facebook_botkit;
 };

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -95,6 +95,7 @@ function Facebookbot(configuration) {
             }
 
             msg.channel = src.channel;
+            msg.page_id = src.page_id;
 
             bot.say(msg, cb);
         };

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -5,6 +5,11 @@ var bodyParser = require('body-parser');
 
 function Facebookbot(configuration) {
 
+    // Check for required params
+    if (!configuration.access_token && !configuration.access_tokens) {
+        throw new Error('One of access_token or access_tokens must be set.');
+    }
+
     // Create a core botkit bot
     var facebook_botkit = Botkit(configuration || {});
 

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -3,16 +3,6 @@ var request = require('request');
 var express = require('express');
 var bodyParser = require('body-parser');
 
-// TODO
-// In order to change Botkit to support multiple Facebook pages:
-// - Change the access_token config key passed to BotKit.facebookbot() to be an object pairing the
-// page id and the corresponding access_token.
-// - Change anywhere access_token is used to check if it's a string or the aforementioned object
-// type.
-// - Change the Conversation object in CoreBot.js to create messages that include the page id
-// - In Facebook.js change the send method to lookup the right access_token by the page id in the
-// message.
-// - In the Facebook /facebook/receive webhook include the page id in the message structure created.
 function Facebookbot(configuration) {
 
     // Create a core botkit bot

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -258,7 +258,7 @@ function Facebookbot(configuration) {
                 if (cb) { cb(null, facebook_botkit.webserver); }
             });
 
-        for (var i = 0; i++; i < configuration.access_tokens.length; i++) {
+        for (var i = 0; i < configuration.access_tokens.length; i++) {
             request.post('https://graph.facebook.com/me/subscribed_apps?access_token=' + configuration.access_tokens[i].access_token,
               function (err, res, body) {
                   if (err) {

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -3,6 +3,16 @@ var request = require('request');
 var express = require('express');
 var bodyParser = require('body-parser');
 
+// TODO
+// In order to change Botkit to support multiple Facebook pages:
+// - Change the access_token config key passed to BotKit.facebookbot() to be an object pairing the
+// page id and the corresponding access_token.
+// - Change anywhere access_token is used to check if it's a string or the aforementioned object
+// type.
+// - Change the Conversation object in CoreBot.js to create messages that include the page id
+// - In Facebook.js change the send method to lookup the right access_token by the page id in the
+// message.
+// - In the Facebook /facebook/receive webhook include the page id in the message structure created.
 function Facebookbot(configuration) {
 
     // Create a core botkit bot

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -278,7 +278,7 @@ function Facebookbot(configuration) {
         if (configuration.access_tokens && configuration.access_tokens.length > 1 && message.page_id) {
             for (var i = 0; i < configuration.access_tokens.length; i++) {
                 if (configuration.access_tokens[i].page_id == message.page_id) {
-                    return configuration.access_tokens[i].page_id;
+                    return configuration.access_tokens[i].access_token;
                 }
             }
         } else {

--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -132,18 +132,21 @@ configuration object. The configuration object has the following keys:
 | Key | Required | Description
 |---  |---  |---
 | access_token | optional* | If your script is handling a single Facebook page, enter the Page Access Token from the Facebook App Settings.
-| access_tokens | optional* | If your script is handling more than one Facebook page, use this configuration setting to provide an object hash of Facebook Page Id to Page Access Token.
+| access_tokens | optional* | If your script is handling more than one Facebook page, use this configuration setting to provide an array of objects, each of which has a `page_id` key for the Facebook Page Id and an `access_token` key for the Page Access Token from the Facebook App Settings.
 | verify_token | required | This is Verify Token that is used to setup your webhooks on your Facebook App Settings.
 
 Below is an example of initiating the controller using multiple page id's:
 
 ```javascript
 var controller = Botkit.facebookbot({
-        access_tokens: {
-          process.env.page_id_foo: process.env.access_token_foo,
-          process.env.page_id_bar: process.env.access_token_bar,
-        },
-        verify_token: process.env.verify_token,
+    access_tokens: [{
+        page_id: process.env.page_id_foo,
+        access_token: process.env.access_token_foo,
+    }, {
+        page_id: process.env.page_id_bar,
+        access_token: process.env.access_token_bar,
+    }],
+    verify_token: process.env.verify_token,
 })
 ```
 

--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -150,7 +150,7 @@ var controller = Botkit.facebookbot({
 })
 ```
 
-* Note that one of access_token or access_tokens configuration settings must be given.
+\* Note that one of access_token or access_tokens configuration settings must be given.
 
 #### controller.setupWebserver()
 | Argument | Description

--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -124,6 +124,30 @@ controller.hears(['cookies'], 'message_received', function(bot, message) {
 });
 ```
 
+#### Botkit.faceboookbot()
+
+This function created the controller for the bot. It takes a single argument, which is a
+configuration object. The configuration object has the following keys:
+
+| Key | Required | Description
+|---  |---  |---
+| access_token | optional* | If your script is handling a single Facebook page, enter the Page Access Token from the Facebook App Settings.
+| access_tokens | optional* | If your script is handling more than one Facebook page, use this configuration setting to provide an object hash of Facebook Page Id to Page Access Token.
+| verify_token | required | This is Verify Token that is used to setup your webhooks on your Facebook App Settings.
+
+Below is an example of initiating the controller using multiple page id's:
+
+```javascript
+var controller = Botkit.facebookbot({
+        access_tokens: {
+          process.env.page_id_foo: process.env.access_token_foo,
+          process.env.page_id_bar: process.env.access_token_bar,
+        },
+        verify_token: process.env.verify_token,
+})
+```
+
+* Note that one of access_token or access_tokens configuration settings must be given.
 
 #### controller.setupWebserver()
 | Argument | Description


### PR DESCRIPTION
This is a crack at supporting multiple Facebook pages. The idea here is that the page_id is passed along in the message object and then used to lookup the corresponding access_token to use when sending messages in reply to Facebook.  You could also use hears middleware to check against the page_id in the incoming message, and handle or ignore the message based on it.  In that way you could essentially run two different bots from the same code base and node process.

Just throwing this out there to see what people think.  I've also updated the Facebook README to explain how to configure this.  But basically, it adds a `access_tokens` config setting passed to the `Botkit.faceboookbot` function, which is an array of objects so you can specify which page_ids you want to listen to and the corresponding access_token.

There was some initial discussion about this feature in https://github.com/howdyai/botkit/issues/222. I know it was turned down, but I wanted to give it a shot anyway. So far, it's working well for my purposes. More testing to be done though.