### PR TITLE
Apps should be able to respond with 200 without text.

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -361,6 +361,22 @@ module.exports = function(botkit, config) {
         }
     };
 
+    /**
+    * Allows responding to slash commands and interactive messages with a plain
+    * 200 OK (without any text or attachments).
+    * @param {function} cb - An optional callback function called at the end of execution.
+    * The callback is passed an optional Error object.
+    */
+    bot.replyAcknowledge = function(cb) {
+      if (!bot.res) {
+          cb && cb(new Error('No web response object found'));
+      } else {
+          bot.res.end();
+
+          cb && cb();
+      }
+    }
+
     bot.replyPublic = function(src, resp, cb) {
         if (!bot.res) {
             cb && cb('No web response object found');


### PR DESCRIPTION
When responding to slash commands and interactive messages, apps should be able to do so without any content:
https://api.slack.com/slash-commands#responding_to_a_command
https://api.slack.com/docs/message-buttons#how_to_respond_to_message_button_actions

After looking at the existing code, I thought a new public method was the best course of action. Adding this functionality into existing method(s) seemed awkward. For example, I considered adding this to the `replyPrivate` method. There were two things I don't like about that. First, the name of the method would be confusing at this point, and changing the method name would be a breaking change. Second, client code would have to pass `null` for the the `resp` argument, or pass in an additional argument, which would make for a less defined api. 