### PR TITLE
Refactor handling of incoming messages from webhooks

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -3,7 +3,7 @@
     "disallowKeywords": ["with"],
     "disallowMultipleLineBreaks": null,
     "disallowMultipleVarDecl": null,
-    "maximumLineLength": 120,
+    "maximumLineLength": 180,
     "disallowSpacesInsideObjectBrackets": null,
     "requireCamelCaseOrUpperCaseIdentifiers": null,
     "requireCurlyBraces": null,

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -185,7 +185,7 @@ function Facebookbot(configuration) {
 
             cb();
         };
-        
+
         // Setup a handler to set the payload for Get Started button
         bot.setGetStartedPayload = function(get_started_payload, cb) {
             get_started_message = {
@@ -225,7 +225,7 @@ function Facebookbot(configuration) {
                         cb && cb(null, body);
                     });
         }
-        
+
         // Setup a handler to delete the payload for Get Started button
         bot.deleteGetStartedPayload = function(cb) {
                     delete_get_started_message = {
@@ -258,7 +258,7 @@ function Facebookbot(configuration) {
                                 cb && cb(null, body);
                             });
         }
-        
+
         return bot;
 
     });
@@ -272,103 +272,12 @@ function Facebookbot(configuration) {
             '** Serving webhook endpoints for Messenger Platform at: ' +
             'http://' + facebook_botkit.config.hostname + ':' + facebook_botkit.config.port + '/facebook/receive');
         webserver.post('/facebook/receive', function(req, res) {
-
             facebook_botkit.debug('GOT A MESSAGE HOOK');
-            var obj = req.body;
-            if (obj.entry) {
-                for (var e = 0; e < obj.entry.length; e++) {
-                    for (var m = 0; m < obj.entry[e].messaging.length; m++) {
-                        var facebook_message = obj.entry[e].messaging[m];
-                        if (facebook_message.message) {
-                            var message = {
-                                text: facebook_message.message.text,
-                                user: facebook_message.sender.id,
-                                channel: facebook_message.sender.id,
-                                timestamp: facebook_message.timestamp,
-                                seq: facebook_message.message.seq,
-                                is_echo: facebook_message.message.is_echo,
-                                mid: facebook_message.message.mid,
-                                sticker_id: facebook_message.message.sticker_id,
-                                attachments: facebook_message.message.attachments,
-                                quick_reply: facebook_message.message.quick_reply,
-                                type: 'user_message',
-                            };
-
-                            facebook_botkit.receiveMessage(bot, message);
-                        } else if (facebook_message.postback) {
-
-                            // trigger BOTH a facebook_postback event
-                            // and a normal message received event.
-                            // this allows developers to receive postbacks as part of a conversation.
-                            var message = {
-                                payload: facebook_message.postback.payload,
-                                user: facebook_message.sender.id,
-                                channel: facebook_message.sender.id,
-                                timestamp: facebook_message.timestamp,
-                            };
-
-                            facebook_botkit.trigger('facebook_postback', [bot, message]);
-
-                            var message = {
-                                text: facebook_message.postback.payload,
-                                user: facebook_message.sender.id,
-                                channel: facebook_message.sender.id,
-                                timestamp: facebook_message.timestamp,
-                                type: 'facebook_postback',
-                            };
-
-                            facebook_botkit.receiveMessage(bot, message);
-
-                        } else if (facebook_message.optin) {
-
-                            var message = {
-                                optin: facebook_message.optin,
-                                user: facebook_message.sender.id,
-                                channel: facebook_message.sender.id,
-                                timestamp: facebook_message.timestamp,
-                            };
-
-                            facebook_botkit.trigger('facebook_optin', [bot, message]);
-                        } else if (facebook_message.delivery) {
-
-                            var message = {
-                                optin: facebook_message.delivery,
-                                user: facebook_message.sender.id,
-                                channel: facebook_message.sender.id,
-                                timestamp: facebook_message.timestamp,
-                            };
-
-                            facebook_botkit.trigger('message_delivered', [bot, message]);
-                        } else if (facebook_message.read) {
-
-                            var message = {
-                                optin: facebook_message.read,
-                                user: facebook_message.sender.id,
-                                channel: facebook_message.sender.id,
-                                timestamp: facebook_message.timestamp,
-                            };
-
-                            facebook_botkit.trigger('message_read', [bot, message]);
-                        } else if (facebook_message.referral) {
-                          var message = {
-                              user: facebook_message.sender.id,
-                              channel: facebook_message.sender.id,
-                              timestamp: facebook_message.timestamp,
-                              referral: facebook_message.referral,
-                          };
-
-                          facebook_botkit.trigger('facebook_referral', [bot, message]);
-                        }  else {
-                            facebook_botkit.log('Got an unexpected message from Facebook: ', facebook_message);
-                        }
-                    }
-                }
-            }
             res.send('ok');
+            facebook_botkit.handleWebhookPayload(req, res, bot);
         });
 
         webserver.get('/facebook/receive', function(req, res) {
-            console.log(req.query);
             if (req.query['hub.mode'] == 'subscribe') {
                 if (req.query['hub.verify_token'] == configuration.verify_token) {
                     res.send(req.query['hub.challenge']);
@@ -384,6 +293,100 @@ function Facebookbot(configuration) {
 
         return facebook_botkit;
     };
+
+    facebook_botkit.handleWebhookPayload = function(req, res, bot) {
+
+        var obj = req.body;
+        if (obj.entry) {
+            for (var e = 0; e < obj.entry.length; e++) {
+                for (var m = 0; m < obj.entry[e].messaging.length; m++) {
+                    var facebook_message = obj.entry[e].messaging[m];
+                    if (facebook_message.message) {
+                        var message = {
+                            text: facebook_message.message.text,
+                            user: facebook_message.sender.id,
+                            channel: facebook_message.sender.id,
+                            timestamp: facebook_message.timestamp,
+                            seq: facebook_message.message.seq,
+                            is_echo: facebook_message.message.is_echo,
+                            mid: facebook_message.message.mid,
+                            sticker_id: facebook_message.message.sticker_id,
+                            attachments: facebook_message.message.attachments,
+                            quick_reply: facebook_message.message.quick_reply,
+                            type: 'user_message',
+                        };
+
+                        facebook_botkit.receiveMessage(bot, message);
+                    } else if (facebook_message.postback) {
+
+                        // trigger BOTH a facebook_postback event
+                        // and a normal message received event.
+                        // this allows developers to receive postbacks as part of a conversation.
+                        var message = {
+                            payload: facebook_message.postback.payload,
+                            user: facebook_message.sender.id,
+                            channel: facebook_message.sender.id,
+                            timestamp: facebook_message.timestamp,
+                        };
+
+                        facebook_botkit.trigger('facebook_postback', [bot, message]);
+
+                        var message = {
+                            text: facebook_message.postback.payload,
+                            user: facebook_message.sender.id,
+                            channel: facebook_message.sender.id,
+                            timestamp: facebook_message.timestamp,
+                            type: 'facebook_postback',
+                        };
+
+                        facebook_botkit.receiveMessage(bot, message);
+
+                    } else if (facebook_message.optin) {
+
+                        var message = {
+                            optin: facebook_message.optin,
+                            user: facebook_message.sender.id,
+                            channel: facebook_message.sender.id,
+                            timestamp: facebook_message.timestamp,
+                        };
+
+                        facebook_botkit.trigger('facebook_optin', [bot, message]);
+                    } else if (facebook_message.delivery) {
+
+                        var message = {
+                            optin: facebook_message.delivery,
+                            user: facebook_message.sender.id,
+                            channel: facebook_message.sender.id,
+                            timestamp: facebook_message.timestamp,
+                        };
+
+                        facebook_botkit.trigger('message_delivered', [bot, message]);
+                    } else if (facebook_message.read) {
+
+                        var message = {
+                            optin: facebook_message.read,
+                            user: facebook_message.sender.id,
+                            channel: facebook_message.sender.id,
+                            timestamp: facebook_message.timestamp,
+                        };
+
+                        facebook_botkit.trigger('message_read', [bot, message]);
+                    } else if (facebook_message.referral) {
+                      var message = {
+                          user: facebook_message.sender.id,
+                          channel: facebook_message.sender.id,
+                          timestamp: facebook_message.timestamp,
+                          referral: facebook_message.referral,
+                      };
+
+                      facebook_botkit.trigger('facebook_referral', [bot, message]);
+                    }  else {
+                        facebook_botkit.log('Got an unexpected message from Facebook: ', facebook_message);
+                    }
+                }
+            }
+        }
+    }
 
     facebook_botkit.setupWebserver = function(port, cb) {
 

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -276,6 +276,7 @@ function Facebookbot(configuration) {
                         // and a normal message received event.
                         // this allows developers to receive postbacks as part of a conversation.
                         var message = {
+                            text: facebook_message.postback.payload,
                             payload: facebook_message.postback.payload,
                             user: facebook_message.sender.id,
                             channel: facebook_message.sender.id,
@@ -284,15 +285,17 @@ function Facebookbot(configuration) {
 
                         facebook_botkit.trigger('facebook_postback', [bot, message]);
 
-                        var message = {
-                            text: facebook_message.postback.payload,
-                            user: facebook_message.sender.id,
-                            channel: facebook_message.sender.id,
-                            timestamp: facebook_message.timestamp,
-                            type: 'facebook_postback',
-                        };
+                        if (facebook_botkit.config.receive_via_postback) {
+                            var message = {
+                                text: facebook_message.postback.payload,
+                                user: facebook_message.sender.id,
+                                channel: facebook_message.sender.id,
+                                timestamp: facebook_message.timestamp,
+                                type: 'facebook_postback',
+                            };
 
-                        facebook_botkit.receiveMessage(bot, message);
+                            facebook_botkit.receiveMessage(bot, message);
+                        }
 
                     } else if (facebook_message.optin) {
 
@@ -307,17 +310,16 @@ function Facebookbot(configuration) {
                     } else if (facebook_message.delivery) {
 
                         var message = {
-                            optin: facebook_message.delivery,
+                            delivery: facebook_message.delivery,
                             user: facebook_message.sender.id,
                             channel: facebook_message.sender.id,
-                            timestamp: facebook_message.timestamp,
                         };
 
                         facebook_botkit.trigger('message_delivered', [bot, message]);
                     } else if (facebook_message.read) {
 
                         var message = {
-                            optin: facebook_message.read,
+                            read: facebook_message.read,
                             user: facebook_message.sender.id,
                             channel: facebook_message.sender.id,
                             timestamp: facebook_message.timestamp,
@@ -325,14 +327,14 @@ function Facebookbot(configuration) {
 
                         facebook_botkit.trigger('message_read', [bot, message]);
                     } else if (facebook_message.referral) {
-                      var message = {
-                          user: facebook_message.sender.id,
-                          channel: facebook_message.sender.id,
-                          timestamp: facebook_message.timestamp,
-                          referral: facebook_message.referral,
-                      };
+                        var message = {
+                            user: facebook_message.sender.id,
+                            channel: facebook_message.sender.id,
+                            timestamp: facebook_message.timestamp,
+                            referral: facebook_message.referral,
+                        };
 
-                      facebook_botkit.trigger('facebook_referral', [bot, message]);
+                        facebook_botkit.trigger('facebook_referral', [bot, message]);
                     }  else {
                         facebook_botkit.log('Got an unexpected message from Facebook: ', facebook_message);
                     }

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -341,7 +341,7 @@ function Facebookbot(configuration) {
                 }
             }
         }
-    }
+    };
 
     facebook_botkit.setupWebserver = function(port, cb) {
 

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -157,7 +157,7 @@ function Slackbot(configuration) {
         var team_id = payload.team_id || (payload.team && payload.team.id) || null;
         slack_botkit.findTeamById(team_id, function(err, team) {
             if (err) {
-                slack_botkit.log.error('Could not load team while processing webhook: ',err);
+                slack_botkit.log.error('Could not load team while processing webhook: ', err);
                 return;
             } else if (!team) {
                 // if this is NOT a slack app, it is ok to spawn a generic bot
@@ -184,19 +184,18 @@ function Slackbot(configuration) {
             if (payload.type === 'event_callback') {
                 // Receive messages and trigger events from the Events API
                 return handleEventsAPI(payload, bot);
-            } else if (req.body.payload) {
+            } else if (payload.payload) {
                 // is this an interactive message callback?
                 res.send('');
                 return handleInteractiveMessage(payload, bot);
-            } else if (req.body.command) {
+            } else if (payload.command) {
                 // this is a slash command
-                return handleSlashCommand(req,res);
-            } else if (req.body.trigger_word) {
-                return handleOutgoingWebhook(req,res);
+                return handleSlashCommand(payload, bot);
+            } else if (payload.trigger_word) {
+                return handleOutgoingWebhook(payload, bot);
             }
         });
-
-    }
+    };
 
     /* Handler functions for the various ways Slack might send a message to
      * Botkit via webhooks.  These include interactive messages (button clicks),
@@ -255,79 +254,28 @@ function Slackbot(configuration) {
         }
     };
 
-    function handleSlashCommand(req, res) {
+    function handleSlashCommand(payload, bot) {
         var message = {};
 
-        for (var key in req.body) {
-            message[key] = req.body[key];
+        for (var key in payload) {
+            message[key] = payload[key];
         }
 
         // let's normalize some of these fields to match the rtm message format
         message.user = message.user_id;
         message.channel = message.channel_id;
 
-        // Is this configured to use Slackbutton?
-        // If so, validate this team before triggering the event!
-        // Otherwise, it's ok to just pass a generic bot in
-        if (slack_botkit.config.clientId && slack_botkit.config.clientSecret) {
+        message.type = 'slash_command';
 
-            slack_botkit.findTeamById(message.team_id, function(err, team) {
-                if (err || !team) {
-                    slack_botkit.log.error('Received slash command, but could not load team');
-                } else {
-                    message.type = 'slash_command';
-                    // HEY THERE
-                    // Slash commands can actually just send back a response
-                    // and have it displayed privately. That means
-                    // the callback needs access to the res object
-                    // to send an optional response.
-
-                    res.status(200);
-
-                    var bot = slack_botkit.spawn(team);
-
-                    bot.team_info = team;
-                    bot.res = res;
-
-                    slack_botkit.receiveMessage(bot, message);
-
-                }
-            });
-        } else {
-
-            message.type = 'slash_command';
-            // HEY THERE
-            // Slash commands can actually just send back a response
-            // and have it displayed privately. That means
-            // the callback needs access to the res object
-            // to send an optional response.
-
-            var team = {
-                id: message.team_id,
-            };
-
-            res.status(200);
-
-            var bot = slack_botkit.spawn({});
-
-            bot.team_info = team;
-            bot.res = res;
-
-            slack_botkit.receiveMessage(bot, message);
-
-        }
+        slack_botkit.receiveMessage(bot, message);
     }
-    function handleOutgoingWebhook(req, res) {
+
+    function handleOutgoingWebhook(payload, bot) {
         var message = {};
 
-        for (var key in req.body) {
-            message[key] = req.body[key];
+        for (var key in payload) {
+            message[key] = payload[key];
         }
-
-
-        var team = {
-            id: message.team_id,
-        };
 
         // let's normalize some of these fields to match the rtm message format
         message.user = message.user_id;
@@ -335,18 +283,7 @@ function Slackbot(configuration) {
 
         message.type = 'outgoing_webhook';
 
-        res.status(200);
-
-        var bot = slack_botkit.spawn(team);
-        bot.res = res;
-        bot.team_info = team;
-
-
         slack_botkit.receiveMessage(bot, message);
-
-        // outgoing webhooks are also different. They can simply return
-        // a response instead of using the API to reply.  Maybe this is
-        // a different type of event!!
     };
 
     /* End of webhook handler functions

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -155,7 +155,6 @@ function Slackbot(configuration) {
             payload = JSON.parse(payload.payload);
         }
         var team_id = payload.team_id || (payload.team && payload.team.id) || null;
-        console.log(payload);
         slack_botkit.findTeamById(team_id, function(err, team) {
             if (err) {
                 slack_botkit.log.error('Could not load team while processing webhook: ',err);
@@ -249,7 +248,6 @@ function Slackbot(configuration) {
             return;
         } else {
             if (message.type === 'message') {
-                console.log('receiving message ', message);
                 slack_botkit.receiveMessage(bot, message);
             } else {
                 slack_botkit.trigger(message.type, [bot, message]);

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -133,32 +133,37 @@ function Slackbot(configuration) {
             'webhooks at: http://' + slack_botkit.config.hostname + ':' + slack_botkit.config.port + '/slack/receive');
         webserver.post('/slack/receive', function(req, res) {
 
-            // is this an events api url handshake?
-            if (req.body.type === 'url_verification') {
-                slack_botkit.debug('Received url handshake');
-                res.status(200).json({ challenge: req.body.challenge });
-                return;
-            }
-
-
-
-            if (req.body.type === 'event_callback') {
-                // Receive messages and trigger events from the Events API
-                return handleEventsAPI(req, res);
-            } else if (req.body.payload) {
-                // is this an interactive message callback?
-                return handleInteractiveMessage(req,res);
-            } else if (req.body.command) {
-                // this is a slash command
-                return handleSlashCommand(req,res);
-            } else if (req.body.trigger_word) {
-                return handleOutgoingWebhook(req,res);
-            }
+            slack_botkit.handleWebhookPayload(req, res);
 
         });
 
         return slack_botkit;
     };
+
+    slack_botkit.handleWebhookPayload = function(req, res) {
+
+        // is this an events api url handshake?
+        if (req.body.type === 'url_verification') {
+            slack_botkit.debug('Received url handshake');
+            res.status(200).json({ challenge: req.body.challenge });
+            return;
+        }
+
+        if (req.body.type === 'event_callback') {
+            // Receive messages and trigger events from the Events API
+            return handleEventsAPI(req, res);
+        } else if (req.body.payload) {
+            // is this an interactive message callback?
+            return handleInteractiveMessage(req,res);
+        } else if (req.body.command) {
+            // this is a slash command
+            return handleSlashCommand(req,res);
+        } else if (req.body.trigger_word) {
+            return handleOutgoingWebhook(req,res);
+        }
+
+
+    }
 
     /* Handler functions for the various ways Slack might send a message to
      * Botkit via webhooks.  These include interactive messages (button clicks),

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -130,6 +130,10 @@ function Slackbot(configuration) {
             'webhooks at: http://' + slack_botkit.config.hostname + ':' + slack_botkit.config.port + '/slack/receive');
         webserver.post('/slack/receive', function(req, res) {
 
+            // respond to Slack that the webhook has been received.
+            res.status(200);
+
+            // Now, pass the webhook into be processed
             slack_botkit.handleWebhookPayload(req, res);
 
         });
@@ -142,23 +146,56 @@ function Slackbot(configuration) {
         // is this an events api url handshake?
         if (req.body.type === 'url_verification') {
             slack_botkit.debug('Received url handshake');
-            res.status(200).json({ challenge: req.body.challenge });
+            res.json({ challenge: req.body.challenge });
             return;
         }
 
-        if (req.body.type === 'event_callback') {
-            // Receive messages and trigger events from the Events API
-            return handleEventsAPI(req, res);
-        } else if (req.body.payload) {
-            // is this an interactive message callback?
-            return handleInteractiveMessage(req,res);
-        } else if (req.body.command) {
-            // this is a slash command
-            return handleSlashCommand(req,res);
-        } else if (req.body.trigger_word) {
-            return handleOutgoingWebhook(req,res);
+        var payload = req.body;
+        if (payload.payload) {
+            payload = JSON.parse(payload.payload);
         }
+        var team_id = payload.team_id || (payload.team && payload.team.id) || null;
+        console.log(payload);
+        slack_botkit.findTeamById(team_id, function(err, team) {
+            if (err) {
+                slack_botkit.log.error('Could not load team while processing webhook: ',err);
+                return;
+            } else if (!team) {
+                // if this is NOT a slack app, it is ok to spawn a generic bot
+                // this is only likely to happen with custom slash commands
+                if (!slack_botkit.config.clientId) {
+                    bot = slack_botkit.spawn({});
+                } else {
+                    return;
+                }
+            } else {
+                // spawn a bot
+                bot = slack_botkit.spawn(team);
 
+                // Identify the bot from either team storage or identifyBot()
+                bot.team_info = team;
+                bot.identity = {
+                    id: team.bot.user_id,
+                    name: team.bot.name
+                };
+            }
+
+            bot.res = res;
+
+            if (payload.type === 'event_callback') {
+                // Receive messages and trigger events from the Events API
+                return handleEventsAPI(payload, bot);
+            } else if (req.body.payload) {
+                // is this an interactive message callback?
+                res.send('');
+                return handleInteractiveMessage(payload, bot);
+            } else if (req.body.command) {
+                // this is a slash command
+                return handleSlashCommand(req,res);
+            } else if (req.body.trigger_word) {
+                return handleOutgoingWebhook(req,res);
+            }
+        });
 
     }
 
@@ -167,10 +204,11 @@ function Slackbot(configuration) {
      * events api (messages sent over web hook), slash commands, and outgoing webhooks
      * (patterns matched in slack that result in a webhook)
      */
-    function handleInteractiveMessage(req, res) {
-        var message = JSON.parse(req.body.payload);
-        for (var key in req.body) {
-            message[key] = req.body[key];
+    function handleInteractiveMessage(payload, bot) {
+
+        var message = {};
+        for (var key in payload) {
+            message[key] = payload[key];
         }
 
         // let's normalize some of these fields to match the rtm message format
@@ -183,71 +221,42 @@ function Slackbot(configuration) {
 
         message.type = 'interactive_message_callback';
 
-        slack_botkit.findTeamById(message.team.id, function(err, team) {
-            if (err || !team) {
-                slack_botkit.log.error('Received interactive message, but could not load team');
-            } else {
-                res.status(200);
-                res.send('');
+        slack_botkit.trigger('interactive_message_callback', [bot, message]);
 
-                var bot = slack_botkit.spawn(team);
-
-                bot.team_info = team;
-                bot.res = res;
-
-                slack_botkit.trigger('interactive_message_callback', [bot, message]);
-
-                if (configuration.interactive_replies) {
-                    message.type = 'message';
-                    slack_botkit.receiveMessage(bot, message);
-                }
-            }
-        });
+        if (configuration.interactive_replies) {
+            message.type = 'message';
+            slack_botkit.receiveMessage(bot, message);
+        }
     }
-    function handleEventsAPI(req, res) {
-        // respond to events api with a 200
-        res.sendStatus(200);
+
+    function handleEventsAPI(payload, bot) {
 
         var message = {};
-        for (var key in req.body.event) {
-            message[key] = req.body.event[key];
+        for (var key in payload.event) {
+            message[key] = payload.event[key];
         }
 
         // let's normalize some of these fields to match the rtm message format
-        message.team = req.body.team_id;
+        message.team = payload.team_id;
         message.events_api = true;
-        message.authed_users = req.body.authed_users;
+        message.authed_users = payload.authed_users;
 
-        slack_botkit.findTeamById(message.team, function(err, team) {
-            if (err || !team) {
-                slack_botkit.log.error('Received Events API message, but could not load team:', err);
-                return;
+        if (bot.identity == undefined || bot.identity.id == null) {
+            slack_botkit.log.error('Could not identify bot');
+            return;
+        } else if (bot.identity.id === message.user) {
+            slack_botkit.debug('Got event from this bot user, ignoring it');
+            return;
+        } else {
+            if (message.type === 'message') {
+                console.log('receiving message ', message);
+                slack_botkit.receiveMessage(bot, message);
             } else {
-                var bot = slack_botkit.spawn(team);
-                // Identify the bot from either team storage or identifyBot()
-                bot.team_info = team;
-                bot.identity = {
-                    id: team.bot.user_id,
-                    name: team.bot.name
-                };
-
-                if (team.bot.user_id === req.body.event.user) {
-                    slack_botkit.debug('Got event from this bot user, ignoring it');
-                    return;
-                }
-                if (bot.identity == undefined || bot.identity.id == null) {
-                    slack_botkit.log.error('Could not identify bot');
-                    return;
-                } else {
-                    if (req.body.event.type === 'message') {
-                        slack_botkit.receiveMessage(bot, message);
-                    } else {
-                        slack_botkit.trigger(message.type, [bot, message]);
-                    }
-                }
+                slack_botkit.trigger(message.type, [bot, message]);
             }
-        });
+        }
     };
+
     function handleSlashCommand(req, res) {
         var message = {};
 

--- a/lib/TwilioIPMBot.js
+++ b/lib/TwilioIPMBot.js
@@ -264,8 +264,7 @@ function Twiliobot(configuration) {
         } else {
             twilio_botkit.trigger(req.body.EventType, [bot, message]);
         }
-
-    }
+    };
 
     // handle events here
     twilio_botkit.handleTwilioEvents = function() {

--- a/lib/TwilioIPMBot.js
+++ b/lib/TwilioIPMBot.js
@@ -211,50 +211,10 @@ function Twiliobot(configuration) {
             'webhooks at: http://' + twilio_botkit.config.hostname + ':' +
                 twilio_botkit.config.port + '/twilio/receive');
         webserver.post('/twilio/receive', function(req, res) {
-            // ensure all messages
-            // have a user & channel
-            var message = req.body;
-            if (req.body.EventType == 'onMessageSent') {
-
-                // customize fields to be compatible with Botkit
-                message.text = req.body.Body;
-                message.from = req.body.From;
-                message.to = req.body.To;
-                message.user = req.body.From;
-                message.channel = req.body.ChannelSid;
-
-                twilio_botkit.receiveMessage(bot, message);
-
-            }else if (req.body.EventType == 'onChannelAdded' || req.body.EventType == 'onChannelAdd') {
-                // this event has a channel sid but not a user
-                message.channel = req.body.ChannelSid;
-                twilio_botkit.trigger(req.body.EventType, [bot, message]);
-
-            }else if (req.body.EventType == 'onChannelDestroyed' || req.body.EventType == 'onChannelDestroy') {
-                // this event has a channel sid but not a user
-                message.channel = req.body.ChannelSid;
-                twilio_botkit.trigger(req.body.EventType, [bot, message]);
-
-            }else if (req.body.EventType == 'onMemberAdded' || req.body.EventType == 'onMemberAdd') {
-                // should user be MemberSid the The Member Sid of the newly added Member
-                message.user = req.body.Identity;
-                message.channel = req.body.ChannelSid;
-                twilio_botkit.trigger(req.body.EventType, [bot, message]);
-            } else if (req.body.EventType == 'onMemberRemoved' || req.body.EventType == 'onMemberRemove') {
-                message.user = req.body.Identity;
-                message.channel = req.body.ChannelSid;
-                twilio_botkit.trigger(req.body.EventType, [bot, message]);
-
-                if (req.body.EventType == 'onMemberRemoved') {
-
-                }
-            } else {
-                twilio_botkit.trigger(req.body.EventType, [bot, message]);
-            }
 
             res.status(200);
             res.send('ok');
-
+            twilio_botkit.handleWebhookPayload(req, res, bot);
 
         });
 
@@ -263,7 +223,49 @@ function Twiliobot(configuration) {
         return twilio_botkit;
     };
 
+    twilio_botkit.handleWebhookPayload = function(req, res, bot) {
+        // ensure all messages
+        // have a user & channel
+        var message = req.body;
+        if (req.body.EventType == 'onMessageSent') {
 
+            // customize fields to be compatible with Botkit
+            message.text = req.body.Body;
+            message.from = req.body.From;
+            message.to = req.body.To;
+            message.user = req.body.From;
+            message.channel = req.body.ChannelSid;
+
+            twilio_botkit.receiveMessage(bot, message);
+
+        }else if (req.body.EventType == 'onChannelAdded' || req.body.EventType == 'onChannelAdd') {
+            // this event has a channel sid but not a user
+            message.channel = req.body.ChannelSid;
+            twilio_botkit.trigger(req.body.EventType, [bot, message]);
+
+        }else if (req.body.EventType == 'onChannelDestroyed' || req.body.EventType == 'onChannelDestroy') {
+            // this event has a channel sid but not a user
+            message.channel = req.body.ChannelSid;
+            twilio_botkit.trigger(req.body.EventType, [bot, message]);
+
+        }else if (req.body.EventType == 'onMemberAdded' || req.body.EventType == 'onMemberAdd') {
+            // should user be MemberSid the The Member Sid of the newly added Member
+            message.user = req.body.Identity;
+            message.channel = req.body.ChannelSid;
+            twilio_botkit.trigger(req.body.EventType, [bot, message]);
+        } else if (req.body.EventType == 'onMemberRemoved' || req.body.EventType == 'onMemberRemove') {
+            message.user = req.body.Identity;
+            message.channel = req.body.ChannelSid;
+            twilio_botkit.trigger(req.body.EventType, [bot, message]);
+
+            if (req.body.EventType == 'onMemberRemoved') {
+
+            }
+        } else {
+            twilio_botkit.trigger(req.body.EventType, [bot, message]);
+        }
+
+    }
 
     // handle events here
     twilio_botkit.handleTwilioEvents = function() {


### PR DESCRIPTION
The goal of this PR is to normalize the way messages flow from incoming webhooks sent by the messaging platforms into botkit-style messages.

I do not intend to change the way these actually work, just to normalize the interfaces that are presented to make it easier for developers who want to integrate Botkit into existing web apps in different ways.

The result should be that devs who want to write their own webhook endpoint can call controller.handleWebhookPayload() and Botkit will handle all the rest.