### PR TITLE
Added FB sticker detection

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -140,7 +140,7 @@ function Facebookbot(configuration) {
                                 timestamp: facebook_message.timestamp,
                                 seq: facebook_message.message.seq,
                                 mid: facebook_message.message.mid,
-								sticker_id: facebook_message.message.sticker_id,
+                                sticker_id: facebook_message.message.sticker_id,
                                 attachments: facebook_message.message.attachments,
                                 quick_reply: facebook_message.message.quick_reply
                             };

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -43,6 +43,10 @@ function Facebookbot(configuration) {
                 facebook_message.message.attachment = message.attachment;
             }
 
+            if (message.sticker_id) {
+                facebook_message.message.sticker_id = message.sticker_id;
+            }
+
             if (message.quick_replies) {
                 facebook_message.message.quick_replies = message.quick_replies;
             }
@@ -136,6 +140,7 @@ function Facebookbot(configuration) {
                                 timestamp: facebook_message.timestamp,
                                 seq: facebook_message.message.seq,
                                 mid: facebook_message.message.mid,
+								sticker_id: facebook_message.message.sticker_id,
                                 attachments: facebook_message.message.attachments,
                                 quick_reply: facebook_message.message.quick_reply
                             };


### PR DESCRIPTION
FB stickers can be distinguished from regular images sent by the user by looking at the message data for a sticker_id field. Right now, botkit doesn't support plumbing that through so it's impossible to distinguish a Like from someone sending an image. This fixes that issue.