### PR TITLE
Add user_info to the bot object

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -131,10 +131,14 @@ module.exports = function(botkit, config) {
 
             bot.identity = res.self;
             bot.team_info = res.team;
+            bot.user_info = {};
+            res.users.forEach(userRecord => {
+                bot.user_info[userRecord.id] = userRecord;
+            });
 
             /**
              * Also available:
-             * res.users, res.channels, res.groups, res.ims,
+             * res.channels, res.groups, res.ims,
              * res.bots
              *
              * Could be stored & cached for later use.


### PR DESCRIPTION
Adds a dictionary from the users key of the auth response, indexed by id, and containing the information about users who are members of the chat room.

See line 75 of [insultbot.js](https://github.com/rmd6502/insultbot/blob/master/insultbot.js) for an example.

<img width="419" alt="screen shot 2016-08-13 at 2 02 30 pm" src="https://cloud.githubusercontent.com/assets/419223/17645578/9b9c249c-615e-11e6-90b8-e9ed451c5763.png">
