### PR TITLE
Uppercase env vars

### DIFF
--- a/botframework_bot.js
+++ b/botframework_bot.js
@@ -23,7 +23,7 @@ This bot demonstrates many of the core features of Botkit:
 
   Run your bot from the command line:
 
-    app_id=<MY APP ID> app_password=<MY APP PASSWORD> node botframework_bot.js [--lt [--ltsubdomain LOCALTUNNEL_SUBDOMAIN]]
+    APP_ID=<MY APP ID> APP_PASSWORD=<MY APP PASSWORD> node botframework_bot.js [--lt [--ltsubdomain LOCALTUNNEL_SUBDOMAIN]]
 
   Use the --lt option to make your bot available on the web through localtunnel.me.
 
@@ -87,15 +87,15 @@ var controller = Botkit.botframeworkbot({
 });
 
 var bot = controller.spawn({
-    appId: process.env.app_id,
-    appPassword: process.env.app_password
+    appId: process.env.APP_ID,
+    appPassword: process.env.APP_PASSWORD
 });
 
-controller.setupWebserver(process.env.port || 3000, function(err, webserver) {
+controller.setupWebserver(process.env.PORT || 3000, function(err, webserver) {
     controller.createWebhookEndpoints(webserver, bot, function() {
         console.log('ONLINE!');
         if(ops.lt) {
-            var tunnel = localtunnel(process.env.port || 3000, {subdomain: ops.ltsubdomain}, function(err, tunnel) {
+            var tunnel = localtunnel(process.env.PORT || 3000, {subdomain: ops.ltsubdomain}, function(err, tunnel) {
                 if (err) {
                     console.log(err);
                     process.exit();

--- a/examples/convo_bot.js
+++ b/examples/convo_bot.js
@@ -18,7 +18,7 @@ This bot demonstrates a multi-stage conversation
 
   Run your bot from the command line:
 
-    token=<MY TOKEN> node demo_bot.js
+    TOKEN=<MY TOKEN> node demo_bot.js
 
 # USE THE BOT:
 
@@ -54,8 +54,8 @@ This bot demonstrates a multi-stage conversation
 
 var Botkit = require('../lib/Botkit.js');
 
-if (!process.env.token) {
-  console.log('Error: Specify token in environment');
+if (!process.env.TOKEN) {
+  console.log('Error: Specify TOKEN in environment');
   process.exit(1);
 }
 
@@ -64,7 +64,7 @@ var controller = Botkit.slackbot({
 });
 
 controller.spawn({
-  token: process.env.token
+  token: process.env.TOKEN
 }).startRTM(function(err) {
   if (err) {
     throw new Error(err);

--- a/examples/demo_bot.js
+++ b/examples/demo_bot.js
@@ -23,7 +23,7 @@ This bot demonstrates many of the core features of Botkit:
 
   Run your bot from the command line:
 
-    token=<MY TOKEN> node demo_bot.js
+    TOKEN=<MY TOKEN> node demo_bot.js
 
 # USE THE BOT:
 
@@ -56,8 +56,8 @@ This bot demonstrates many of the core features of Botkit:
 var Botkit = require('../lib/Botkit.js');
 
 
-if (!process.env.token) {
-  console.log('Error: Specify token in environment');
+if (!process.env.TOKEN) {
+  console.log('Error: Specify TOKEN in environment');
   process.exit(1);
 }
 
@@ -66,7 +66,7 @@ var controller = Botkit.slackbot({
 });
 
 controller.spawn({
-  token: process.env.token
+  token: process.env.TOKEN
 }).startRTM(function(err) {
   if (err) {
     throw new Error(err);

--- a/examples/middleware_example.js
+++ b/examples/middleware_example.js
@@ -25,7 +25,7 @@ This bot demonstrates many of the core features of Botkit:
 
   Run your bot from the command line:
 
-    token=<MY TOKEN> node bot.js
+    TOKEN=<MY TOKEN> node bot.js
 
 # USE THE BOT:
 
@@ -64,8 +64,8 @@ This bot demonstrates many of the core features of Botkit:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
 
-if (!process.env.token) {
-    console.log('Error: Specify token in environment');
+if (!process.env.TOKEN) {
+    console.log('Error: Specify TOKEN in environment');
     process.exit(1);
 }
 
@@ -77,7 +77,7 @@ var controller = Botkit.slackbot({
 });
 
 var bot = controller.spawn({
-    token: process.env.token
+    token: process.env.TOKEN
 }).startRTM();
 
 

--- a/examples/sentiment_analysis.js
+++ b/examples/sentiment_analysis.js
@@ -55,7 +55,7 @@ function startBot(db) {
     });
 
     botkitController.spawn({
-        token: process.env.token
+        token: process.env.TOKEN
     }).startRTM(function (err) {
         if (err) {
             throw err;
@@ -145,8 +145,8 @@ function startBot(db) {
     });
 }
 
-if (!process.env.token) {
-    console.log('Error: Specify token in environment');
+if (!process.env.TOKEN) {
+    console.log('Error: Specify TOKEN in environment');
     process.exit(1);
 }
 

--- a/examples/slackbutton_bot.js
+++ b/examples/slackbutton_bot.js
@@ -27,8 +27,8 @@ This is a sample Slack Button application that adds a bot to one or many slack t
 /* Uses the slack button feature to offer a real time bot to multiple teams */
 var Botkit = require('../lib/Botkit.js');
 
-if (!process.env.clientId || !process.env.clientSecret || !process.env.port) {
-  console.log('Error: Specify clientId clientSecret and port in environment');
+if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET || !process.env.PORT) {
+  console.log('Error: Specify CLIENT_ID CLIENT_SECRET and PORT in environment');
   process.exit(1);
 }
 
@@ -37,13 +37,13 @@ var controller = Botkit.slackbot({
   json_file_store: './db_slackbutton_bot/',
 }).configureSlackApp(
   {
-    clientId: process.env.clientId,
-    clientSecret: process.env.clientSecret,
+    clientId: process.env.CLIENT_ID,
+    clientSecret: process.env.CLIENT_SECRET,
     scopes: ['bot'],
   }
 );
 
-controller.setupWebserver(process.env.port,function(err,webserver) {
+controller.setupWebserver(process.env.PORT,function(err,webserver) {
   controller.createWebhookEndpoints(controller.webserver);
 
   controller.createOauthEndpoints(controller.webserver,function(err,req,res) {

--- a/examples/slackbutton_bot_interactivemsg.js
+++ b/examples/slackbutton_bot_interactivemsg.js
@@ -27,8 +27,8 @@ This is a sample Slack Button application that adds a bot to one or many slack t
 /* Uses the slack button feature to offer a real time bot to multiple teams */
 var Botkit = require('../lib/Botkit.js');
 
-if (!process.env.clientId || !process.env.clientSecret || !process.env.port) {
-  console.log('Error: Specify clientId clientSecret and port in environment');
+if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET || !process.env.PORT) {
+  console.log('Error: Specify CLIENT_ID CLIENT_SECRET and PORT in environment');
   process.exit(1);
 }
 
@@ -38,13 +38,13 @@ var controller = Botkit.slackbot({
   json_file_store: './db_slackbutton_bot/',
 }).configureSlackApp(
   {
-    clientId: process.env.clientId,
-    clientSecret: process.env.clientSecret,
+    clientId: process.env.CLIENT_ID,
+    clientSecret: process.env.CLIENT_SECRET,
     scopes: ['bot'],
   }
 );
 
-controller.setupWebserver(process.env.port,function(err,webserver) {
+controller.setupWebserver(process.env.PORT,function(err,webserver) {
   controller.createWebhookEndpoints(controller.webserver);
 
   controller.createOauthEndpoints(controller.webserver,function(err,req,res) {

--- a/examples/slackbutton_incomingwebhooks.js
+++ b/examples/slackbutton_incomingwebhooks.js
@@ -23,7 +23,7 @@ This bot demonstrates many of the core features of Botkit:
 
   Run your bot from the command line:
 
-    clientId=<my client id> clientSecret=<my client secret> port=3000 node bot.js
+    CLIENT_ID=<my client id> CLIENT_SECRET=<my client secret> PORT=3000 node bot.js
 
 # USE THE APP
 
@@ -51,8 +51,8 @@ This bot demonstrates many of the core features of Botkit:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 var Botkit = require('../lib/Botkit.js');
 
-if (!process.env.clientId || !process.env.clientSecret || !process.env.port) {
-  console.log('Error: Specify clientId clientSecret and port in environment');
+if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET || !process.env.PORT) {
+  console.log('Error: Specify CLIENT_ID CLIENT_SECRET and PORT in environment');
   process.exit(1);
 }
 
@@ -60,14 +60,14 @@ var controller = Botkit.slackbot({
   json_file_store: './db_slackbutton_incomingwebhook/',
 }).configureSlackApp(
   {
-    clientId: process.env.clientId,
-    clientSecret: process.env.clientSecret,
+    clientId: process.env.CLIENT_ID,
+    clientSecret: process.env.CLIENT_SECRET,
     scopes: ['incoming-webhook'],
   }
 );
 
 
-controller.setupWebserver(process.env.port,function(err,webserver) {
+controller.setupWebserver(process.env.PORT,function(err,webserver) {
 
 
   webserver.get('/',function(req,res) {

--- a/examples/slackbutton_slashcommand.js
+++ b/examples/slackbutton_slashcommand.js
@@ -24,7 +24,7 @@ This bot demonstrates many of the core features of Botkit:
 
   Run your bot from the command line:
 
-    clientId=<my client id> clientSecret=<my client secret> port=3000 node bot.js
+    CLIENT_ID=<my client id> CLIENT_SECRET=<my client secret> PORT=3000 node bot.js
 
     Note: you can test your oauth authentication locally, but to use Slash commands
     in Slack, the app must be hosted at a publicly reachable IP or host.
@@ -41,21 +41,21 @@ This bot demonstrates many of the core features of Botkit:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 var Botkit = require('../lib/Botkit.js');
 
-if (!process.env.clientId || !process.env.clientSecret || !process.env.port) {
-  console.log('Error: Specify clientId clientSecret and port in environment');
+if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET || !process.env.PORT) {
+  console.log('Error: Specify CLIENT_ID CLIENT_SECRET and PORT in environment');
   process.exit(1);
 }
 
 var controller = Botkit.slackbot({
   json_file_store: './db_slackbutton_slashcommand/',
 }).configureSlackApp({
-    clientId: process.env.clientId,
-    clientSecret: process.env.clientSecret,
+    clientId: process.env.CLIENT_ID,
+    clientSecret: process.env.CLIENT_SECRET,
     scopes: ['commands'],
   });
 
 
-controller.setupWebserver(process.env.port,function(err,webserver) {
+controller.setupWebserver(process.env.PORT,function(err,webserver) {
 
   controller.createWebhookEndpoints(controller.webserver);
 

--- a/facebook_bot.js
+++ b/facebook_bot.js
@@ -25,7 +25,7 @@ This bot demonstrates many of the core features of Botkit:
 
   Run your bot from the command line:
 
-    page_token=<MY PAGE TOKEN> verify_token=<MY_VERIFY_TOKEN> node facebook_bot.js [--lt [--ltsubdomain LOCALTUNNEL_SUBDOMAIN]]
+    PAGE_TOKEN=<MY PAGE TOKEN> VERIFY_TOKEN=<MY_VERIFY_TOKEN> node facebook_bot.js [--lt [--ltsubdomain LOCALTUNNEL_SUBDOMAIN]]
 
   Use the --lt option to make your bot available on the web through localtunnel.me.
 
@@ -66,13 +66,13 @@ This bot demonstrates many of the core features of Botkit:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
 
-if (!process.env.page_token) {
-    console.log('Error: Specify page_token in environment');
+if (!process.env.PAGE_TOKEN) {
+    console.log('Error: Specify PAGE_TOKEN in environment');
     process.exit(1);
 }
 
-if (!process.env.verify_token) {
-    console.log('Error: Specify verify_token in environment');
+if (!process.env.VERIFY_TOKEN) {
+    console.log('Error: Specify VERIFY_TOKEN in environment');
     process.exit(1);
 }
 
@@ -96,18 +96,18 @@ if(ops.lt === false && ops.ltsubdomain !== null) {
 
 var controller = Botkit.facebookbot({
     debug: true,
-    access_token: process.env.page_token,
-    verify_token: process.env.verify_token,
+    access_token: process.env.PAGE_TOKEN,
+    verify_token: process.env.VERIFY_TOKEN,
 });
 
 var bot = controller.spawn({
 });
 
-controller.setupWebserver(process.env.port || 3000, function(err, webserver) {
+controller.setupWebserver(process.env.PORT || 3000, function(err, webserver) {
     controller.createWebhookEndpoints(webserver, bot, function() {
         console.log('ONLINE!');
         if(ops.lt) {
-            var tunnel = localtunnel(process.env.port || 3000, {subdomain: ops.ltsubdomain}, function(err, tunnel) {
+            var tunnel = localtunnel(process.env.PORT || 3000, {subdomain: ops.ltsubdomain}, function(err, tunnel) {
                 if (err) {
                     console.log(err);
                     process.exit();

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -156,7 +156,7 @@ module.exports = function(botkit, config) {
             botkit.log.notice('** BOT ID:', bot.identity.name, '...attempting to connect to RTM!');
 
             var agent = null;
-            var proxyUrl = process.env.https_proxy || process.env.http_proxy;
+            var proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
             if (proxyUrl) {
                 agent = new HttpsProxyAgent(proxyUrl);
             }

--- a/readme-botframework.md
+++ b/readme-botframework.md
@@ -34,7 +34,7 @@ Table of Contents
 4) Run the example bot using the App ID & Password you were assigned. If you are _not_ running your bot at a public, SSL-enabled internet address, use the --lt option and update your bots endpoint in the developer portal to use the URL assigned to your bot.
 
 ```
-app_id=<MY_APP_ID> app_password=<MY_APP_PASSWORD> node botframework_bot.js [--lt [--ltsubdomain CUSTOM_SUBDOMAIN]]
+APP_ID=<MY_APP_ID> APP_PASSWORD=<MY_APP_PASSWORD> node botframework_bot.js [--lt [--ltsubdomain CUSTOM_SUBDOMAIN]]
 ```    
 
 5) Your bot should be online! Within Skype, find the bot in your contacts list, and send it a message.
@@ -81,13 +81,13 @@ var controller = Botkit.botframeworkbot({
 });
 
 var bot = controller.spawn({
-        appId: process.env.app_id,
-        appPassword: process.env.app_password
+        appId: process.env.APP_ID,
+        appPassword: process.env.APP_PASSWORD
 });
 
 // if you are already using Express, you can use your own server instance...
 // see "Use BotKit with an Express web server"
-controller.setupWebserver(process.env.port,function(err,webserver) {
+controller.setupWebserver(process.env.PORT,function(err,webserver) {
   controller.createWebhookEndpoints(controller.webserver, bot, function() {
       console.log('This bot is online!!!');
   });

--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -85,8 +85,8 @@ Here is the complete code for a basic Facebook bot:
 ```javascript
 var Botkit = require('botkit');
 var controller = Botkit.facebookbot({
-        access_token: process.env.access_token,
-        verify_token: process.env.verify_token,
+        access_token: process.env.ACCESS_TOKEN,
+        verify_token: process.env.VERIFY_TOKEN,
 })
 
 var bot = controller.spawn({
@@ -94,7 +94,7 @@ var bot = controller.spawn({
 
 // if you are already using Express, you can use your own server instance...
 // see "Use BotKit with an Express web server"
-controller.setupWebserver(process.env.port,function(err,webserver) {
+controller.setupWebserver(process.env.PORT,function(err,webserver) {
   controller.createWebhookEndpoints(controller.webserver, bot, function() {
       console.log('This bot is online!!!');
   });

--- a/readme-slack.md
+++ b/readme-slack.md
@@ -270,7 +270,7 @@ bot.sendWebhook({
 // receive outgoing or slash commands
 // if you are already using Express, you can use your own server instance...
 // see "Use BotKit with an Express web server"
-controller.setupWebserver(process.env.port,function(err,webserver) {
+controller.setupWebserver(process.env.PORT,function(err,webserver) {
 
   controller.createWebhookEndpoints(controller.webserver);
 
@@ -588,13 +588,13 @@ var Botkit = require('botkit');
 var controller = Botkit.slackbot();
 
 controller.configureSlackApp({
-  clientId: process.env.clientId,
-  clientSecret: process.env.clientSecret,
+  clientId: process.env.CLIENT_ID,
+  clientSecret: process.env.CLIENT_SECRET,
   redirectUri: 'http://localhost:3002',
   scopes: ['incoming-webhook','team:read','users:read','channels:read','im:read','im:write','groups:read','emoji:read','chat:write:bot']
 });
 
-controller.setupWebserver(process.env.port,function(err,webserver) {
+controller.setupWebserver(process.env.PORT,function(err,webserver) {
 
   // set up web endpoints for oauth, receiving webhooks, etc.
   controller
@@ -648,7 +648,7 @@ During development, a tool such as [localtunnel.me](http://localtunnel.me) is us
 
 ```
 // set up a botkit app to expose oauth and webhook endpoints
-controller.setupWebserver(process.env.port,function(err,webserver) {
+controller.setupWebserver(process.env.PORT,function(err,webserver) {
 
   // set up web endpoints for oauth, receiving webhooks, etc.
   controller

--- a/readme-twilioipm.md
+++ b/readme-twilioipm.md
@@ -156,7 +156,7 @@ var bot = controller.spawn({
 
 // if you are already using Express, you can use your own server instance...
 // see "Use BotKit with an Express web server"
-controller.setupWebserver(process.env.port,function(err,webserver) {
+controller.setupWebserver(process.env.PORT,function(err,webserver) {
   controller.createWebhookEndpoints(controller.webserver, bot, function() {
       console.log('This bot is online!!!');
   });

--- a/slack_bot.js
+++ b/slack_bot.js
@@ -25,7 +25,7 @@ This bot demonstrates many of the core features of Botkit:
 
   Run your bot from the command line:
 
-    token=<MY TOKEN> node slack_bot.js
+    TOKEN=<MY TOKEN> node slack_bot.js
 
 # USE THE BOT:
 
@@ -64,8 +64,8 @@ This bot demonstrates many of the core features of Botkit:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
 
-if (!process.env.token) {
-    console.log('Error: Specify token in environment');
+if (!process.env.TOKEN) {
+    console.log('Error: Specify TOKEN in environment');
     process.exit(1);
 }
 
@@ -77,7 +77,7 @@ var controller = Botkit.slackbot({
 });
 
 var bot = controller.spawn({
-    token: process.env.token
+    token: process.env.TOKEN
 }).startRTM();
 
 

--- a/twilio_ipm_bot.js
+++ b/twilio_ipm_bot.js
@@ -13,7 +13,7 @@ var bot = controller.spawn({
     autojoin: true
 });
 
-controller.setupWebserver(process.env.port || 3000, function(err, server) {
+controller.setupWebserver(process.env.PORT || 3000, function(err, server) {
 
     server.get('/', function(req, res) {
         res.send(':)');


### PR DESCRIPTION
Heya! This fixes #437 -- I agree that they should be uppercase as this is what's normal for env vars :) Uppercasing and snakecasing them also makes sure they all look the same (twilio's env vars was already upper- and snakecased)
