### PR TITLE
remove 'bot' variables that are not defined

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -56,7 +56,7 @@ function Slackbot(configuration) {
         slack_botkit.log('** Configuring app as a Slack App!');
         if (!slack_app_config || !slack_app_config.clientId ||
             !slack_app_config.clientSecret || !slack_app_config.scopes) {
-            throw new Error('Missing oauth config details', bot);
+            throw new Error('Missing oauth config details');
         } else {
             slack_botkit.config.clientId = slack_app_config.clientId;
             slack_botkit.config.clientSecret = slack_app_config.clientSecret;
@@ -66,7 +66,7 @@ function Slackbot(configuration) {
             } else {
                 slack_botkit.config.scopes = slack_app_config.scopes;
             }
-            if (cb) cb(null, bot);
+            if (cb) cb(null);
         }
 
         return slack_botkit;


### PR DESCRIPTION
Removed some variables that weren't defined.  
```
/home/nodejs/nodeapps/smchatbot/node_modules/botkit/lib/SlackBot.js:69
            if (cb) cb(null, bot);
                             ^

ReferenceError: bot is not defined
    at Object.Slackbot.slack_botkit.configureSlackApp (/home/nodejs/nodeapps/smchatbot/node_modules/botkit/lib/SlackBot.js:69:30)
    at Object.<anonymous> (/home/nodejs/nodeapps/smchatbot/node_modules/botkit/examples/slackbutton_bot.js:39:4)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:134:18)
    at node.js:962:3
```

Also, it doesn't appear that there would be any benefit in passing in a callback to that `configureSlackApp()` function, as there's nothing asynchronous about it. Perhaps it should be removed altogether.