### PR TITLE
Remove integer port requirement for Facebook

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -285,9 +285,6 @@ function Facebookbot(configuration) {
         if (!port) {
             throw new Error('Cannot start webserver without a port');
         }
-        if (isNaN(port)) {
-            throw new Error('Specified port is not a valid number');
-        }
 
         var static_dir =  __dirname + '/public';
 


### PR DESCRIPTION
PaaS hosting offerings like Heroku and Azure App Service do not have a standard numerical port, as it's randomly generated when the app is re-started. 

The code currently has a check that ensures the port specified is a number. This will always fail and throw an exception on Heroku and Azure App Service, causing the app the crash. 

Example port from Azure App Service: "\\.\pipe\a59322f5-0005-4a3b-9242-24625191a3f2"

My fix removes the number check as ExpressJS, which is how the bots are served, has no requirement that ports are a number. 

Closes howdyai/botkit#369