### PR TITLE
Set 0.0.0.0 to default hostname

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -1036,10 +1036,12 @@ function Botkit(configuration) {
 
     botkit.config = configuration;
 
-    // default the application to listen to the localhost IP address
-    // developers can specify a hostname or IP address to override this
+    /** Default the application to listen to the 0.0.0.0, the default
+      * for node's http module. Developers can specify a hostname or IP 
+      * address to override this.
+    **/
     if (!botkit.config.hostname) {
-        botkit.config.hostname = '127.0.0.1';
+        botkit.config.hostname = '0.0.0.0';
     };
 
 


### PR DESCRIPTION
See issue #492. Using a default hostname of 127.0.0.1 overrides the http module's expected default hostname as described here: https://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback. This can cause deployment errors on services such as heroku.

> If the hostname is omitted, the server will accept connections on any IPv6 address (::) when IPv6 is available, or any IPv4 address (0.0.0.0) otherwise.