### PR TITLE
Ensure no reconnect happens after destroy()

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -17,6 +17,9 @@ module.exports = function(botkit, config) {
         }
     };
 
+    // Set when destroy() is called - prevents a reconnect from completing
+    // if it was fired off prior to destroy being called
+    var destroyed = false;
     var pingIntervalId = null;
     var lastPong = 0;
     var retryBackoff = null;
@@ -97,7 +100,7 @@ module.exports = function(botkit, config) {
             botkit.log.notice('** BOT ID:', bot.identity.name, '...reconnect attempt #' +
                 back.settings.attempt + ' of ' + options.retries + ' being made after ' + back.settings.timeout + 'ms');
             bot.startRTM(function(err) {
-                if (err) {
+                if (err && !destroyed) {
                     return reconnect(err);
                 }
                 retryBackoff = null;
@@ -109,6 +112,9 @@ module.exports = function(botkit, config) {
      * Shutdown and cleanup the spawned worker
      */
     bot.destroy = function() {
+        // this prevents a startRTM from completing if it was fired off
+        // prior to destroy being called
+        destroyed = true;
         if (retryBackoff) {
             retryBackoff.close();
             retryBackoff = null;
@@ -132,6 +138,12 @@ module.exports = function(botkit, config) {
 
             bot.identity = res.self;
             bot.team_info = res.team;
+
+            // Bail out if destroy() was called
+            if (destroyed) {
+                botkit.log.notice('Ignoring rtm.start response, bot was destroyed');
+                return cb('Ignoring rtm.start response, bot was destroyed');
+            }
 
             /**
              * Also available:


### PR DESCRIPTION
The purpose of this PR is to ensure if someone calls `destroy()` on their worker instance, it won't reconnect.  Calling `destroy()` already cancels any pending reconnect attempts, but there's a small chance that the `start.rtm` api call was already issue, but hasn't received a response yet.  In this case what happens is the worker closes out the current RTM connection and cancels any queued up reconnect attempts.  It doesn't currently handle a case where the callback from the `rtm.started` api call comes back after `destroy()` was called.

I added a flag to track the state of if the worker has been _destroyed_ - and then make sure to check that prior to creating the websocket connection for the RTM.  This prevents the case described above.

We've run with this particular patch on a bot with about 60 teams connected and it's resolved issues they've had related to this bug (they would end up with 2 RTM connections to a team when trying to manually destroy a worker instance, and create a new one).