### PR TITLE
slackbutton_bot.js redirectUri Bug Fix

### DIFF
--- a/examples/slackbutton_bot.js
+++ b/examples/slackbutton_bot.js
@@ -27,8 +27,8 @@ This is a sample Slack Button application that adds a bot to one or many slack t
 /* Uses the slack button feature to offer a real time bot to multiple teams */
 var Botkit = require('../lib/Botkit.js');
 
-if (!process.env.clientId || !process.env.clientSecret || !process.env.port || !process.env.redirectUri) {
-  console.log('Error: Specify clientId clientSecret redirectUri and port in environment');
+if (!process.env.clientId || !process.env.clientSecret || !process.env.port) {
+  console.log('Error: Specify clientId clientSecret and port in environment');
   process.exit(1);
 }
 
@@ -40,7 +40,7 @@ var controller = Botkit.slackbot({
   {
     clientId: process.env.clientId,
     clientSecret: process.env.clientSecret,
-    redirectUri: process.env.redirectUri,
+    // redirectUri: process.env.redirectUri, // optional parameter passed to slackbutton oauth flow
     scopes: ['bot'],
   }
 );


### PR DESCRIPTION
Closes #510 

I introduced a bug in #465 by adding `process.env.redirectUri` as a required variable to run slackbutton_bot.js example.

`redirectUri` is an optional parameter that is part of the slackbutton oauth flow, and as such should not be required to run the file.

This removes that requirement, and comments out redirectUri in the bot's config while pointing it out as an optional parameter. 