### PR TITLE
Add option to set API base path

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -232,10 +232,10 @@ function Facebookbot(configuration) {
     // set up a web route for receiving outgoing webhooks and/or slash commands
     facebook_botkit.createWebhookEndpoints = function(webserver, bot, cb) {
         var base_path = getBasePath();
-        
+
         facebook_botkit.log(
             '** Serving webhook endpoints for Messenger Platform at: ' +
-            'http://' + facebook_botkit.config.hostname + ':' + facebook_botkit.config.port + basePath + '/facebook/receive');
+            'http://' + facebook_botkit.config.hostname + ':' + facebook_botkit.config.port + base_path + '/facebook/receive');
         webserver.post('/facebook/receive', function(req, res) {
             res.send('ok');
             facebook_botkit.handleWebhookPayload(req, res, bot);
@@ -386,8 +386,10 @@ function Facebookbot(configuration) {
         var base_path = getBasePath();
         if (base_path !== '') {
             app.use(base_path, facebook_botkit.webserver);
+        } else {
+            app.use(facebook_botkit.webserver);
         }
-      
+
         var server = app.listen(
             facebook_botkit.config.port,
             facebook_botkit.config.hostname,
@@ -532,7 +534,7 @@ function Facebookbot(configuration) {
             next();
         }
     }
-    
+
     function getBasePath() {
         if (!(facebook_botkit.config && facebook_botkit.config.webserver && facebook_botkit.config.webserver.base_path)) {
             return ''

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -230,12 +230,12 @@ function Facebookbot(configuration) {
     });
 
     // set up a web route for receiving outgoing webhooks and/or slash commands
-
     facebook_botkit.createWebhookEndpoints = function(webserver, bot, cb) {
-
+        var base_path = getBasePath();
+        
         facebook_botkit.log(
             '** Serving webhook endpoints for Messenger Platform at: ' +
-            'http://' + facebook_botkit.config.hostname + ':' + facebook_botkit.config.port + '/facebook/receive');
+            'http://' + facebook_botkit.config.hostname + ':' + facebook_botkit.config.port + basePath + '/facebook/receive');
         webserver.post('/facebook/receive', function(req, res) {
             res.send('ok');
             facebook_botkit.handleWebhookPayload(req, res, bot);
@@ -370,6 +370,7 @@ function Facebookbot(configuration) {
         facebook_botkit.config.port = port;
 
         facebook_botkit.webserver = express();
+        var app = express();
 
         // Validate that requests come from facebook, and abort on validation errors
         if (facebook_botkit.config.validate_requests === true) {
@@ -382,7 +383,12 @@ function Facebookbot(configuration) {
         facebook_botkit.webserver.use(bodyParser.urlencoded({ extended: true }));
         facebook_botkit.webserver.use(express.static(static_dir));
 
-        var server = facebook_botkit.webserver.listen(
+        var base_path = getBasePath();
+        if (base_path !== '') {
+            app.use(base_path, facebook_botkit.webserver);
+        }
+      
+        var server = app.listen(
             facebook_botkit.config.port,
             facebook_botkit.config.hostname,
             function() {
@@ -390,7 +396,6 @@ function Facebookbot(configuration) {
                     facebook_botkit.config.port);
                 if (cb) { cb(null, facebook_botkit.webserver); }
             });
-
 
         request.post('https://graph.facebook.com/me/subscribed_apps?access_token=' + configuration.access_token,
             function(err, res, body) {
@@ -526,6 +531,22 @@ function Facebookbot(configuration) {
         } else {
             next();
         }
+    }
+    
+    function getBasePath() {
+        if (!(facebook_botkit.config && facebook_botkit.config.webserver && facebook_botkit.config.webserver.base_path)) {
+            return ''
+        }
+
+        var base_path = facebook_botkit.config.webserver.base_path;
+        if (base_path[0] !== '/') {
+            base_path = '/' + base_path;
+        }
+        if (base_path[base_path.length - 1] === '/' ) {
+            base_path = base_path.substring(0, base_path.length -1);
+        }
+
+        return base_path;
     }
 
     return facebook_botkit;


### PR DESCRIPTION
This helps to setup the server with a custom base path for cases where it is required.

```json
var controller = Botkit.facebookbot({
    webserver: {
      base_path: '/bot'
    },
    ...
});
```

This will accepts requests like `http://{hostname}/bot/facebook/receive`.