### PR TITLE
Add hearing for impersonating bots.

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -476,7 +476,7 @@ function Slackbot(configuration) {
                 // set up a couple of special cases based on subtype
                 if (message.subtype && message.subtype == 'channel_join') {
                     // someone joined. maybe do something?
-                    if (message.user == bot.identity.id) {
+                    if (message.user == bot.identity.id && message.bot_id) {
                         slack_botkit.trigger('bot_channel_join', [bot, message]);
                         return false;
                     } else {
@@ -485,7 +485,7 @@ function Slackbot(configuration) {
                     }
                 } else if (message.subtype && message.subtype == 'group_join') {
                     // someone joined. maybe do something?
-                    if (message.user == bot.identity.id) {
+                    if (message.user == bot.identity.id && message.bot_id) {
                         slack_botkit.trigger('bot_group_join', [bot, message]);
                         return false;
                     } else {
@@ -497,7 +497,7 @@ function Slackbot(configuration) {
                     return false;
                 } else if (message.channel.match(/^D/)) {
                     // this is a direct message
-                    if (message.user == bot.identity.id) {
+                    if (message.user == bot.identity.id && message.bot_id) {
                         return false;
                     }
                     if (!message.text) {
@@ -515,7 +515,7 @@ function Slackbot(configuration) {
                     return false;
 
                 } else {
-                    if (message.user == bot.identity.id) {
+                    if (message.user == bot.identity.id && message.bot_id) {
                         return false;
                     }
                     if (!message.text) {


### PR DESCRIPTION
I made a bot that impersonates me, but this disabled hearing for my messages.
I can separate my messages from the bot's messages by checking for message.bot_id .
