### PR TITLE
Update command-line-args to new API version in facebook_bot.js

### DIFF
--- a/facebook_bot.js
+++ b/facebook_bot.js
@@ -81,7 +81,7 @@ var os = require('os');
 var commandLineArgs = require('command-line-args');
 var localtunnel = require('localtunnel');
 
-const cli = commandLineArgs([
+const ops = commandLineArgs([
       {name: 'lt', alias: 'l', args: 1, description: 'Use localtunnel.me to make your bot available on the web.',
       type: Boolean, defaultValue: false},
       {name: 'ltsubdomain', alias: 's', args: 1,
@@ -89,7 +89,6 @@ const cli = commandLineArgs([
       type: String, defaultValue: null},
    ]);
 
-const ops = cli.parse();
 if(ops.lt === false && ops.ltsubdomain !== null) {
     console.log("error: --ltsubdomain can only be used together with --lt.");
     process.exit();

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "async": "^2.0.0-rc.5",
     "back": "^1.0.1",
     "body-parser": "^1.14.2",
-    "command-line-args": "^2.1.6",
+    "command-line-args": "^3.0.0",
     "express": "^4.13.3",
     "https-proxy-agent": "^1.0.0",
     "jfs": "^0.2.6",


### PR DESCRIPTION
According to the [release note](https://github.com/75lb/command-line-args/releases) of command-line-args, there is a breaking change between v2.1.6 and v3.0.0 which will cause runtime error.

