### PR TITLE
Add users.setPresence to Slack API

### DIFF
--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -93,7 +93,8 @@ module.exports = function(bot, config) {
         'users.getPresence',
         'users.info',
         'users.list',
-        'users.setActive'
+        'users.setActive'.
+        'users.setPresence'
     ];
 
     /**

--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -93,7 +93,7 @@ module.exports = function(bot, config) {
         'users.getPresence',
         'users.info',
         'users.list',
-        'users.setActive'.
+        'users.setActive',
         'users.setPresence'
     ];
 


### PR DESCRIPTION
The users.setPresence method is currently missing from the Slack API. I'm not sure if there is a reason for this but I came across a need for it and figured I would submit a pull request (my first ever so be gentle).