### PR TITLE
fix single-character utterances

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -24,8 +24,8 @@ function Botkit(configuration) {
     };
 
     botkit.utterances = {
-        yes: new RegExp(/^(yes|yea|yup|yep|ya|sure|ok|y|yeah|yah)/i),
-        no: new RegExp(/^(no|nah|nope|n)/i),
+        yes: new RegExp(/^(yes|yea|yup|yep|ya|sure|ok|y(?!.)|yeah|yah)/i),
+        no: new RegExp(/^(no|nah|nope|n(?!.))/i)
     };
 
     // define some middleware points where custom functions


### PR DESCRIPTION
This simply will consider "n" as a "no" utterance and "y" as a "yes" utterance _only_ if there are no more characters in the string. This protects against conflicts between capturing-options, for instance, when one option matches a word like `'^next`, and another matches "no"utterances so when the user responds with "next", we don't want it to be considered a "no" utterance erroneously.