### PR TITLE
Add option to receive Slack bot user events

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -244,8 +244,12 @@ function Slackbot(configuration) {
             slack_botkit.log.error('Could not identify bot');
             return;
         } else if (bot.identity.id === message.user && message.subtype !== 'channel_join' && message.subtype !== 'group_join') {
-            slack_botkit.debug('Got event from this bot user, ignoring it');
-            return;
+            // receive events from this bot user if requested in configuration
+            if (configuration.receive_bot_user_events) {
+              slack_botkit.trigger(message.type, [bot, message]);
+            } else {
+              slack_botkit.debug('Got event from this bot user, ignoring it');
+            }
         } else {
             if (message.type === 'message') {
                 slack_botkit.receiveMessage(bot, message);


### PR DESCRIPTION
Bot user events are currently blocked. I added a configuration option to let them through. 
https://github.com/howdyai/botkit/issues/600