### PR TITLE
Events API support

### DIFF
--- a/examples/slackbutton_bot.js
+++ b/examples/slackbutton_bot.js
@@ -35,6 +35,7 @@ if (!process.env.clientId || !process.env.clientSecret || !process.env.port || !
 
 var controller = Botkit.slackbot({
   json_file_store: './db_slackbutton_bot/',
+  // rtm_receive_messages: false, // disable rtm_receive_messages if you enable events api
 }).configureSlackApp(
   {
     clientId: process.env.clientId,

--- a/examples/slackbutton_bot_interactivemsg.js
+++ b/examples/slackbutton_bot_interactivemsg.js
@@ -309,24 +309,24 @@ controller.on(['direct_message','mention','direct_mention'],function(bot,message
     bot.reply(message,'I heard you loud and clear boss.');
   });
 });
-
-controller.storage.teams.all(function(err,teams) {
-
-  if (err) {
-    throw new Error(err);
-  }
-
-  // connect all teams with bots up to slack!
-  for (var t  in teams) {
-    if (teams[t].bot) {
-      controller.spawn(teams[t]).startRTM(function(err, bot) {
-        if (err) {
-          console.log('Error connecting bot to Slack:',err);
-        } else {
-          trackBot(bot);
-        }
-      });
-    }
-  }
-
-});
+// 
+// controller.storage.teams.all(function(err,teams) {
+//
+//   if (err) {
+//     throw new Error(err);
+//   }
+//
+//   // connect all teams with bots up to slack!
+//   for (var t  in teams) {
+//     if (teams[t].bot) {
+//       controller.spawn(teams[t]).startRTM(function(err, bot) {
+//         if (err) {
+//           console.log('Error connecting bot to Slack:',err);
+//         } else {
+//           trackBot(bot);
+//         }
+//       });
+//     }
+//   }
+//
+// });

--- a/examples/slackbutton_bot_interactivemsg.js
+++ b/examples/slackbutton_bot_interactivemsg.js
@@ -36,6 +36,7 @@ if (!process.env.clientId || !process.env.clientSecret || !process.env.port) {
 var controller = Botkit.slackbot({
   // interactive_replies: true, // tells botkit to send button clicks into conversations
   json_file_store: './db_slackbutton_bot/',
+  // rtm_receive_messages: false, // disable rtm_receive_messages if you enable events api
 }).configureSlackApp(
   {
     clientId: process.env.clientId,
@@ -309,24 +310,24 @@ controller.on(['direct_message','mention','direct_mention'],function(bot,message
     bot.reply(message,'I heard you loud and clear boss.');
   });
 });
-// 
-// controller.storage.teams.all(function(err,teams) {
-//
-//   if (err) {
-//     throw new Error(err);
-//   }
-//
-//   // connect all teams with bots up to slack!
-//   for (var t  in teams) {
-//     if (teams[t].bot) {
-//       controller.spawn(teams[t]).startRTM(function(err, bot) {
-//         if (err) {
-//           console.log('Error connecting bot to Slack:',err);
-//         } else {
-//           trackBot(bot);
-//         }
-//       });
-//     }
-//   }
-//
-// });
+
+controller.storage.teams.all(function(err,teams) {
+
+  if (err) {
+    throw new Error(err);
+  }
+
+  // connect all teams with bots up to slack!
+  for (var t  in teams) {
+    if (teams[t].bot) {
+      controller.spawn(teams[t]).startRTM(function(err, bot) {
+        if (err) {
+          console.log('Error connecting bot to Slack:',err);
+        } else {
+          trackBot(bot);
+        }
+      });
+    }
+  }
+
+});

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -1037,7 +1037,7 @@ function Botkit(configuration) {
     botkit.config = configuration;
 
     /** Default the application to listen to the 0.0.0.0, the default
-      * for node's http module. Developers can specify a hostname or IP 
+      * for node's http module. Developers can specify a hostname or IP
       * address to override this.
     **/
     if (!botkit.config.hostname) {

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -9,6 +9,19 @@ function Slackbot(configuration) {
     // Create a core botkit bot
     var slack_botkit = Botkit(configuration || {});
 
+    // Set some default configurations unless they've already been set.
+
+    // Should the RTM connections ingest received messages
+    // Developers using the new Events API will set this to false
+    // This allows an RTM connection to be kept alive (so bot appears online)
+    // but receive messages only via events api
+    if (slack_botkit.config.rtm_receive_messages === undefined) {
+        slack_botkit.config.rtm_receive_messages = true;
+    }
+
+
+
+
     var spawned_bots = [];
 
     // customize the bot definition, which will be used when new connections
@@ -127,146 +140,19 @@ function Slackbot(configuration) {
                 return;
             }
 
-            // Receive messages and trigger events from the Events API
+
+
             if (req.body.type === 'event_callback') {
+                // Receive messages and trigger events from the Events API
                 return handleEventsAPI(req, res);
-            }
-
-
-            // is this an interactive message callback?
-            if (req.body.payload) {
-
-                var message = JSON.parse(req.body.payload);
-                for (var key in req.body) {
-                    message[key] = req.body[key];
-                }
-
-                // let's normalize some of these fields to match the rtm message format
-                message.user = message.user.id;
-                message.channel = message.channel.id;
-
-                // put the action value in the text field
-                // this allows button clicks to respond to asks
-                message.text = message.actions[0].value;
-
-                message.type = 'interactive_message_callback';
-
-                slack_botkit.findTeamById(message.team.id, function(err, team) {
-                    if (err || !team) {
-                        slack_botkit.log.error('Received interactive message, but could not load team');
-                    } else {
-                        res.status(200);
-                        res.send('');
-
-                        var bot = slack_botkit.spawn(team);
-
-                        bot.team_info = team;
-                        bot.res = res;
-
-                        slack_botkit.trigger('interactive_message_callback', [bot, message]);
-
-                        if (configuration.interactive_replies) {
-                            message.type = 'message';
-                            slack_botkit.receiveMessage(bot, message);
-                        }
-                    }
-                });
-
-            // this is a slash command
+            } else if (req.body.payload) {
+                // is this an interactive message callback?
+                return handleInteractiveMessage(req,res);
             } else if (req.body.command) {
-                var message = {};
-
-                for (var key in req.body) {
-                    message[key] = req.body[key];
-                }
-
-                // let's normalize some of these fields to match the rtm message format
-                message.user = message.user_id;
-                message.channel = message.channel_id;
-
-                // Is this configured to use Slackbutton?
-                // If so, validate this team before triggering the event!
-                // Otherwise, it's ok to just pass a generic bot in
-                if (slack_botkit.config.clientId && slack_botkit.config.clientSecret) {
-
-                    slack_botkit.findTeamById(message.team_id, function(err, team) {
-                        if (err || !team) {
-                            slack_botkit.log.error('Received slash command, but could not load team');
-                        } else {
-                            message.type = 'slash_command';
-                            // HEY THERE
-                            // Slash commands can actually just send back a response
-                            // and have it displayed privately. That means
-                            // the callback needs access to the res object
-                            // to send an optional response.
-
-                            res.status(200);
-
-                            var bot = slack_botkit.spawn(team);
-
-                            bot.team_info = team;
-                            bot.res = res;
-
-                            slack_botkit.receiveMessage(bot, message);
-
-                        }
-                    });
-                } else {
-
-                    message.type = 'slash_command';
-                    // HEY THERE
-                    // Slash commands can actually just send back a response
-                    // and have it displayed privately. That means
-                    // the callback needs access to the res object
-                    // to send an optional response.
-
-                    var team = {
-                        id: message.team_id,
-                    };
-
-                    res.status(200);
-
-                    var bot = slack_botkit.spawn({});
-
-                    bot.team_info = team;
-                    bot.res = res;
-
-                    slack_botkit.receiveMessage(bot, message);
-
-                }
-
+                // this is a slash command
+                return handleSlashCommand(req,res);
             } else if (req.body.trigger_word) {
-
-                var message = {};
-
-                for (var key in req.body) {
-                    message[key] = req.body[key];
-                }
-
-
-                var team = {
-                    id: message.team_id,
-                };
-
-                // let's normalize some of these fields to match the rtm message format
-                message.user = message.user_id;
-                message.channel = message.channel_id;
-
-                message.type = 'outgoing_webhook';
-
-                res.status(200);
-
-                var bot = slack_botkit.spawn(team);
-                bot.res = res;
-                bot.team_info = team;
-
-
-                slack_botkit.receiveMessage(bot, message);
-
-                // outgoing webhooks are also different. They can simply return
-                // a response instead of using the API to reply.  Maybe this is
-                // a different type of event!!
-
+                return handleOutgoingWebhook(req,res);
             }
 
         });
@@ -274,7 +160,48 @@ function Slackbot(configuration) {
         return slack_botkit;
     };
 
+    /* Handler functions for the various ways Slack might send a message to
+     * Botkit via webhooks.  These include interactive messages (button clicks),
+     * events api (messages sent over web hook), slash commands, and outgoing webhooks
+     * (patterns matched in slack that result in a webhook)
+     */
+    function handleInteractiveMessage(req,res) {
+        var message = JSON.parse(req.body.payload);
+        for (var key in req.body) {
+            message[key] = req.body[key];
+        }
 
+        // let's normalize some of these fields to match the rtm message format
+        message.user = message.user.id;
+        message.channel = message.channel.id;
+
+        // put the action value in the text field
+        // this allows button clicks to respond to asks
+        message.text = message.actions[0].value;
+
+        message.type = 'interactive_message_callback';
+
+        slack_botkit.findTeamById(message.team.id, function(err, team) {
+            if (err || !team) {
+                slack_botkit.log.error('Received interactive message, but could not load team');
+            } else {
+                res.status(200);
+                res.send('');
+
+                var bot = slack_botkit.spawn(team);
+
+                bot.team_info = team;
+                bot.res = res;
+
+                slack_botkit.trigger('interactive_message_callback', [bot, message]);
+
+                if (configuration.interactive_replies) {
+                    message.type = 'message';
+                    slack_botkit.receiveMessage(bot, message);
+                }
+            }
+        });
+    }
     function handleEventsAPI(req, res) {
         // respond to events api with a 200
         res.sendStatus(200);
@@ -288,8 +215,6 @@ function Slackbot(configuration) {
         message.team = req.body.team_id;
         message.events_api = true;
         message.authed_users = req.body.authed_users;
-
-        console.log(message);
 
         slack_botkit.findTeamById(message.team, function(err, team) {
             if (err || !team) {
@@ -312,10 +237,8 @@ function Slackbot(configuration) {
                     slack_botkit.log.error('Could not identify bot');
                     return;
                 } else {
-
                     if (req.body.event.type === 'message') {
                         slack_botkit.receiveMessage(bot, message);
-
                     } else {
                         slack_botkit.trigger(message.type, [bot, message]);
                     }
@@ -323,7 +246,102 @@ function Slackbot(configuration) {
             }
         });
     };
+    function handleSlashCommand(req, res) {
+        var message = {};
 
+        for (var key in req.body) {
+            message[key] = req.body[key];
+        }
+
+        // let's normalize some of these fields to match the rtm message format
+        message.user = message.user_id;
+        message.channel = message.channel_id;
+
+        // Is this configured to use Slackbutton?
+        // If so, validate this team before triggering the event!
+        // Otherwise, it's ok to just pass a generic bot in
+        if (slack_botkit.config.clientId && slack_botkit.config.clientSecret) {
+
+            slack_botkit.findTeamById(message.team_id, function(err, team) {
+                if (err || !team) {
+                    slack_botkit.log.error('Received slash command, but could not load team');
+                } else {
+                    message.type = 'slash_command';
+                    // HEY THERE
+                    // Slash commands can actually just send back a response
+                    // and have it displayed privately. That means
+                    // the callback needs access to the res object
+                    // to send an optional response.
+
+                    res.status(200);
+
+                    var bot = slack_botkit.spawn(team);
+
+                    bot.team_info = team;
+                    bot.res = res;
+
+                    slack_botkit.receiveMessage(bot, message);
+
+                }
+            });
+        } else {
+
+            message.type = 'slash_command';
+            // HEY THERE
+            // Slash commands can actually just send back a response
+            // and have it displayed privately. That means
+            // the callback needs access to the res object
+            // to send an optional response.
+
+            var team = {
+                id: message.team_id,
+            };
+
+            res.status(200);
+
+            var bot = slack_botkit.spawn({});
+
+            bot.team_info = team;
+            bot.res = res;
+
+            slack_botkit.receiveMessage(bot, message);
+
+        }
+    }
+    function handleOutgoingWebhook(req, res) {
+        var message = {};
+
+        for (var key in req.body) {
+            message[key] = req.body[key];
+        }
+
+
+        var team = {
+            id: message.team_id,
+        };
+
+        // let's normalize some of these fields to match the rtm message format
+        message.user = message.user_id;
+        message.channel = message.channel_id;
+
+        message.type = 'outgoing_webhook';
+
+        res.status(200);
+
+        var bot = slack_botkit.spawn(team);
+        bot.res = res;
+        bot.team_info = team;
+
+
+        slack_botkit.receiveMessage(bot, message);
+
+        // outgoing webhooks are also different. They can simply return
+        // a response instead of using the API to reply.  Maybe this is
+        // a different type of event!!
+    };
+
+    /* End of webhook handler functions
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
     slack_botkit.saveTeam = function(team, cb) {
         slack_botkit.storage.teams.save(team, cb);

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -120,6 +120,19 @@ function Slackbot(configuration) {
             'webhooks at: http://' + slack_botkit.config.hostname + ':' + slack_botkit.config.port + '/slack/receive');
         webserver.post('/slack/receive', function(req, res) {
 
+            // is this an events api url handshake?
+            if (req.body.type === 'url_verification') {
+                slack_botkit.debug('Received url handshake');
+                res.status(200).json({ challenge: req.body.challenge });
+                return;
+            }
+
+            // Receive messages and trigger events from the Events API
+            if (req.body.type === 'event_callback') {
+                return handleEventsAPI(req, res);
+            }
+
+
             // is this an interactive message callback?
             if (req.body.payload) {
 
@@ -261,6 +274,57 @@ function Slackbot(configuration) {
         return slack_botkit;
     };
 
+
+    function handleEventsAPI(req, res) {
+        // respond to events api with a 200
+        res.sendStatus(200);
+
+        var message = {};
+        for (var key in req.body.event) {
+            message[key] = req.body.event[key];
+        }
+
+        // let's normalize some of these fields to match the rtm message format
+        message.team = req.body.team_id;
+        message.events_api = true;
+        message.authed_users = req.body.authed_users;
+
+        console.log(message);
+
+        slack_botkit.findTeamById(message.team, function(err, team) {
+            if (err || !team) {
+                slack_botkit.log.error('Received Events API message, but could not load team:', err);
+                return;
+            } else {
+                var bot = slack_botkit.spawn(team);
+                // Identify the bot from either team storage or identifyBot()
+                bot.team_info = team;
+                bot.identity = {
+                    id: team.bot.user_id,
+                    name: team.bot.name
+                };
+
+                if (team.bot.user_id === req.body.event.user) {
+                    slack_botkit.debug('Got event from this bot user, ignoring it');
+                    return;
+                }
+                if (bot.identity == undefined || bot.identity.id == null) {
+                    slack_botkit.log.error('Could not identify bot');
+                    return;
+                } else {
+
+                    if (req.body.event.type === 'message') {
+                        slack_botkit.receiveMessage(bot, message);
+
+                    } else {
+                        slack_botkit.trigger(message.type, [bot, message]);
+                    }
+                }
+            }
+        });
+    };
+
+
     slack_botkit.saveTeam = function(team, cb) {
         slack_botkit.storage.teams.save(team, cb);
     };
@@ -268,6 +332,7 @@ function Slackbot(configuration) {
     // look up a team's memory and configuration and return it, or
     // return an error!
     slack_botkit.findTeamById = function(id, cb) {
+        console.log('attempt to get a team',id);
         slack_botkit.storage.teams.get(id, cb);
     };
 
@@ -474,6 +539,7 @@ function Slackbot(configuration) {
                                 }
 
                                 if (auth.bot) {
+
                                     team.bot = {
                                         token: auth.bot.bot_access_token,
                                         user_id: auth.bot.bot_user_id,
@@ -500,7 +566,23 @@ function Slackbot(configuration) {
                                             slack_botkit.trigger('update_team', [bot, team]);
                                         }
 
-                                        slack_botkit.storage.users.get(identity.user_id, function(err, user) {
+                                        if (team.bot) {
+                                            // call auth test on the bot token
+                                            // to capture its name
+                                            auth_test({
+                                                token: team.bot.token
+                                            }, function(err, auth_data) {
+                                                team.bot.name = auth_data.user;
+                                                slack_botkit.saveTeam(team, function(err, id) {
+                                                    if (err) {
+                                                        slack_botkit.log.error('An error occurred while saving a team: ', err);
+                                                    }
+                                                });
+
+                                            });
+                                        }
+
+                                       slack_botkit.storage.users.get(identity.user_id, function(err, user) {
                                             isnew = false;
                                             if (!user) {
                                                 isnew = true;

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -350,7 +350,6 @@ function Slackbot(configuration) {
     // look up a team's memory and configuration and return it, or
     // return an error!
     slack_botkit.findTeamById = function(id, cb) {
-        console.log('attempt to get a team',id);
         slack_botkit.storage.teams.get(id, cb);
     };
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -200,7 +200,7 @@ module.exports = function(botkit, config) {
                      * but adds in additional fields for internal use!
                      * (including the teams api details)
                      */
-                    if (message != null) {
+                    if (message != null && bot.botkit.config.rtm_receive_messages) {
                         botkit.receiveMessage(bot, message);
                     }
                 });

--- a/lib/Studio.js
+++ b/lib/Studio.js
@@ -1,6 +1,7 @@
 var request = require('request');
 var Promise = require('promise');
 var md5 = require('md5');
+var SDK = require('botkit-studio-sdk');
 
 module.exports = function(controller) {
     var before_hooks = {};
@@ -11,71 +12,51 @@ module.exports = function(controller) {
     // define a place for the studio specific features to live.
     controller.studio = {};
 
-
-    function studioAPI(bot, options) {
-        var _STUDIO_COMMAND_API = controller.config.studio_command_uri || 'https://api.botkit.ai';
-        options.uri = _STUDIO_COMMAND_API + options.uri;
-        return new Promise(function(resolve, reject) {
-            var headers = {
-                'content-type': 'application/json',
-            };
-            if (bot.config.studio_token) {
-                options.uri = options.uri + '?access_token=' + bot.config.studio_token;
-            } else if (controller.config.studio_token) {
-                options.uri = options.uri + '?access_token=' + controller.config.studio_token;
-            } else {
-                throw new Error('No Botkit Studio Token');
-            }
-            options.headers = headers;
-            request(options, function(err, res, body) {
-                if (err) {
-                    console.log('Error in Botkit Studio:', err);
-                    return reject(err);
-                }
-                try {
-                    json = JSON.parse(body);
-                    if (json.error) {
-                        console.log('Error in Botkit Studio:', json.error);
-                        reject(json.error);
-                    } else {
-                        resolve(json);
-                    }
-                } catch (e) {
-                    console.log('Error in Botkit Studio:', e);
-                    return reject('Invalid JSON');
-                }
-            });
-        });
-    }
-
     /* ----------------------------------------------------------------
      * Botkit Studio Script Services
      * The features in this section grant access to Botkit Studio's
      * script and trigger services
      * ---------------------------------------------------------------- */
 
+     function genConfig(bot) {
+         var config = {};
 
-    controller.studio.evaluateTrigger = function(bot, text) {
-        var url = '/api/v1/commands/triggers';
-        return studioAPI(bot, {
-            uri: url,
-            method: 'post',
-            form: {
-                triggers: text
-            },
-        });
+         if (bot.config && bot.config.studio_token) {
+             config.studio_token = bot.config.studio_token;
+         }
+
+         if (bot.config && bot.config.studio_command_uri) {
+             config.studio_command_uri = bot.config.studio_command_uri;
+         }
+
+         if (controller.config && controller.config.studio_token) {
+             config.studio_token = controller.config.studio_token;
+         }
+
+         if (controller.config && controller.config.studio_command_uri) {
+             config.studio_command_uri = controller.config.studio_command_uri;
+         }
+
+         return config;
+     }
+
+    controller.studio.evaluateTrigger = function(bot, text, user) {
+
+        var userHash = md5(user);
+        var sdk = new SDK(genConfig(bot));
+        return sdk.evaluateTrigger(text, userHash);
+
     };
 
+
+
+
     // load a script from the pro service
-    controller.studio.getScript = function(bot, text) {
-        var url = '/api/v1/commands/name';
-        return studioAPI(bot, {
-            uri: url,
-            method: 'post',
-            form: {
-                command: text
-            },
-        });
+    controller.studio.getScript = function(bot, text, user) {
+
+        var userHash = md5(user);
+        var sdk = new SDK(genConfig(bot));
+        return sdk.getScript(text, user);
     };
 
 
@@ -161,7 +142,7 @@ module.exports = function(controller) {
             channel: channel,
         };
         return new Promise(function(resolve, reject) {
-            controller.studio.getScript(bot, input_text).then(function(command) {
+            controller.studio.getScript(bot, input_text, user).then(function(command) {
                 controller.trigger('command_triggered', [bot, context, command]);
                 controller.studio.compileScript(
                     bot,
@@ -201,7 +182,7 @@ module.exports = function(controller) {
             channel: channel,
         };
         return new Promise(function(resolve, reject) {
-            controller.studio.evaluateTrigger(bot, input_text).then(function(command) {
+            controller.studio.evaluateTrigger(bot, input_text, user).then(function(command) {
                 if (command !== {} && command.id) {
                     controller.trigger('command_triggered', [bot, context, command]);
                     controller.studio.compileScript(
@@ -251,7 +232,7 @@ module.exports = function(controller) {
             channel: channel,
         };
         return new Promise(function(resolve, reject) {
-            controller.studio.evaluateTrigger(bot, input_text).then(function(command) {
+            controller.studio.evaluateTrigger(bot, input_text, user).then(function(command) {
                 if (command !== {} && command.id) {
                     resolve(true);
                 } else {
@@ -442,9 +423,12 @@ module.exports = function(controller) {
             stats_body.meta = {};
             stats_body.meta.user = options.form.user;
             stats_body.meta.channel = options.form.channel;
+            if (options.form.final_thread) {
+                stats_body.meta.final_thread = options.form.final_thread;
+            }
             stats_body.meta.timestamp = options.form.timestamp;
-            stats_body.meta.bot_type = options.form.bot_type,
-                stats_body.meta.conversation_length = options.form.conversation_length;
+            stats_body.meta.bot_type = options.form.bot_type;
+            stats_body.meta.conversation_length = options.form.conversation_length;
             stats_body.meta.status = options.form.status;
             stats_body.meta.type = options.form.type;
             stats_body.meta.command = options.form.command;
@@ -560,6 +544,7 @@ module.exports = function(controller) {
                 conversation_length: convo.lastActive - convo.startTime,
                 status: convo.status,
                 type: 'remote_command_end',
+                final_thread: convo.thread,
                 bot_type: bot.type,
             };
             controller.trigger('stats:remote_command_end', message);

--- a/lib/Studio.js
+++ b/lib/Studio.js
@@ -426,6 +426,9 @@ module.exports = function(controller) {
             if (options.form.final_thread) {
                 stats_body.meta.final_thread = options.form.final_thread;
             }
+            if (bot.botkit.config.clientId) {
+                stats_body.meta.app = md5(bot.botkit.config.clientId);
+            }
             stats_body.meta.timestamp = options.form.timestamp;
             stats_body.meta.bot_type = options.form.bot_type;
             stats_body.meta.conversation_length = options.form.conversation_length;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "back": "^1.0.1",
     "body-parser": "^1.14.2",
     "botbuilder": "^3.2.3",
+    "botkit-studio-sdk": "^1.0.0",
     "clone": "2.0.0",
     "command-line-args": "^3.0.0",
     "express": "^4.13.3",


### PR DESCRIPTION
This PR adds support for the events API, along with a few other changes and bug fixes in the Botkit Studio functionality.

This is mostly the same as #480, but a cleaned up merge with some features normalized for maintainability in the future.