### PR TITLE
Add Facebook read receipt event

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -193,6 +193,17 @@ function Facebookbot(configuration) {
 
                             facebook_botkit.trigger('message_delivered', [bot, message]);
 
+                        } else if (facebook_message.read) {
+
+                            var message = {
+                                optin: facebook_message.read,
+                                user: facebook_message.sender.id,
+                                channel: facebook_message.sender.id,
+                                timestamp: facebook_message.timestamp,
+                            };
+
+                            facebook_botkit.trigger('message_read', [bot, message]);
+
                         } else {
                             facebook_botkit.log('Got an unexpected message from Facebook: ', facebook_message);
                         }


### PR DESCRIPTION
Add support for read receipt events which were introduced in platform version 1.1. They work exactly like delivery receipts. 