### PR TITLE
Add replyAndUpdate method for updating Slack messages

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -570,6 +570,45 @@ module.exports = function(botkit, config) {
     };
 
     /**
+     * replies with message, performs arbitrary task, then updates reply message
+     * note: don't use this as a replacement for the `typing` event
+     *
+     * @param {Object} src - message source
+     * @param {(string|Object)} resp - response string or object
+     * @param {function} [cb] - updater callback
+     */
+    bot.replyAndUpdate = function(src, resp, cb) {
+        try {
+            resp = typeof resp === 'string' ? { text: resp } : resp;
+            // trick bot.reply into using web API instead of RTM
+            resp.attachments = resp.attachments || [];
+        } catch (err) {
+            return cb && cb(err);
+        }
+        // send the "updatable" message
+        return bot.reply(src, resp, function(err, src) {
+            if (err) return cb && cb(err);
+
+            // if provided, call the updater callback - it controls how and when to update the "updatable" message
+            return cb && cb(null, function(resp, cb) {
+                try {
+                    // format the "update" message to target the "updatable" message
+                    resp = typeof resp === 'string' ? { text: resp } : resp;
+                    resp.ts = src.ts;
+                    resp.channel = src.channel;
+                    resp.attachments = JSON.stringify(resp.attachments || []);
+                } catch (err) {
+                    return cb && cb(err);
+                }
+                // update the "updatable" message with the "update" message
+                return bot.api.chat.update(resp, function(err, json) {
+                    return cb && cb(err, json);
+                });
+            });
+        });
+    };
+
+    /**
      * This handles the particulars of finding an existing conversation or
      * topic to fit the message into...
      */

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -364,18 +364,19 @@ module.exports = function(botkit, config) {
     /**
     * Allows responding to slash commands and interactive messages with a plain
     * 200 OK (without any text or attachments).
+    *
     * @param {function} cb - An optional callback function called at the end of execution.
     * The callback is passed an optional Error object.
     */
     bot.replyAcknowledge = function(cb) {
-      if (!bot.res) {
-          cb && cb(new Error('No web response object found'));
-      } else {
-          bot.res.end();
+        if (!bot.res) {
+            cb && cb(new Error('No web response object found'));
+        } else {
+            bot.res.end();
 
-          cb && cb();
-      }
-    }
+            cb && cb();
+        }
+    };
 
     bot.replyPublic = function(src, resp, cb) {
         if (!bot.res) {

--- a/readme-slack.md
+++ b/readme-slack.md
@@ -462,6 +462,32 @@ slash commands also support private, and delayed messages. See below.
 | reply | reply message (string or object)
 | callback | optional callback
 
+#### bot.replyAndUpdate()
+
+| Argument | Description
+|---  |---
+| src | source message as received from slash or webhook
+| reply | reply message that might get updated (string or object)
+| callback | optional asynchronous callback that performs a task and updates the reply message
+
+Sending a message, performing a task and then updating the sent message based on the result of that task is made simple with this method:
+
+> **Note**: For the best user experience, try not to use this method to indicate bot activity. Instead, use `bot.startTyping`.
+
+```javascript
+// fixing a typo
+controller.hears('hello', ['ambient'], function(bot, msg) {
+  // send a message back: "hellp"
+  bot.replyAndUpdate(msg, 'hellp', function(err, updateResponse) {
+    if (error) console.error(err);
+    // oh no, "hellp" is a typo - let's update the message to "hello"
+    updateResponse('hello', function(err) {
+      console.error(err)
+    });
+  });
+});
+```
+
 
 
 ### Using the Slack Web API
@@ -652,7 +678,7 @@ controller.hears('interactive', 'direct_message', function(bot, message) {
                 ]
             }
         ]
-    });    
+    });
 });
 ```
 
@@ -752,7 +778,7 @@ bot.startConversation(message, function(err, convo) {
                 convo.next();
             }
         },
-        {   
+        {
             default: true,
             callback: function(reply, convo) {
                 // do nothing


### PR DESCRIPTION
This pull request adds a new method to `Slackbot_worker.js`: `replyAndUpdate` which allows quick editing of a previously sent reply. 

Which addresses this issue: #156 

(I also snuck in a commit that fixes some linter issues outside of this implementation)

Here is a GIF demonstrating it in action:

![botkit-update](https://cloud.githubusercontent.com/assets/1918632/17167930/ec9e50fe-53df-11e6-82d0-dd5d7d987b67.gif)

I figured that there was so much boilerplate code necessary when updating previously sent messages that it warranted a helper function, and this is what I've come up with.

It takes a `source` message, a `response` message (string or object) (the "_updateable_" - that is, a message which may or may not be updated) and an asynchronous "_updater_" callback which determines how and when to update the "_updateable_" `response` message. Internally, `replyAndUpdate` ensures that a response message with a valid `ts` timestamp is returned to the callback by fooling `bot.reply` into using the Slack Web API instead of RTM messaging - it does this by ensuring that there is always an `attachments` field on the `response` message.

The "_updater_" callback receives two arguments - an `error` (passed from `bot.reply` when sending the initial response message) and an `updateResponse` function. The `updateResponse` function accepts an "_update_" message (string or object) (which internally will receive the `ts` and `channel` properties of the `response` message) and an optional callback which receives an error from `bot.api.chat.update`.

Here are two examples of how it could be used (though contrived - you would never typically do the following in a real chatbot app - they serve as the simplest examples to get the point across without too much cognitive overhead):

```js
// fixing a typo
controller.hears('hello', ['ambient'], (bot, msg) => {
  // send a message back: "hellp"
  return bot.replyAndUpdate(msg, 'hellp', (error, updateResponse) => {
    if (error) return console.error(error);
    // oh no, "hellp" is a typo - let's update the message to "hello"
    return updateResponse('hello', (error) => console.error(error));
  });
});

// updating on result of third-party APIs
// (though, you should probably use the `typing` event for this instead of "Ok, let me think...")
controller.hears('tell me a joke', ['ambient'], (bot, msg) => {
  return bot.replyAndUpdate(msg, 'Ok, let me think...', (error, updateResponse) => {
    if (error) return console.error(error);
    return http.get('https://joke.api/random', (error, response) => {
      if (error) return updateResponse('Sorry, but I cannot think of a joke right now.', console.error.bind(console));
      let joke;
      try {
        joke = JSON.parse(response);
      } catch (error) {
        return updateResponse('Sorry, but I cannot think of a joke right now.', console.error.bind(console));
      }
      return updateResponse(joke.text, console.error.bind(console));
    });
  });
});
```