### PR TITLE
Issue 307: Fix reference error in slash command processing.

### DIFF
--- a/lib/middleware/slack_authentication.js
+++ b/lib/middleware/slack_authentication.js
@@ -36,10 +36,6 @@ function init(tokens) {
             return;
         }
 
-        slack_botkit.log(
-            '** Requiring token authentication for webhook endpoints for Slash commands ' +
-            'and outgoing webhooks; configured ' + tokens.length + ' tokens'
-        );
         next();
     }
 


### PR DESCRIPTION
https://github.com/howdyai/botkit/issues/307

There is logging happening here which introduces a reference error on `slack_botkit`. Removed this logging code because it already happens in SlackBot.js.