### PR TITLE
Slack reconnect cleanup

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -165,6 +165,7 @@ module.exports = function(botkit, config) {
                         var err = new Error('Stale RTM connection, closing RTM');
                         botkit.log.error(err)
                         bot.closeRTM(err);
+                        clearInterval(pingIntervalId);
                         return;
                     }
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -163,6 +163,7 @@ module.exports = function(botkit, config) {
                 pingIntervalId = setInterval(function() {
                     if (lastPong && lastPong + 12000 < Date.now()) {
                         var err = new Error('Stale RTM connection, closing RTM');
+                        botkit.log.error(err)
                         bot.closeRTM(err);
                         return;
                     }

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -18,7 +18,6 @@ module.exports = function(botkit, config) {
     };
 
     var pingIntervalId = null;
-    var lastPong = 0;
     var retryBackoff = null;
 
     // config.retry, can be Infinity too
@@ -69,7 +68,6 @@ module.exports = function(botkit, config) {
             clearInterval(pingIntervalId);
         }
 
-        lastPong = 0;
         botkit.trigger('rtm_close', [bot, err]);
 
         // only retry, if enabled, when there was an error
@@ -118,6 +116,7 @@ module.exports = function(botkit, config) {
     };
 
     bot.startRTM = function(cb) {
+        var lastPong = 0;
         bot.api.rtm.start({
             no_unreads: true,
             simple_latest: true,


### PR DESCRIPTION
Fixed some observed issues where reconnections would hit a ping/pong error right away.  This was due to the interval and the lastPong from the previous connection not being properly cleaned up.