### PR TITLE
Support `files.upload` API call.

### DIFF
--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -103,13 +103,17 @@ module.exports = function(bot, config) {
      * @param {Object} data The data to pass to the API call
      * @param {function} cb A NodeJS-style callback
      */
-    slack_api.callAPI = function(command, data, cb) {
-        if (!data.token) {
+    slack_api.callAPI = function(command, data, multiPartData, cb) {
+        if (data && !data.token) {
             data.token = config.token;
         }
 
-        bot.debug(command, data);
-        postForm(slack_api.api_url + command, data, cb);
+        if (multiPartData && !multiPartData.token) {
+            multiPartData.token = config.token;
+        }
+
+        bot.debug(command, data, multiPartData);
+        postForm(slack_api.api_url + command, data, multiPartData, cb);
     };
 
     /**
@@ -131,7 +135,7 @@ module.exports = function(bot, config) {
         }
 
         // DON'T log options: that could expose the client secret!
-        postForm(slack_api.api_url + command, data, cb);
+        postForm(slack_api.api_url + command, data, null, cb);
     };
 
 
@@ -154,7 +158,7 @@ module.exports = function(bot, config) {
         });
 
         currentGroup[method] = function(options, cb) {
-            slack_api.callAPI(slackMethod, options, cb);
+            slack_api.callAPI(slackMethod, options, null, cb);
         };
 
     });
@@ -169,7 +173,11 @@ module.exports = function(bot, config) {
                 bot.log.error('Could not parse attachments', err);
             }
         }
-        slack_api.callAPI('chat.postMessage', options, cb);
+        slack_api.callAPI('chat.postMessage', options, null, cb);
+    };
+
+    slack_api.files.upload = function(options, cb) {
+      slack_api.callAPI('files.upload', null, options, cb);
     };
 
     return slack_api;
@@ -182,11 +190,18 @@ module.exports = function(bot, config) {
      * @param {Object} formData The data to POST as a form
      * @param {function=} cb An optional NodeJS style callback when the POST completes or errors out.
      */
-    function postForm(url, formData, cb) {
+    function postForm(url, formData, multiPartData, cb) {
         cb = cb || noop;
 
         bot.log('** API CALL: ' + url);
-        request.post(url, function(error, response, body) {
+
+        var params = {
+            url: url,
+            form: formData,
+            formData: multiPartData
+        };
+
+        request.post(params, function(error, response, body) {
             bot.debug('Got response', error, body);
             if (!error && response.statusCode == 200) {
                 var json;
@@ -202,6 +217,6 @@ module.exports = function(bot, config) {
                 return cb(json.error, json);
             }
             return cb(error || new Error('Invalid response'));
-        }).form(formData);
+        });
     }
 };


### PR DESCRIPTION
Fixes this old, closed issue: https://github.com/howdyai/botkit/issues/29
And is a follow up to this old PR: https://github.com/howdyai/botkit/pull/112

Added some robustness around posting to the Slack API by also accepting mutlipart form data, which is what the `files.upload` method requires. The reason why I didn't modify `callAPIWithoutToken`'s API  is because `files.upload` requires a user token.
