### PR TITLE
Add custom api_host env variable

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -338,7 +338,8 @@ function Slackbot(configuration) {
     slack_botkit.getAuthorizeURL = function(team_id, redirect_params) {
 
         var scopes = slack_botkit.config.scopes;
-        var url = 'https://slack.com/oauth/authorize' + '?client_id=' +
+        var api_host = process.env.api_host ? process.env.api_host : 'slack.com';
+        var url = 'https://' + api_host + '/oauth/authorize' + '?client_id=' +
             slack_botkit.config.clientId + '&scope=' + scopes.join(',') + '&state=botkit';
 
         if (team_id)
@@ -381,8 +382,9 @@ function Slackbot(configuration) {
         }
 
         var call_api = function(command, options, cb) {
-            slack_botkit.log('** API CALL: ' + 'https://slack.com/api/' + command);
-            request.post('https://slack.com/api/' + command, function(error, response, body) {
+            var api_host = process.env.api_host ? process.env.api_host : 'slack.com';
+            slack_botkit.log('** API CALL: ' + 'https://' + api_host + '/api/' + command);
+            request.post('https://' + api_host + '/api/' + command, function(error, response, body) {
                 slack_botkit.debug('Got response', error, body);
                 if (!error && response.statusCode == 200) {
                     var json = JSON.parse(body);

--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -13,8 +13,9 @@ function noop() {}
  * @returns {Object} A callback-based Slack API interface.
  */
 module.exports = function(bot, config) {
+    var api_host = process.env.api_host ? process.env.api_host : 'slack.com';
     var slack_api = {
-        api_url: 'https://slack.com/api/'
+        api_url: 'https://' + api_host + '/api/'
     };
 
     // Slack API methods: https://api.slack.com/methods


### PR DESCRIPTION
Allows users to change default "slack.com" api host to any custom host via env variable.
Can be useful for various api proxies needed by different services.