### PR TITLE
Integrate facebook thread settings

### DIFF
--- a/facebook_bot.js
+++ b/facebook_bot.js
@@ -123,6 +123,9 @@ controller.setupWebserver(process.env.port || 3000, function(err, webserver) {
     });
 });
 
+controller.threadSettings.setupGreeting('Hello ! i\'m the awesome Botkit');
+controller.threadSettings.setupGetStarted('getStarted');
+
 controller.hears(['quick'], 'message_received', function(bot, message) {
 
     bot.reply(message, {

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -346,7 +346,15 @@ function Facebookbot(configuration) {
     };
 
     facebook_botkit.threadSettings = {
-
+        setupGreeting: function(greeting) {
+            var message = {
+                "setting_type": "greeting",
+                "greeting": {
+                    "text": greeting
+                }
+            };
+            this.threadSetup(message);
+        }
     };
 
     return facebook_botkit;

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -354,6 +354,19 @@ function Facebookbot(configuration) {
                 }
             };
             this.threadSetup(message);
+        },
+        setupGetStarted: function(payload) {
+            var message = {
+                "setting_type": "call_to_actions",
+                "thread_state": "new_thread",
+                "call_to_actions":
+                    [
+                        {
+                            "payload": payload
+                        }
+                    ]
+            };
+            this.threadSetup(message);
         }
     };
 

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -367,6 +367,17 @@ function Facebookbot(configuration) {
                     ]
             };
             this.threadSetup(message);
+        },
+        threadSetup: function(message) {
+            request.post('https://graph.facebook.com/v2.6/me/thread_settings?access_token=' + configuration.access_token,
+                {form: message},
+                function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not configure thread settings');
+                    } else {
+                        facebook_botkit.debug('Successfully configured thread settings', message);
+                    }
+                });
         }
     };
 

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -287,7 +287,7 @@ function Facebookbot(configuration) {
 
         webserver.get('/facebook/receive', function(req, res) {
             console.log(req.query);
-            if (req.query['hub.mthread settingsode'] == 'subscribe') {
+            if (req.query['hub.mode'] == 'subscribe') {
                 if (req.query['hub.verify_token'] == configuration.verify_token) {
                     res.send(req.query['hub.challenge']);
                 } else {

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -287,7 +287,7 @@ function Facebookbot(configuration) {
 
         webserver.get('/facebook/receive', function(req, res) {
             console.log(req.query);
-            if (req.query['hub.mode'] == 'subscribe') {
+            if (req.query['hub.mthread settingsode'] == 'subscribe') {
                 if (req.query['hub.verify_token'] == configuration.verify_token) {
                     res.send(req.query['hub.challenge']);
                 } else {
@@ -342,6 +342,10 @@ function Facebookbot(configuration) {
             });
 
         return facebook_botkit;
+
+    };
+
+    facebook_botkit.threadSettings = {
 
     };
 


### PR DESCRIPTION
Yo,

By this PR, i want to bring a new functionality proposed by Facebook to our lovely Botkit :cupid:

Recently, FB let us configure the Thread Settings on Messenger to improve the user experience, by adding  a welcome screen to display a get started button or putting a greeting for the new conversations ... and much more.

Documentation : https://developers.facebook.com/docs/messenger-platform/thread-settings/get-started-button