### PR TITLE
Going through Slack OAuth flow should update the user's token and sco…

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -484,12 +484,16 @@ function Slackbot(configuration) {
                                                 isnew = true;
                                                 user = {
                                                     id: identity.user_id,
-                                                    access_token: auth.access_token,
-                                                    scopes: scopes,
                                                     team_id: identity.team_id,
                                                     user: identity.user,
                                                 };
                                             }
+
+                                            // Always update these because the token could become invalid
+                                            // and scopes could change.
+                                            user.access_token = auth.access_token;
+                                            user.scopes = scopes;
+
                                             slack_botkit.storage.users.save(user, function(err, id) {
 
                                                 if (err) {


### PR DESCRIPTION
…pes.

This is necessary because the OAuth access token could become invalid or revoked. Also the application's required scopes could change. If these things happen and we need to have the user auth again, the new tokens/scopes should be updated on that user.