### PR TITLE
Facebook sender_action support ("is typing" indicator)

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -117,7 +117,7 @@ function Facebookbot(configuration) {
 
             var typingLength = Math.min(Math.floor(text.length / (avgCPM / 60)) * 1000, 5000)
 
-            console.log('typing takes', typingLength, 'ms')
+            botkit.debug('typing takes', typingLength, 'ms')
             bot.startTyping(src, function (err) {
               if (err) console.log(err)
               setTimeout(function() {

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -22,11 +22,13 @@ function Facebookbot(configuration) {
             botkit.startConversation(this, message, cb);
         };
 
+
+
         bot.send = function(message, cb) {
 
             var facebook_message = {
                 recipient: {},
-                message: {}
+                message: message.sender_action ? undefined : {}
             };
 
             if (typeof(message.channel) == 'string' && message.channel.match(/\+\d+\(\d\d\d\)\d\d\d\-\d\d\d\d/)) {
@@ -35,20 +37,25 @@ function Facebookbot(configuration) {
                 facebook_message.recipient.id = message.channel;
             }
 
-            if (message.text) {
-                facebook_message.message.text = message.text;
-            }
+            if (!message.sender_action) {
+              if (message.text) {
+                  facebook_message.message.text = message.text;
+              }
 
-            if (message.attachment) {
-                facebook_message.message.attachment = message.attachment;
-            }
+              if (message.attachment) {
+                  facebook_message.message.attachment = message.attachment;
+              }
 
-            if (message.sticker_id) {
-                facebook_message.message.sticker_id = message.sticker_id;
-            }
+              if (message.sticker_id) {
+                  facebook_message.message.sticker_id = message.sticker_id;
+              }
 
-            if (message.quick_replies) {
-                facebook_message.message.quick_replies = message.quick_replies;
+              if (message.quick_replies) {
+                  facebook_message.message.quick_replies = message.quick_replies;
+              }
+            }
+            else {
+                facebook_message.sender_action = message.sender_action;
             }
 
             //Add Access Token to outgoing request
@@ -81,6 +88,45 @@ function Facebookbot(configuration) {
                     cb && cb(null, body);
                 })
         };
+
+        bot.startTyping = function (src, cb) {
+          var msg = {};
+          msg.channel = src.channel;
+          msg.sender_action = 'typing_on';
+          bot.say(msg, cb);
+        };
+
+        bot.stopTyping = function (src, cb) {
+          var msg = {};
+          msg.channel = src.channel;
+          msg.sender_action = 'typing_off';
+          bot.say(msg, cb);
+        };
+
+        bot.replyWithTyping = function(src, resp, cb) {
+            var text;
+
+            if (typeof(resp) == 'string') {
+                text = resp;
+            } else {
+                text = resp.text;
+            }
+
+            var avgWPM = 85
+            var avgCPM = avgWPM * 7
+
+            var typingLength = Math.min(Math.floor(text.length / (avgCPM / 60)) * 1000, 5000)
+
+            console.log('typing takes', typingLength, 'ms')
+            bot.startTyping(src, function (err) {
+              if (err) console.log(err)
+              setTimeout(function() {
+                  bot.reply(src, resp, cb);
+              }, typingLength);
+            });
+
+        };
+
 
         bot.reply = function(src, resp, cb) {
             var msg = {};

--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -15,6 +15,7 @@ Table of Contents
 * [Facebook-specific Events](#facebook-specific-events)
 * [Working with Facebook Webhooks](#working-with-facebook-messenger)
 * [Using Structured Messages and Postbacks](#using-structured-messages-and-postbacks)
+* [Simulate typing](#simulate-typing)
 * [Running Botkit with an Express server](#use-botkit-for-facebook-messenger-with-an-express-web-server)
 
 ## Getting Started
@@ -194,8 +195,22 @@ controller.on('facebook_postback', function(bot, message) {
 });
 ```
 
+## Simulate typing
+To make it a bit more realistic, you can trigger a "user is typing" signal (shown in Messenger as a bubble with 3 animated dots) by using the following convenience methods.
+
+```javascript
+bot.startTyping(message, function () {
+  // do something here, the "is typing" animation is visible
+});
+
+bot.stopTyping(message, function () {
+  // do something here, the "is typing" animation is not visible
+});
+
+bot.replyWithTyping(message, 'Hello there, my friend!');
+```
+
 ## Use BotKit for Facebook Messenger with an Express web server
 Instead of the web server generated with setupWebserver(), it is possible to use a different web server to receive webhooks, as well as serving web pages.
 
 Here is an example of [using an Express web server alongside BotKit for Facebook Messenger](https://github.com/mvaragnat/botkit-messenger-express-demo).
-


### PR DESCRIPTION
Implements `sender_action` parameter from the API as in: https://developers.facebook.com/docs/messenger-platform/send-api-reference#payload

Also adds convenience method `replyWithTyping`, following same convention than in Slackbot.

```javascript
 +bot.startTyping(message, function () {
 +  // do something here, the "is typing" animation is visible
 +});
 +
 +bot.stopTyping(message, function () {
 +  // do something here, the "is typing" animation is not visible
 +});
 +
 +bot.replyWithTyping(message, 'Hello there, my friend!');
 +```