### PR TITLE
Optionall allow non-numeric ports

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -274,7 +274,8 @@ function Slackbot(configuration) {
         if (!port) {
             throw new Error('Cannot start webserver without a port');
         }
-        if (isNaN(port)) {
+        var allowNonNumericPort = slack_botkit.config && slack_botkit.config.webserver && slack_botkit.config.webserver.allowNonNumericPort; 
+        if (isNaN(port) && !allowNonNumericPort) {
             throw new Error('Specified port is not a valid number');
         }
 


### PR DESCRIPTION
Added optional support for non-numeric ports for webserver so you can
run your slackbot on an Azure webapp (which uses a `\.\pipe\...` port
format)

Fixes #150