### PR TITLE
Add support for Facebook messaging_referral - fixes #518

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -349,7 +349,16 @@ function Facebookbot(configuration) {
                             };
 
                             facebook_botkit.trigger('message_read', [bot, message]);
-                        } else {
+                        } else if (facebook_message.referral) {
+                          var message = {
+                              user: facebook_message.sender.id,
+                              channel: facebook_message.sender.id,
+                              timestamp: facebook_message.timestamp,
+                              referral: facebook_message.referral,
+                          };
+
+                          facebook_botkit.trigger('facebook_referral', [bot, message]);
+                        }  else {
                             facebook_botkit.log('Got an unexpected message from Facebook: ', facebook_message);
                         }
                     }

--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -66,6 +66,7 @@ Normal messages will be sent to your bot using the `message_received` event.  In
 | message_delivered | a confirmation from Facebook that a message has been received
 | message_read | a confirmation from Facebook that a message has been read
 | facebook_optin | a user has clicked the [Send-to-Messenger plugin](https://developers.facebook.com/docs/messenger-platform/implementation#send_to_messenger_plugin)
+| message_referral | a user has clicked on a [m.me URL with a referral param](https://developers.facebook.com/docs/messenger-platform/referral-params)
 
 All incoming events will contain the fields `user` and `channel`, both of which represent the Facebook user's ID, and a `timestamp` field.
 


### PR DESCRIPTION
* Add to Facebook readme.

* Add code to /lib/Facebook.js to recognise the messaging_referral webhook and create a corresponding event in botkit, to be used:

```
controller.on('facebook_referral', function(bot, message) {
   console.log('the referral code is' + message.referral.ref)
});
```
