### PR TITLE
adds createPrivateConversation to Slack bots

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -305,6 +305,16 @@ module.exports = function(botkit, config) {
         botkit.createConversation(this, message, cb);
     };
 
+    bot.createPrivateConversation = function(message, cb) {
+        bot.api.im.open({ user: message.user }, function(err, channel) {
+            if (err) return cb(err);
+
+            message.channel = channel.channel.id;
+
+            botkit.createConversation(bot, message, cb);
+        });
+    }
+
 
     /**
      * Convenience method for creating a DM convo.

--- a/readme.md
+++ b/readme.md
@@ -481,6 +481,17 @@ and the conversation will not collect responses until it is activated using [con
 
 Use `createConversation()` instead of `startConversation()` when you plan on creating more complex conversation structures using [threads](#conversation-threads) or [variables and templates](#using-variable-tokens-and-templates-in-conversation-threads) in your messages.
 
+#### bot.createPrivateConversation()
+| Argument | Description
+|---  |---
+| message   | message object containing {user: userId} of the user you would like to start a conversation with
+| callback  | a callback function in the form of function(err,conversation) { ... }
+
+`createPrivateConversation()` is a function that initiates a conversation with a specific user. Note function is currently *Slack-only!*
+
+Use `createPrivateConversation()` instead of `startPrivateConversation()` when you plan on creating more complex conversation structures using [threads](#conversation-threads) or [variables and templates](#using-variable-tokens-and-templates-in-conversation-threads) in your messages.
+
+
 ### Control Conversation Flow
 
 #### conversation.activate()


### PR DESCRIPTION
This adds a `createPrivateConversation` method for Slack bots so that complex private conversations can be made with threads, etc.

Closes #585 