### PR TITLE
Make stale connection detection configurable

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -21,7 +21,7 @@ module.exports = function(botkit, config) {
     // Set when destroy() is called - prevents a reconnect from completing
     // if it was fired off prior to destroy being called
     var destroyed = false;
-    var pingIntervalId = null;
+    var pingTimeoutId = null;
     var retryBackoff = null;
 
     // config.retry, can be Infinity too
@@ -68,8 +68,8 @@ module.exports = function(botkit, config) {
             bot.rtm.close();
         }
 
-        if (pingIntervalId) {
-            clearInterval(pingIntervalId);
+        if (pingTimeoutId) {
+            clearTimeout(pingTimeoutId);
         }
 
         botkit.trigger('rtm_close', [bot, err]);
@@ -166,24 +166,26 @@ module.exports = function(botkit, config) {
 
             bot.rtm.on('pong', function(obj) {
                 lastPong = Date.now();
-                botkit.debug('PONG received');
             });
 
             bot.rtm.on('open', function() {
                 botkit.log.notice('RTM websocket opened');
 
-                pingIntervalId = setInterval(function() {
-                    if (lastPong && lastPong + 12000 < Date.now()) {
-                        var err = new Error('Stale RTM connection, closing RTM');
-                        botkit.log.error(err);
-                        bot.closeRTM(err);
-                        clearInterval(pingIntervalId);
-                        return;
-                    }
+                var pinger = function () {
+                  var pongTimeout = bot.botkit.config.stale_connection_timeout || 12000
+                  if (lastPong && lastPong + pongTimeout < Date.now()) {
+                      var err = new Error('Stale RTM connection, closing RTM');
+                      botkit.log.error(err);
+                      bot.closeRTM(err);
+                      clearTimeout(pingTimeoutId);
+                      return;
+                  }
 
-                    botkit.debug('PING sent');
-                    bot.rtm.ping(null, null, true);
-                }, 5000);
+                  bot.rtm.ping(null, null, true);
+                  pingTimeoutId = setTimeout(pinger, 5000);
+                };
+
+                pingTimeoutId = setTimeout(pinger, 5000);
 
                 botkit.trigger('rtm_open', [bot]);
                 bot.rtm.on('message', function(data, flags) {
@@ -212,16 +214,16 @@ module.exports = function(botkit, config) {
 
             bot.rtm.on('error', function(err) {
                 botkit.log.error('RTM websocket error!', err);
-                if (pingIntervalId) {
-                    clearInterval(pingIntervalId);
+                if (pingTimeoutId) {
+                    clearTimeout(pingTimeoutId);
                 }
                 botkit.trigger('rtm_close', [bot, err]);
             });
 
             bot.rtm.on('close', function(code, message) {
                 botkit.log.notice('RTM close event: ' + code + ' : ' + message);
-                if (pingIntervalId) {
-                    clearInterval(pingIntervalId);
+                if (pingTimeoutId) {
+                    clearTimeout(pingTimeoutId);
                 }
                 botkit.trigger('rtm_close', [bot]);
 

--- a/readme-slack.md
+++ b/readme-slack.md
@@ -69,6 +69,24 @@ This is particularly true if you store and use API tokens on behalf of users oth
 
 [Read Slack's Bot User documentation](https://api.slack.com/bot-users)
 
+#### Botkit.slackbot()
+| Argument | Description
+|--- |---
+| config | Configuration object
+
+Creates a new Botkit SlackBot controller.
+
+```javascript
+var controller = Botkit.slackbot({debug: true})
+```
+
+`config` object accepts these properties:
+
+| Name | Value | Description
+|--- |--- |---
+| debug | Boolean | Enable debug logging
+| stale_connection_timeout  | Positive integer | Number of milliseconds to wait for a connection keep-alive "pong" response before declaring the connection stale. Default is `12000`
+
 
 #### controller.spawn()
 | Argument | Description


### PR DESCRIPTION
A Beep Boop user ran into an issue when on connection and periodic points in time, they were doing A LOT of work that was maxing out CPU so much that it caused node.js's event loop to queue excessively. RTM connections were healthy and returning `pong` responses but the node process wasn't processing the `pong` response in time because the event queue was so backed up. This caused a lot of thrashing of connects/discconects/connects within their process:

![thrash](https://cloud.githubusercontent.com/assets/30455/20540698/6f073a2c-b0b7-11e6-8515-5a93b8c15393.gif)

![screenshot 2016-11-16 15 06 37](https://cloud.githubusercontent.com/assets/30455/20540486/9d3fe430-b0b6-11e6-8d85-44908e5dd290.png)

Ultimately they need to better manage/throttle the work being done inside of the process, but the mitigation to avoid the connection thrashing was to increase the amount of time considered to consider a connection stale.

An overview of the changes:

- add `stale_connection_timeout` to make stale connection detection configurable. This is the number of milliseconds to wait for a `pong` response to a `ping`
- replace the use of an `interval` with a `timeout` to ensure we don't clog the event loop under duress.
- add details to the Slack Readme