### PR TITLE
Make createConversation callable on facebook bot instance

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -23,6 +23,9 @@ function Facebookbot(configuration) {
             botkit.startConversation(this, message, cb);
         };
 
+        bot.createConversation = function(message, cb) {
+            botkit.createConversation(this, message, cb);
+        };
 
 
         bot.send = function(message, cb) {


### PR DESCRIPTION
This fixes Issue #450 
The documentation says `createConversation` should be callable on the bot instance passed to event handlers; the slackbot works exactly as documented.  I read through the code and see no slack-specific reason why createConversation shouldn't work everywhere that startConversation does. Live tests show no problem.

See https://github.com/howdyai/botkit/blob/b4f69f4cb32fc94dc6563e8bb63cedc33e949aa3/lib/Slackbot_worker.js#L297
