### PR TITLE
Don't use JSON.parse/stringify to clone.

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -8,6 +8,7 @@ var simple_storage = require(__dirname + '/storage/simple_storage.js');
 var ConsoleLogger = require(__dirname + '/console_logger.js');
 var LogLevels = ConsoleLogger.LogLevels;
 var ware = require('ware');
+var clone = require('clone');
 
 var studio = require('./Studio.js');
 
@@ -457,7 +458,7 @@ function Botkit(configuration) {
 
         this.cloneMessage = function(message) {
             // clone this object so as not to modify source
-            var outbound = JSON.parse(JSON.stringify(message));
+            var outbound = clone(message);
 
             if (typeof(message.text) == 'string') {
                 outbound.text = this.replaceTokens(message.text);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "back": "^1.0.1",
     "body-parser": "^1.14.2",
     "botbuilder": "^3.2.3",
+    "clone": "2.0.0",
     "command-line-args": "^3.0.0",
     "express": "^4.13.3",
     "https-proxy-agent": "^1.0.0",


### PR DESCRIPTION
Fixes #439.

Uses the `clone` npm package to provide a deep clone. This _probably_ has performance implications since `JSON.parse(JSON.stringify(thing))` is super fast, but I don't think the original implementation meant to throw away `Date` and `Symbol` objects.
