### PR TITLE
Show winston levels being set

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -850,6 +850,7 @@ Then, use it when you create your bot:
 ```javascript
 var controller = Botkit.slackbot({
   logger: new winston.Logger({
+    levels: winston.config.syslog.levels
     transports: [
       new (winston.transports.Console)(),
       new (winston.transports.File)({ filename: './bot.log' })
@@ -858,6 +859,7 @@ var controller = Botkit.slackbot({
 });
 ```
 
+Note: with Winston, we must use the syslog.levels over the default or else some botkit log messages (like 'notice') will not be logged properly.  
 
 ##Use BotKit with an Express web server
 Instead of controller.setupWebserver(), it is possible to use a different web server to manage authentication flows, as well as serving web pages.


### PR DESCRIPTION
I discovered a ton of botkit messages that weren't logging with the default levels in Winston, hence an update to the readme logger example.  