### PR TITLE
Fixed typo on logs, 'interactive message' instead of 'slash command'

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -138,7 +138,7 @@ function Slackbot(configuration) {
 
                 slack_botkit.findTeamById(message.team.id, function(err, team) {
                     if (err || !team) {
-                        slack_botkit.log.error('Received slash command, but could not load team');
+                        slack_botkit.log.error('Received interactive message, but could not load team');
                     } else {
                         res.status(200);
                         res.send('');


### PR DESCRIPTION
Just something minor but bothered me during debugging/exploring.

Cheers,
Deu