### PR TITLE
Add removeListener function for event handlers

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -18,6 +18,7 @@ var PKG_VERSION = require('../package.json').version;
 function Botkit(configuration) {
     var botkit = {
         events: {}, // this will hold event handlers
+        listeners: {}, // this will hold listeners wrapped inside event handlers.
         config: {}, // this will hold the configuration
         tasks: [],
         taskCount: 0,
@@ -1012,7 +1013,7 @@ function Botkit(configuration) {
 
         for (var e = 0; e < events.length; e++) {
             (function(keywords, test_function) {
-                botkit.on(events[e], function(bot, message) {
+                botkit.on(events[e], cb, function(bot, message) {
                     if (test_function && test_function(keywords, message)) {
                         botkit.debug('I HEARD', keywords);
                         botkit.middleware.heard.run(bot, message, function(err, bot, message) {
@@ -1028,17 +1029,42 @@ function Botkit(configuration) {
         return this;
     };
 
-    botkit.on = function(event, cb) {
+    botkit.on = function(event, handler, cb) {
+        if (!cb) {
+            // handler is the callback
+            cb = handler;
+            handler = null;
+        }
         botkit.debug('Setting up a handler for', event);
         var events = (typeof(event) == 'string') ? event.split(/\,/g) : event;
-
         for (var e in events) {
             if (!this.events[events[e]]) {
                 this.events[events[e]] = [];
             }
+            if (!this.listeners[events[e]]) {
+                this.listeners[events[e]] = [];
+            }
+            if (handler) {
+                this.listeners[events[e]].push(handler);
+            }
             this.events[events[e]].push(cb);
         }
         return this;
+    };
+
+    botkit.removeListener = function(event, handler) {
+        var events = (typeof(event) == 'string') ? event.split(/\,/g) : event;
+        for (var e = 0; e < events.length; e++) {
+            // Allows removal of middleware event handler using provided handlers.
+            var listeners = this.listeners[events[e]];
+            for (var i = 0; i < listeners.length; i++) {
+                if (listeners[i] === handler) {
+                    botkit.debug('Removing event handler for %s', events[e]);
+                    listeners.splice(i, 1);
+                    this.events[events[e]].splice(i, 1);
+                }
+            }
+        }
     };
 
     botkit.trigger = function(event, data) {
@@ -1232,7 +1258,6 @@ function Botkit(configuration) {
             botkit.my_version = PKG_VERSION;
         }
         return botkit.my_version;
-
     };
 
 


### PR DESCRIPTION
A removeListener function that lets the API user provide the
function they're using to handle .hears and .on events in a way
that lets them remove that event without needing to dive into
the underlying mechanisms in CoreBot.