### PR TITLE
Add flexibility to Slack auth flow via custom redirect params

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -2,6 +2,7 @@ var Botkit = require(__dirname + '/CoreBot.js');
 var request = require('request');
 var express = require('express');
 var bodyParser = require('body-parser');
+var querystring = require('querystring');
 
 function Slackbot(configuration) {
 
@@ -303,7 +304,7 @@ function Slackbot(configuration) {
     };
 
     // get a team url to redirect the user through oauth process
-    slack_botkit.getAuthorizeURL = function(team_id) {
+    slack_botkit.getAuthorizeURL = function(team_id, redirect_params) {
 
         var scopes = slack_botkit.config.scopes;
         var url = 'https://slack.com/oauth/authorize' + '?client_id=' +
@@ -312,8 +313,14 @@ function Slackbot(configuration) {
         if (team_id)
             url += '&team=' + team_id;
 
-        if (slack_botkit.config.redirectUri)
-            url += '&redirect_uri=' + slack_botkit.config.redirectUri;
+        if (slack_botkit.config.redirectUri) {
+            var redirect_query = '';
+            if (redirect_params)
+                redirect_query += encodeURIComponent(querystring.stringify(redirect_params));
+
+            var redirect_uri = slack_botkit.config.redirectUri + '?' + redirect_query;
+            url += '&redirect_uri=' + redirect_uri;
+        }
 
         return url;
 
@@ -382,7 +389,17 @@ function Slackbot(configuration) {
                 code: code
             };
 
-            if (slack_botkit.config.redirectUri) opts.redirect_uri = slack_botkit.config.redirectUri;
+            var redirect_params = {};
+            if (slack_botkit.config.redirectUri) {
+              Object.assign(redirect_params, req.query);
+              delete redirect_params.code;
+              delete redirect_params.state;
+
+              var redirect_query = querystring.stringify(redirect_params);
+              var redirect_uri = slack_botkit.config.redirectUri + '?' + redirect_query;
+
+              opts.redirect_uri = redirect_uri;
+            }
 
             oauth_access(opts, function(err, auth) {
 
@@ -507,9 +524,9 @@ function Slackbot(configuration) {
                                                     slack_botkit.trigger('error', [err]);
                                                 } else {
                                                     if (isnew) {
-                                                        slack_botkit.trigger('create_user', [bot, user]);
+                                                        slack_botkit.trigger('create_user', [bot, user, redirect_params]);
                                                     } else {
-                                                        slack_botkit.trigger('update_user', [bot, user]);
+                                                        slack_botkit.trigger('update_user', [bot, user, redirect_params]);
                                                     }
                                                     if (callback) {
                                                         callback(null, req, res);

--- a/readme-slack.md
+++ b/readme-slack.md
@@ -606,6 +606,24 @@ controller.setupWebserver(process.env.port,function(err,webserver) {
 
 ```
 
+#### Custom auth flows
+In addition to the Slack Button, you can send users through an auth flow via a Slack interaction.
+The `getAuthorizeURL` provides the url. It requires the `team_id` and accepts an optional `redirect_params` argument.
+```javascript
+controller.getAuthorizeURL(team_id, redirect_params);
+```
+
+The `redirect_params` argument is passed back into the `create_user` and `update_user` events so you can handle
+auth flows in different ways. For example:
+```javascript
+controller.on('create_user', function(bot, user, redirect_params) {
+    if (redirect_params.slash_command_id) {
+        // continue processing the slash command for the user
+    }
+}
+```
+
+
 ### How to identify what team your message came from
 ```javascript
 var team = bot.identifyTeam() // returns team id


### PR DESCRIPTION
https://github.com/howdyai/botkit/issues/329

This will enable handling auth flows for various use cases by way of `redirect_uri` query params. 

If we stay with the existing design, I see two approaches:
a) Pass params around and only use them if the Slack App controller is configured with the `redirectUri` value.
b) Pass the entire redirect URI around. This options gives more flexibility in case apps want to have multiple redirect URI endpoints. This might be useful if they want greater control over their auth flows than what Botkit provides.

For the app we're building, we don't have a use case for b), so I thought to try out a) and get some feedback. 

Question (if the approach is ok):
Should the `redirect_params` be passed into the `create/update_team` and `create_bot` events also?
