### PR TITLE
Fix #159 - Add support for ip on webserver

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -207,9 +207,13 @@ function Slackbot(configuration) {
 
         if (slack_botkit.config && slack_botkit.config.webserver && slack_botkit.config.webserver.static_dir)
             static_dir = slack_botkit.config.webserver.static_dir;
-
-        slack_botkit.config.port = port;
-        slack_botkit.config.ip = slack_botkit.config.ip || '127.0.0.1';
+        
+        if (slack_botkit.config) {
+            slack_botkit.config.port = port;
+            slack_botkit.config.ip = slack_botkit.config.ip || '127.0.0.1';
+        }
+        
+        var ip = slack_botkit.config? slack_botkit.config.ip : '127.0.0.1';
 
         slack_botkit.webserver = express();
         slack_botkit.webserver.use(bodyParser.json());
@@ -217,12 +221,10 @@ function Slackbot(configuration) {
         slack_botkit.webserver.use(express.static(static_dir));
 
         var server = slack_botkit.webserver.listen(
-            slack_botkit.config.port,
-            slack_botkit.config.ip,
+            port,
+            ip,
             function() {
-                slack_botkit.log('** Starting webserver on ' +
-                    ((slack_botkit.config.ip)?slack_botkit.config.ip+':':'port ') +
-                    slack_botkit.config.port);
+                slack_botkit.log('** Starting webserver on ' + ip + ':' + port);
                 if (cb) { cb(null, slack_botkit.webserver); }
             });
 

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -209,7 +209,7 @@ function Slackbot(configuration) {
             static_dir = slack_botkit.config.webserver.static_dir;
 
         slack_botkit.config.port = port;
-        slack_botkit.config.ip = slack_botkit.config.ip || 127.0.0.1;
+        slack_botkit.config.ip = slack_botkit.config.ip || '127.0.0.1';
 
         slack_botkit.webserver = express();
         slack_botkit.webserver.use(bodyParser.json());

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -194,7 +194,7 @@ function Slackbot(configuration) {
         slack_botkit.storage.teams.get(id, cb);
     };
 
-    slack_botkit.setupWebserver = function(port, cb) {
+    slack_botkit.setupWebserver = function(port, cb, ip) {
 
         if (!port) {
             throw new Error('Cannot start webserver without a port');
@@ -209,6 +209,7 @@ function Slackbot(configuration) {
             static_dir = slack_botkit.config.webserver.static_dir;
 
         slack_botkit.config.port = port;
+        slack_botkit.config.ip = ip || 127.0.0.1;
 
         slack_botkit.webserver = express();
         slack_botkit.webserver.use(bodyParser.json());
@@ -217,8 +218,10 @@ function Slackbot(configuration) {
 
         var server = slack_botkit.webserver.listen(
             slack_botkit.config.port,
+            slack_botkit.config.ip,
             function() {
-                slack_botkit.log('** Starting webserver on port ' +
+                slack_botkit.log('** Starting webserver on ' +
+                    ((slack_botkit.config.ip)?slack_botkit.config.ip+':':'port ') +
                     slack_botkit.config.port);
                 if (cb) { cb(null, slack_botkit.webserver); }
             });

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -194,7 +194,7 @@ function Slackbot(configuration) {
         slack_botkit.storage.teams.get(id, cb);
     };
 
-    slack_botkit.setupWebserver = function(port, cb, ip) {
+    slack_botkit.setupWebserver = function(port, cb) {
 
         if (!port) {
             throw new Error('Cannot start webserver without a port');
@@ -209,7 +209,7 @@ function Slackbot(configuration) {
             static_dir = slack_botkit.config.webserver.static_dir;
 
         slack_botkit.config.port = port;
-        slack_botkit.config.ip = ip || 127.0.0.1;
+        slack_botkit.config.ip = slack_botkit.config.ip || 127.0.0.1;
 
         slack_botkit.webserver = express();
         slack_botkit.webserver.use(bodyParser.json());

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -221,7 +221,7 @@ function Slackbot(configuration) {
         slack_botkit.webserver.use(express.static(static_dir));
 
         var server = slack_botkit.webserver.listen(
-            port,
+            slack_botkit.config.port,
             ip,
             function() {
                 slack_botkit.log('** Starting webserver on ' + ip + ':' + port);


### PR DESCRIPTION
This PR is based on - and supersedes - #249, and addresses an issue with that PR, namely, the quoting of the localhost IP as a string. It adds a new supported field - ip - to the config consumed by the Slack variant of Botkit so that it can be used out-of-the-box on hosting providers (like RedHat Openshift) that require processes to listen on specific IP addresses.

This issue fixes #159.