### PR TITLE
Also keep app access_token

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -457,6 +457,7 @@ function Slackbot(configuration) {
                                         token: auth.bot.bot_access_token,
                                         user_id: auth.bot.bot_user_id,
                                         createdBy: identity.user_id,
+                                        app_token: auth.access_token,
                                     };
                                     bot.configureRTM(team.bot);
                                     slack_botkit.trigger('create_bot', [bot, team.bot]);


### PR DESCRIPTION
Not only save bot token but also app access token as some calls need it and it can have different permissions
