### PR TITLE
Fix `bot.replyPrivateDelayed`. https://github.com/howdyai/botkit/issu…

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -494,6 +494,43 @@ module.exports = function(botkit, config) {
             msg.channel = src.channel;
 
             msg.response_type = 'ephemeral';
+            msg.replace_original = false;
+
+            var requestOptions = {
+                uri: src.response_url,
+                method: 'POST',
+                json: msg
+            };
+            request(requestOptions, function(err, resp, body) {
+                /**
+                 * Do something?
+                 */
+                if (err) {
+                    botkit.log.error('Error sending slash command response:', err);
+                    cb && cb(err);
+                } else {
+                    cb && cb();
+                }
+            });
+        }
+    };
+
+    bot.replyDelayedPrivate = function(src, resp, replace_original, cb) {
+        if (!src.response_url) {
+            cb && cb('No response_url found');
+        } else {
+            var msg = {};
+
+            if (typeof(resp) == 'string') {
+                msg.text = resp;
+            } else {
+                msg = resp;
+            }
+
+            msg.channel = src.channel;
+
+            msg.response_type = 'ephemeral';
+            msg.replace_original = replace_original;
 
             var requestOptions = {
                 uri: src.response_url,


### PR DESCRIPTION
…es/444

I discovered this when trying to ephemerally respond to an interactive button click. We need to set `replace_original` to `false` in order for our reply to be ephemeral. Otherwise, it will reply publicly. Furrther, when responding to an ephemeral message's button click, currently we cannot update it. Thus, introduce new method to provide the option to update or not. The existing one could be depcrecated.
