### PR TITLE
Reconnect when websocket closes abnormally

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -212,7 +212,10 @@ module.exports = function(botkit, config) {
                 }
                 botkit.trigger('rtm_close', [bot]);
 
-                // CLOSE_ABNORMAL error - wasn't closed explicitly, should attempt to reconnect
+                /**
+                 * CLOSE_ABNORMAL error
+                 * wasn't closed explicitly, should attempt to reconnect
+                 */
                 if (code === 1006) {
                     botkit.log.error('Abnormal websocket close event, attempting to reconnect');
                     reconnect();

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -204,11 +204,14 @@ module.exports = function(botkit, config) {
                 botkit.trigger('rtm_close', [bot, err]);
             });
 
-            bot.rtm.on('close', function() {
+            bot.rtm.on('close', function(code, message) {
+                botkit.log.error('RTM close event: ' + code + ' : ' + message);
                 if (pingIntervalId) {
                     clearInterval(pingIntervalId);
                 }
                 botkit.trigger('rtm_close', [bot]);
+
+                reconnect();
             });
         });
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -158,6 +158,7 @@ module.exports = function(botkit, config) {
             });
 
             bot.rtm.on('open', function() {
+                botkit.log.notice('RTM websocket opened');
 
                 pingIntervalId = setInterval(function() {
                     if (lastPong && lastPong + 12000 < Date.now()) {
@@ -205,13 +206,17 @@ module.exports = function(botkit, config) {
             });
 
             bot.rtm.on('close', function(code, message) {
-                botkit.log.error('RTM close event: ' + code + ' : ' + message);
+                botkit.log.notice('RTM close event: ' + code + ' : ' + message);
                 if (pingIntervalId) {
                     clearInterval(pingIntervalId);
                 }
                 botkit.trigger('rtm_close', [bot]);
 
-                reconnect();
+                // CLOSE_ABNORMAL error - wasn't closed explicitly, should attempt to reconnect
+                if (code === 1006) {
+                    botkit.log.error('Abnormal websocket close event, attempting to reconnect');
+                    reconnect();
+                }
             });
         });
 


### PR DESCRIPTION
I've been debugging some websocket connection issues that we've seen pretty consistently on Beep Boop where the connection lasts 6 or 7 days, then disconnects, and doesn't attempt to reconnect.  I've narrowed this down to the following scenario:

+ websocket connection goes stale, i.e. `PONG` receipt times out
+ attempts to reconnect - but is unsuccessful
+ a `close` event triggers on the websocket with an error code `1006` with this unsuccessful reconnect attept, meaning it was an abormal close ([more info here](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent))

Currently that's where the websocket reconnect attempt stops, so this PR adds another reconnect attempt when an abnormal close event is received on the websocket.  We've seen this fix our slack rtm connections going down on a few bots on Beep Boop.

Below are some annotated logs that helped me figure out what was going on:

```
// Stale RTM Connection via PONG timeout - called closeRTM - ln 165

2016-06-11T05:19:00.160Z - error: RTM Connection closed
  // from `beepboop-botkit` logged on `rtm_close` event

2016-06-11T05:19:01.166Z - botkit: ** BOT ID: roflbot ...reconnect attempt #1 of Infinity being made after 1000ms
  // reconnect() called - ln 77

2016-06-11T05:19:01.181Z - botkit: ** API CALL: https://slack.com/api/rtm.start
  // startRTM() via reconnect()

2016-06-11T05:19:01.527Z - botkit: ** BOT ID: roflbot ...attempting to connect to RTM!
 // startRTM() via reconnect()

2016-06-11T10:25:31.915Z - botkit: RTM close event: 1006 :
  // unsuccessful websocket connection: websocket `close` event

2016-06-11T10:25:31.916Z - error: RTM Connection closed
  // from `beepboop-botkit` logged on `rtm_close` event

2016-06-11T10:25:32.917Z - botkit: ** BOT ID: roflbot ...reconnect attempt #1 of Infinity being made after 1000ms
  // reconnect() attempt

2016-06-11T10:25:32.918Z - botkit: ** API CALL: https://slack.com/api/rtm.start
  // startRTM() via reconnect()

2016-06-11T10:25:33.260Z - botkit: ** BOT ID: roflbot ...attempting to connect to RTM!
 // startRTM() via reconnect()
```
