### PR TITLE
Fix authentication for Slack Interactive Messages.

### DIFF
--- a/lib/middleware/slack_authentication.js
+++ b/lib/middleware/slack_authentication.js
@@ -27,7 +27,8 @@ function init(tokens) {
      * @param {function} next - Express callback
      */
     function authenticate(req, res, next) {
-        if (!req.body || !req.body.token || authenticationTokens.indexOf(req.body.token) === TOKEN_NOT_FOUND) {
+        var token = getToken(req.body);
+        if (!token || authenticationTokens.indexOf(token) === TOKEN_NOT_FOUND) {
             res.status(401).send({
                 'code': 401,
                 'message': 'Unauthorized'
@@ -57,3 +58,16 @@ function flatten(args) {
         return result;
     }
 module.exports = init;
+
+function getToken(body) {
+    if (!body) return null;
+    if (body.token) return body.token;
+    if (!body.payload) return null;
+
+    var payload = body.payload;
+    if (typeof payload === 'string') {
+        payload = JSON.parse(payload);
+    }
+
+    return payload.token;
+}


### PR DESCRIPTION
The incoming request for an Interactive Message has a different structure than Slash Commands. The authentication middleware should be able to handle this different format. Specifically, the request body has a `payload` JSON string, which contains the token.