### PR TITLE
Maintain title length to 20 character in quick reply

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -228,8 +228,31 @@ function Botkit(configuration) {
 
 
         this.ask = function(message, cb, capture_options) {
+          if (message.quick_replies !== undefined) {
+            var newMessage = {
+              text: message.text,
+              quick_replies: message.quick_replies.map(function(item) {
+                return {
+                  content_type: "text",
+                  title: titleLimit(item.title),
+                  payload: item.payload
+                }
+              })
+            }
+            this.addQuestion(newMessage, cb, capture_options, this.topic || 'default');
+          } else {
             this.addQuestion(message, cb, capture_options, this.topic || 'default');
+          }
         };
+       
+        var titleLimit = function(title) {
+          if (title.length > 20) {
+            var newTitle = title.substring(0, 16) + '...'
+            return newTitle
+          } else {
+            return title
+          }
+        }
 
         this.addMessage = function(message, topic) {
             if (!topic) {

--- a/readme.md
+++ b/readme.md
@@ -862,7 +862,7 @@ var controller = Botkit.slackbot({
 ##Use BotKit with an Express web server
 Instead of controller.setupWebserver(), it is possible to use a different web server to manage authentication flows, as well as serving web pages.
 
-Here is an example of [using an Express web server alongside BotKit](https://github.com/mvaragnat/botkit-express-demo).
+Here is an example of [using an Express web server alongside Botkit](https://github.com/mvaragnat/botkit-express-demo).
 
 # Chat with us at dev4slack.slack.com
 You can get an invite here: http://dev4slack.xoxco.com/.


### PR DESCRIPTION
If the title length of a quick reply element in facebook messenger is more than 20 character then it shows a error. So I have added a function to keep the title in limit.
