### PR TITLE
adding "done" and "exit" as a utterances for "quit"

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -29,7 +29,7 @@ function Botkit(configuration) {
     botkit.utterances = {
         yes: new RegExp(/^(yes|yea|yup|yep|ya|sure|ok|y|yeah|yah)/i),
         no: new RegExp(/^(no|nah|nope|n)/i),
-        quit: new RegExp(/^(quit|cancel|end|stop|done|nevermind|never mind)/i)
+        quit: new RegExp(/^(quit|cancel|end|stop|done|exit|nevermind|never mind)/i)
     };
 
     // define some middleware points where custom functions

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -29,7 +29,7 @@ function Botkit(configuration) {
     botkit.utterances = {
         yes: new RegExp(/^(yes|yea|yup|yep|ya|sure|ok|y|yeah|yah)/i),
         no: new RegExp(/^(no|nah|nope|n)/i),
-        quit: new RegExp(/^(quit|cancel|end|stop|nevermind|never mind)/i)
+        quit: new RegExp(/^(quit|cancel|end|stop|done|nevermind|never mind)/i)
     };
 
     // define some middleware points where custom functions


### PR DESCRIPTION
I found it odd that your example for `conversation.ask()` shows a bot that expects responses of "YES, NO or DONE to quit", yet "done" isn't an expected utterance for "quit".

changes:

- Adds "done" to `botkit.utterances.quit`
- Adds "exit" to `botkit.utterances.quit`