### PR TITLE
Refer to Messenger Platform in Facebook botkit log

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -113,8 +113,8 @@ function Facebookbot(configuration) {
     facebook_botkit.createWebhookEndpoints = function(webserver, bot, cb) {
 
         facebook_botkit.log(
-            '** Serving webhook endpoints for Slash commands and outgoing ' +
-            'webhooks at: http://MY_HOST:' + facebook_botkit.config.port + '/facebook/receive');
+            '** Serving webhook endpoints for Messenger Platform at: ' +
+            'http://MY_HOST:' + facebook_botkit.config.port + '/facebook/receive');
         webserver.post('/facebook/receive', function(req, res) {
 
             facebook_botkit.debug('GOT A MESSAGE HOOK');


### PR DESCRIPTION
Update `createWebhookEndpoints` log message to refer to Facebook Messenger Platform instead of Slash commands.