### PR TITLE
Fix slackbutton_slashcommand example

### DIFF
--- a/examples/slackbutton_slashcommand.js
+++ b/examples/slackbutton_slashcommand.js
@@ -51,7 +51,7 @@ var controller = Botkit.slackbot({
 }).configureSlackApp({
     clientId: process.env.clientId,
     clientSecret: process.env.clientSecret,
-    scopes: ['commands'],
+    scopes: ['commands', 'bot'],
   });
 
 
@@ -72,6 +72,6 @@ controller.setupWebserver(process.env.port,function(err,webserver) {
 controller.on('slash_command',function(bot,message) {
 
   bot.replyPublic(message,'<@' + message.user + '> is cool!');
-  bot.replyPrivate(message,'*nudge nudge wink wink*');
+  bot.replyPrivateDelayed(message,'*nudge nudge wink wink*');
 
 });


### PR DESCRIPTION
The example seems to need 'bot' in its scopes (since it uses replyX?). See https://github.com/howdyai/botkit/issues/590.

Based on another example I think (?) you need to use replyXDelayed after the first replyX. Without this change the second reply does not work and prints `Can't set headers after they are sent.` Error.

