### PR TITLE
Slack's `chat.update` should work with attachments

### DIFF
--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -161,16 +161,26 @@ module.exports = function(bot, config) {
 
     // overwrite default behavior
     slack_api.chat.postMessage = function(options, cb) {
-        if (options.attachments && typeof(options.attachments) != 'string') {
-            try {
-                options.attachments = JSON.stringify(options.attachments);
-            } catch (err) {
-                delete options.attachments;
-                bot.log.error('Could not parse attachments', err);
-            }
-        }
+        sanitizeOptions(options);
         slack_api.callAPI('chat.postMessage', options, cb);
     };
+
+    slack_api.chat.update = function(options, cb) {
+        sanitizeOptions(options);
+        slack_api.callAPI('chat.update', options, cb);
+    };
+
+    function sanitizeOptions(options) {
+      if (options.attachments && typeof(options.attachments) != 'string') {
+          try {
+              options.attachments = JSON.stringify(options.attachments);
+          } catch (err) {
+              delete options.attachments;
+              bot.log.error('Could not parse attachments', err);
+          }
+      }
+    }
+
 
     return slack_api;
 


### PR DESCRIPTION
When attachments are sent to these API methods, they need to be handled in the same way. `postMessage` was already doing it, so had `update` do the same.
