### PR TITLE
Fix bot_channel_join and bot_group_join with Slack Events API

### DIFF
--- a/examples/slackbutton_bot.js
+++ b/examples/slackbutton_bot.js
@@ -27,15 +27,16 @@ This is a sample Slack Button application that adds a bot to one or many slack t
 /* Uses the slack button feature to offer a real time bot to multiple teams */
 var Botkit = require('../lib/Botkit.js');
 
-if (!process.env.clientId || !process.env.clientSecret || !process.env.port || !process.env.redirectUri) {
-  console.log('Error: Specify clientId clientSecret redirectUri and port in environment');
+if (!process.env.clientId || !process.env.clientSecret || !process.env.port) {
+  console.log('Error: Specify clientId clientSecret and port in environment');
   process.exit(1);
 }
 
 
 var controller = Botkit.slackbot({
   json_file_store: './db_slackbutton_bot/',
-  // rtm_receive_messages: false, // disable rtm_receive_messages if you enable events api
+  debug: true,
+  rtm_receive_messages: false, // disable rtm_receive_messages if you enable events api
 }).configureSlackApp(
   {
     clientId: process.env.clientId,
@@ -89,6 +90,9 @@ controller.on('create_bot',function(bot,config) {
   }
 
 });
+controller.on('bot_channel_join', function(bot, message) {
+    console.log('================ BOT JOINED CHANNEL!: bot.id', bot.identity)
+})
 
 
 // Handle events related to the websocket connection to Slack

--- a/examples/slackbutton_bot.js
+++ b/examples/slackbutton_bot.js
@@ -27,16 +27,15 @@ This is a sample Slack Button application that adds a bot to one or many slack t
 /* Uses the slack button feature to offer a real time bot to multiple teams */
 var Botkit = require('../lib/Botkit.js');
 
-if (!process.env.clientId || !process.env.clientSecret || !process.env.port) {
-  console.log('Error: Specify clientId clientSecret and port in environment');
+if (!process.env.clientId || !process.env.clientSecret || !process.env.port || !process.env.redirectUri) {
+  console.log('Error: Specify clientId clientSecret redirectUri and port in environment');
   process.exit(1);
 }
 
 
 var controller = Botkit.slackbot({
   json_file_store: './db_slackbutton_bot/',
-  debug: true,
-  rtm_receive_messages: false, // disable rtm_receive_messages if you enable events api
+  // rtm_receive_messages: false, // disable rtm_receive_messages if you enable events api
 }).configureSlackApp(
   {
     clientId: process.env.clientId,
@@ -90,9 +89,6 @@ controller.on('create_bot',function(bot,config) {
   }
 
 });
-controller.on('bot_channel_join', function(bot, message) {
-    console.log('================ BOT JOINED CHANNEL!: bot.id', bot.identity)
-})
 
 
 // Handle events related to the websocket connection to Slack

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -228,8 +228,8 @@ function Slackbot(configuration) {
                     id: team.bot.user_id,
                     name: team.bot.name
                 };
+                if (team.bot.user_id === req.body.event.user && req.body.event.subtype !== 'channel_join') {
 
-                if (team.bot.user_id === req.body.event.user) {
                     slack_botkit.debug('Got event from this bot user, ignoring it');
                     return;
                 }
@@ -682,7 +682,7 @@ function Slackbot(configuration) {
                 // set up a couple of special cases based on subtype
                 if (message.subtype && message.subtype == 'channel_join') {
                     // someone joined. maybe do something?
-                    if (message.user == bot.identity.id && message.bot_id) {
+                    if (message.user == bot.identity.id){
                         slack_botkit.trigger('bot_channel_join', [bot, message]);
                         return false;
                     } else {
@@ -691,7 +691,7 @@ function Slackbot(configuration) {
                     }
                 } else if (message.subtype && message.subtype == 'group_join') {
                     // someone joined. maybe do something?
-                    if (message.user == bot.identity.id && message.bot_id) {
+                    if (message.user == bot.identity.id) {
                         slack_botkit.trigger('bot_group_join', [bot, message]);
                         return false;
                     } else {

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -682,7 +682,7 @@ function Slackbot(configuration) {
                 // set up a couple of special cases based on subtype
                 if (message.subtype && message.subtype == 'channel_join') {
                     // someone joined. maybe do something?
-                    if (message.user == bot.identity.id){
+                    if (message.user == bot.identity.id) {
                         slack_botkit.trigger('bot_channel_join', [bot, message]);
                         return false;
                     } else {

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -228,7 +228,7 @@ function Slackbot(configuration) {
                     id: team.bot.user_id,
                     name: team.bot.name
                 };
-                if (team.bot.user_id === req.body.event.user && req.body.event.subtype !== 'channel_join') {
+                if (team.bot.user_id === req.body.event.user && req.body.event.subtype !== 'channel_join' && req.body.event.subtype !== 'group_join') {
 
                     slack_botkit.debug('Got event from this bot user, ignoring it');
                     return;


### PR DESCRIPTION
Events API does not pass bot_id to channel_join and group_join events, which we were checking for in order to determine if it was the bot which joined the channel or group. 

This restores expected behavior

I added an exception for channel and group joins to filtering out events associated with our bot user, I think this is the only event we listen to with slack that has our bot's user id as the `user: id` so I think this should be fine for now.

closes #347 