### PR TITLE
Slack: fix send_via_rtm, fix typing indicator

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -346,7 +346,7 @@ module.exports = function(botkit, config) {
          * OR if one of the fields that is only supported by the web api is present
          */
         if (
-            bot.config.send_via_rtm !== true && message.type !== 'typing' ||
+            bot.botkit.config.send_via_rtm !== true && message.type !== 'typing' ||
             message.attachments || message.icon_emoji ||
             message.username || message.icon_url) {
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -346,7 +346,7 @@ module.exports = function(botkit, config) {
          * OR if one of the fields that is only supported by the web api is present
          */
         if (
-            bot.botkit.config.send_via_rtm !== true && message.type !== 'typing' ||
+            botkit.config.send_via_rtm !== true && message.type !== 'typing' ||
             message.attachments || message.icon_emoji ||
             message.username || message.icon_url) {
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -346,7 +346,7 @@ module.exports = function(botkit, config) {
          * OR if one of the fields that is only supported by the web api is present
          */
         if (
-            bot.config.send_via_rtm !== true ||
+            bot.config.send_via_rtm !== true && message.type !== 'typing' ||
             message.attachments || message.icon_emoji ||
             message.username || message.icon_url) {
 


### PR DESCRIPTION
closes #507 

`bot.send()` is looking for `bot.config.send_via_rtm !== true` which its not finding in `bot.config`. So messages are being sent via web API, and never reaching the rtm.send

However, `bot.botkit.config.send_via_rtm` does exist, once you've passed it into the controller, and this PR changes the logic to look there. 

Also check if `message.type == 'typing'` to send typing indications via rtm.