### PR TITLE
Added timestamp property to sent messages.

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -484,6 +484,7 @@ function Botkit(configuration) {
 
         this.tick = function() {
             var now = new Date();
+            var self = this;
 
             if (this.isActive()) {
                 if (this.handler) {
@@ -539,9 +540,11 @@ function Botkit(configuration) {
                             if (message.text || message.attachments || message.attachment) {
 
                                 var outbound = this.cloneMessage(message);
-                                this.task.bot.reply(this.source_message, outbound, function(err) {
+                                this.task.bot.reply(this.source_message, outbound, function(err, res) {
                                     if (err) {
                                         botkit.log('An error occurred while sending a message: ', err);
+                                    } else if (res.message.ts) {
+                                        self.sent[self.sent.length - 1].ts = res.message.ts;
                                     }
                                 });
                             }


### PR DESCRIPTION
Since no convo.askAndUpdate method exists, I am using the convo.ask method and updating the previously sent message using the Web API update method. It appears that messages from users contain a timestamp, but messages from bots don't. I added the ts (timestamp) property to messages sent and stored in the sent array. Please consider adding the timestamp to sent messages so they can be easily updated.
