### PR TITLE
Expose the src on #replyAndUpdate()

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -591,7 +591,7 @@ module.exports = function(botkit, config) {
             if (err) return cb && cb(err);
 
             // if provided, call the updater callback - it controls how and when to update the "updatable" message
-            return cb && cb(null, function(resp, cb) {
+            return cb && cb(null, src, function(resp, cb) {
                 try {
                     // format the "update" message to target the "updatable" message
                     resp = typeof resp === 'string' ? { text: resp } : resp;

--- a/readme-slack.md
+++ b/readme-slack.md
@@ -478,7 +478,7 @@ Sending a message, performing a task and then updating the sent message based on
 // fixing a typo
 controller.hears('hello', ['ambient'], function(bot, msg) {
   // send a message back: "hellp"
-  bot.replyAndUpdate(msg, 'hellp', function(err, updateResponse) {
+  bot.replyAndUpdate(msg, 'hellp', function(err, src, updateResponse) {
     if (error) console.error(err);
     // oh no, "hellp" is a typo - let's update the message to "hello"
     updateResponse('hello', function(err) {


### PR DESCRIPTION
The implementation on `#replyAndUpdate` is really nice, but I feel like there is going to be some use in exposing the message object from the initial reply. In my use case I use it to delete the message after 5 seconds if the async callback to update the message fails.