### PR TITLE
added handling for facebook message type other than text, which does …

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -172,18 +172,20 @@ function Facebookbot(configuration) {
         };
 
         bot.replyWithTyping = function(src, resp, cb) {
-            var text;
+            var textLength;
 
             if (typeof(resp) == 'string') {
-                text = resp;
+                textLength = resp.length;
+            } else if(resp.text) {
+                textLength = resp.text.length;
             } else {
-                text = resp.text;
+                textLength = 80; //default attachement text length
             }
 
             var avgWPM = 85;
             var avgCPM = avgWPM * 7;
 
-            var typingLength = Math.min(Math.floor(text.length / (avgCPM / 60)) * 1000, 5000);
+            var typingLength = Math.min(Math.floor(textLength / (avgCPM / 60)) * 1000, 5000);
 
             bot.startTyping(src, function(err) {
                 if (err) console.log(err);


### PR DESCRIPTION
added handling for facebook message type other than text, which does not have text attribute in replyWithTyping. Given a fixed text length of 80 for such messages.