### PR TITLE
Fix typo on readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -860,7 +860,7 @@ var controller = Botkit.slackbot({
 
 Note: with Winston, we must use the syslog.levels over the default or else some botkit log messages (like 'notice') will not be logged properly.  
 
-##Use BotKit with an Express web server
+##Use Botkit with an Express web server
 Instead of controller.setupWebserver(), it is possible to use a different web server to manage authentication flows, as well as serving web pages.
 
 Here is an example of [using an Express web server alongside BotKit](https://github.com/mvaragnat/botkit-express-demo).


### PR DESCRIPTION
Just a simple catch: changed "BotKit" to "Botkit"