### PR TITLE
DDOS Vulnerability Fix - Secure Facebook Webhook

### DIFF
--- a/facebook_bot.js
+++ b/facebook_bot.js
@@ -76,6 +76,10 @@ if (!process.env.verify_token) {
     process.exit(1);
 }
 
+if (!process.env.app_secret) {
+    console.log('Error: Specify app_secret in environment');
+}
+
 var Botkit = require('./lib/Botkit.js');
 var os = require('os');
 var commandLineArgs = require('command-line-args');
@@ -99,6 +103,7 @@ var controller = Botkit.facebookbot({
     log: true,
     access_token: process.env.page_token,
     verify_token: process.env.verify_token,
+    app_secret: process.env.app_secret
     validate_requests: true, // Refuse any requests that don't come from FB on your receive webhook, must provide FB_APP_SECRET in environment variables
 });
 

--- a/facebook_bot.js
+++ b/facebook_bot.js
@@ -78,6 +78,7 @@ if (!process.env.verify_token) {
 
 if (!process.env.app_secret) {
     console.log('Error: Specify app_secret in environment');
+    process.exit(1);
 }
 
 var Botkit = require('./lib/Botkit.js');

--- a/facebook_bot.js
+++ b/facebook_bot.js
@@ -99,6 +99,7 @@ var controller = Botkit.facebookbot({
     log: true,
     access_token: process.env.page_token,
     verify_token: process.env.verify_token,
+    validate_requests: true, // Refuse any requests that don't come from FB on your receive webhook, must provide FB_APP_SECRET in environment variables
 });
 
 var bot = controller.spawn({

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -231,8 +231,6 @@ function Facebookbot(configuration) {
             '** Serving webhook endpoints for Messenger Platform at: ' +
             'http://' + facebook_botkit.config.hostname + ':' + facebook_botkit.config.port + '/facebook/receive');
 
-        webserver.post(bodyParser.json({verify: verifyRequest}))
-        webserver.post(abortOnError)
         webserver.post('/facebook/receive', function(req, res) {
 
             facebook_botkit.debug('GOT A MESSAGE HOOK');
@@ -339,7 +337,9 @@ function Facebookbot(configuration) {
                     res.send('OK');
                 }
             }
+
         });
+
 
         if (cb) {
             cb();
@@ -362,9 +362,19 @@ function Facebookbot(configuration) {
         facebook_botkit.config.port = port;
 
         facebook_botkit.webserver = express();
+
+        // Validate that requests come from facebook, and abort on validation errors
+        if (facebook_botkit.config.validate_requests === true) {
+            // Load verify middleware just for post route on our receive webhook, and catch any errors it might throw to prevent the request from being parsed further.
+            facebook_botkit.webserver.post('/facebook/receive', bodyParser.json({verify: verifyRequest}))
+            facebook_botkit.webserver.use(abortOnValidationError)
+        }
+
         facebook_botkit.webserver.use(bodyParser.json());
         facebook_botkit.webserver.use(bodyParser.urlencoded({ extended: true }));
         facebook_botkit.webserver.use(express.static(static_dir));
+
+
 
         var server = facebook_botkit.webserver.listen(
             facebook_botkit.config.port,
@@ -482,34 +492,37 @@ function Facebookbot(configuration) {
         }
     };
 
+    // Verifies the SHA1 signature of the raw request payload before bodyParser parses it
+    // Will abort parsing if signature is invalid, and pass a generic error to response
+    function verifyRequest(req, res, buf, encoding) {
+      var expected = req.headers['x-hub-signature'];
+      var calculated = getSignature(buf);
+      if (expected !== calculated) {
+        throw new Error("Invalid signature on incoming request");
+      } else {
+        facebook_botkit.debug('** X-Hub Verification successful!')
+      }
+    }
+
+    function getSignature(buf) {
+      var hmac = crypto.createHmac("sha1", process.env.fb_app_secret);
+      hmac.update(buf, "utf-8");
+      return "sha1=" + hmac.digest("hex");
+    }
+
+    function abortOnValidationError(err, req, res, next) {
+      if (err) {
+        facebook_botkit.log('** Invalid X-HUB signature on incoming request!')
+        facebook_botkit.debug('** X-HUB Validation Error:', err)
+        res.status(400).send({ error: "Invalid signature." });
+      } else {
+        next();
+      }
+    }
+
     return facebook_botkit;
 };
 
-function verifyRequest(req, res, buf, encoding) {
-  var expected = req.headers['x-hub-signature'];
-  var calculated = getSignature(buf);
-  console.log("X-Hub-Signature:", expected, "Content:", "-" + buf.toString('utf8') + "-");
-  if (expected !== calculated) {
-    throw new Error("Invalid signature on incoming request");
-  } else {
-    facebook_botkit.debug('** X-Hub Verification successful!')
-  }
-}
 
-function getSignature(buf) {
-  var hmac = crypto.createHmac("sha1", process.env.FB_APP_SECRET);
-  hmac.update(buf, "utf-8");
-  return "sha1=" + hmac.digest("hex");
-}
-
-function abortOnError(err, req, res, next) {
-  if (err) {
-    facebook_botkit.log('** Invalid X-HUB signature on incoming request!')
-    facebook_botkit.debug('** X-HUB Validation Error:', err)
-    res.status(400).send({ error: "Invalid signature." });
-  } else {
-    next();
-  }
-}
 
 module.exports = Facebookbot;

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -2,6 +2,10 @@ var Botkit = require(__dirname + '/CoreBot.js');
 var request = require('request');
 var express = require('express');
 var bodyParser = require('body-parser');
+var crypto = require('crypto')
+
+
+
 
 function Facebookbot(configuration) {
 
@@ -226,6 +230,9 @@ function Facebookbot(configuration) {
         facebook_botkit.log(
             '** Serving webhook endpoints for Messenger Platform at: ' +
             'http://' + facebook_botkit.config.hostname + ':' + facebook_botkit.config.port + '/facebook/receive');
+
+        webserver.post(bodyParser.json({verify: verifyRequest}))
+        webserver.post(abortOnError)
         webserver.post('/facebook/receive', function(req, res) {
 
             facebook_botkit.debug('GOT A MESSAGE HOOK');
@@ -477,5 +484,32 @@ function Facebookbot(configuration) {
 
     return facebook_botkit;
 };
+
+function verifyRequest(req, res, buf, encoding) {
+  var expected = req.headers['x-hub-signature'];
+  var calculated = getSignature(buf);
+  console.log("X-Hub-Signature:", expected, "Content:", "-" + buf.toString('utf8') + "-");
+  if (expected !== calculated) {
+    throw new Error("Invalid signature on incoming request");
+  } else {
+    facebook_botkit.debug('** X-Hub Verification successful!')
+  }
+}
+
+function getSignature(buf) {
+  var hmac = crypto.createHmac("sha1", process.env.FB_APP_SECRET);
+  hmac.update(buf, "utf-8");
+  return "sha1=" + hmac.digest("hex");
+}
+
+function abortOnError(err, req, res, next) {
+  if (err) {
+    facebook_botkit.log('** Invalid X-HUB signature on incoming request!')
+    facebook_botkit.debug('** X-HUB Validation Error:', err)
+    res.status(400).send({ error: "Invalid signature." });
+  } else {
+    next();
+  }
+}
 
 module.exports = Facebookbot;

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -4,9 +4,6 @@ var express = require('express');
 var bodyParser = require('body-parser');
 var crypto = require('crypto')
 
-
-
-
 function Facebookbot(configuration) {
 
     // Create a core botkit bot
@@ -230,7 +227,6 @@ function Facebookbot(configuration) {
         facebook_botkit.log(
             '** Serving webhook endpoints for Messenger Platform at: ' +
             'http://' + facebook_botkit.config.hostname + ':' + facebook_botkit.config.port + '/facebook/receive');
-
         webserver.post('/facebook/receive', function(req, res) {
 
             facebook_botkit.debug('GOT A MESSAGE HOOK');
@@ -337,9 +333,7 @@ function Facebookbot(configuration) {
                     res.send('OK');
                 }
             }
-
         });
-
 
         if (cb) {
             cb();
@@ -373,8 +367,6 @@ function Facebookbot(configuration) {
         facebook_botkit.webserver.use(bodyParser.json());
         facebook_botkit.webserver.use(bodyParser.urlencoded({ extended: true }));
         facebook_botkit.webserver.use(express.static(static_dir));
-
-
 
         var server = facebook_botkit.webserver.listen(
             facebook_botkit.config.port,
@@ -522,7 +514,5 @@ function Facebookbot(configuration) {
 
     return facebook_botkit;
 };
-
-
 
 module.exports = Facebookbot;

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -497,7 +497,7 @@ function Facebookbot(configuration) {
     }
 
     function getSignature(buf) {
-      var hmac = crypto.createHmac("sha1", process.env.fb_app_secret);
+      var hmac = crypto.createHmac("sha1", facebook_botkit.config.app_secret);
       hmac.update(buf, "utf-8");
       return "sha1=" + hmac.digest("hex");
     }

--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -55,10 +55,10 @@ Since Facebook delivers messages via web hook, your application must be availabl
 When you are ready to go live, consider [LetsEncrypt.org](http://letsencrypt.org), a _free_ SSL Certificate Signing Authority which can be used to secure your website very quickly. It is fabulous and we love it.
 
 ## Validate Requests - Secure your webhook!
-Facebook sends an X-HUB signature header with it's requests to your webhook. You can verify that the requests are coming from Facebook by enabling `validate_requests: true` when creating your bot controller. This checks the sha1 signature of the incoming payload against your Facebook App Secret (which is seperate from your webhook's verify_token). You must also pass your FB_APP_SECRET into your environment variables when running your bot.
+Facebook sends an X-HUB signature header with requests to your webhook. You can verify the requests are coming from Facebook by enabling `validate_requests: true` when creating your bot controller. This checks the sha1 signature of the incoming payload against your Facebook App Secret (which is seperate from your webhook's verify_token), preventing unauthorized access to your webhook. You must also pass your `fb_app_secret=` into your environment variables when running your bot.
 
 ```
-page_token=123455abcd verify_token=VerIfY-tOkEn fb_app_secret=abcdefg12345 node facebook_bot.js
+fb_app_secret=abcdefg12345 page_token=123455abcd verify_token=VerIfY-tOkEn node facebook_bot.js
 ```
 
  The Facebook App secret is available on the Overview page of your Facebook App's admin page. Click show to reveal it.

--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -55,10 +55,10 @@ Since Facebook delivers messages via web hook, your application must be availabl
 When you are ready to go live, consider [LetsEncrypt.org](http://letsencrypt.org), a _free_ SSL Certificate Signing Authority which can be used to secure your website very quickly. It is fabulous and we love it.
 
 ## Validate Requests - Secure your webhook!
-Facebook sends an X-HUB signature header with requests to your webhook. You can verify the requests are coming from Facebook by enabling `validate_requests: true` when creating your bot controller. This checks the sha1 signature of the incoming payload against your Facebook App Secret (which is seperate from your webhook's verify_token), preventing unauthorized access to your webhook. You must also pass your `fb_app_secret=` into your environment variables when running your bot.
+Facebook sends an X-HUB signature header with requests to your webhook. You can verify the requests are coming from Facebook by enabling `validate_requests: true` when creating your bot controller. This checks the sha1 signature of the incoming payload against your Facebook App Secret (which is seperate from your webhook's verify_token), preventing unauthorized access to your webhook. You must also pass your `app_secret` into your environment variables when running your bot.
 
 ```
-fb_app_secret=abcdefg12345 page_token=123455abcd verify_token=VerIfY-tOkEn node facebook_bot.js
+app_secret=abcdefg12345 page_token=123455abcd verify_token=VerIfY-tOkEn node facebook_bot.js
 ```
 
  The Facebook App secret is available on the Overview page of your Facebook App's admin page. Click show to reveal it.

--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -54,6 +54,15 @@ Since Facebook delivers messages via web hook, your application must be availabl
 
 When you are ready to go live, consider [LetsEncrypt.org](http://letsencrypt.org), a _free_ SSL Certificate Signing Authority which can be used to secure your website very quickly. It is fabulous and we love it.
 
+## Validate Requests - Secure your webhook!
+Facebook sends an X-HUB signature header with it's requests to your webhook. You can verify that the requests are coming from Facebook by enabling `validate_requests: true` when creating your bot controller. This checks the sha1 signature of the incoming payload against your Facebook App Secret (which is seperate from your webhook's verify_token). You must also pass your FB_APP_SECRET into your environment variables when running your bot.
+
+```
+page_token=123455abcd verify_token=VerIfY-tOkEn fb_app_secret=abcdefg12345 node facebook_bot.js
+```
+
+ The Facebook App secret is available on the Overview page of your Facebook App's admin page. Click show to reveal it.
+
 ## Facebook-specific Events
 
 Once connected to Facebook, bots receive a constant stream of events.

--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -57,11 +57,11 @@ When you are ready to go live, consider [LetsEncrypt.org](http://letsencrypt.org
 ## Validate Requests - Secure your webhook!
 Facebook sends an X-HUB signature header with requests to your webhook. You can verify the requests are coming from Facebook by enabling `validate_requests: true` when creating your bot controller. This checks the sha1 signature of the incoming payload against your Facebook App Secret (which is seperate from your webhook's verify_token), preventing unauthorized access to your webhook. You must also pass your `app_secret` into your environment variables when running your bot.
 
+The Facebook App secret is available on the Overview page of your Facebook App's admin page. Click show to reveal it.
+
 ```
 app_secret=abcdefg12345 page_token=123455abcd verify_token=VerIfY-tOkEn node facebook_bot.js
 ```
-
- The Facebook App secret is available on the Overview page of your Facebook App's admin page. Click show to reveal it.
 
 ## Facebook-specific Events
 


### PR DESCRIPTION
**Proposed Changes:** add express middleware to webhook POST route to validate incoming requests. Validate the X-HUB signature sent in headers against your Facebook App Secret. Throw an error to abort parsing requests that failed validation. The error is handled by an error handler which responds with a safe error to unvalidated requests. Relies on node's crypto lib. 

Configurable by passing `validate_requests: true, app_secret: your_app_secret` when creating your controller object.

When in production, this prevents an attacker from forcing your application to process huge arrays of requests or impersonate FB/users. FB batches its messages, and so a malicious server could make requests stuffed full of data that your bot would then iterate over, potentially locking the process. 
