### PR TITLE
don't require callback for synchronous identify functions

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -227,34 +227,39 @@ module.exports = function(botkit, config) {
     };
 
     bot.identifyBot = function(cb) {
+        var data;
         if (bot.identity) {
-            bot.identifyTeam(function(err, team) {
-                cb(null, {
-                    name: bot.identity.name,
-                    id: bot.identity.id,
-                    team_id: team
-                });
-            });
+            data = {
+                name: bot.identity.name,
+                id: bot.identity.id,
+                team_id: bot.identifyTeam()
+            };
+            cb && cb(null, data);
+            return data;
         } else {
             /**
              * Note: Are there scenarios other than the RTM
              * where we might pull identity info, perhaps from
              * bot.api.auth.test on a given token?
              */
-            cb('Identity Unknown: Not using RTM api');
+            cb && cb('Identity Unknown: Not using RTM api');
+            return null;
         };
     };
 
     bot.identifyTeam = function(cb) {
-        if (bot.team_info)
-            return cb(null, bot.team_info.id);
+        if (bot.team_info) {
+            cb && cb(null, bot.team_info.id);
+            return bot.team_info.id;
+        }
 
         /**
          * Note: Are there scenarios other than the RTM
          * where we might pull identity info, perhaps from
          * bot.api.auth.test on a given token?
          */
-        cb('Unknown Team!');
+        cb && cb('Unknown Team!');
+        return null;
     };
 
     /**

--- a/readme-slack.md
+++ b/readme-slack.md
@@ -596,18 +596,13 @@ controller.setupWebserver(process.env.port,function(err,webserver) {
 
 ### How to identify what team your message came from
 ```javascript
-bot.identifyTeam(function(err,team_id) {
-
-})
+var team = bot.identifyTeam() // returns team id
 ```
 
 
 ### How to identify the bot itself (for RTM only)
 ```javascript
-bot.identifyBot(function(err,identity) {
-  // identity contains...
-  // {name, id, team_id}
-})
+var identity = bot.identifyBot() // returns object with {name, id, team_id}
 ```
 
 


### PR DESCRIPTION
Perhaps this is just a personal preference, but I believe that callbacks should only be required for functions that may perform asynchronous operations. For all synchronous functions, requiring a callback to be passed in may mislead devs into thinking that it's asynchronous and requires unnecessary consideration for control flow. Therefore, I made the callbacks optional for `bot.identifyBot()` and `bot.identifyTeam()` because there's absolutely nothing async taking place in those.