### PR TITLE
Fixed the link to #handling-the-end-of-conversation section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -760,7 +760,7 @@ Set the action field of a message to `stop` end immediately, but mark as failed.
 
 Set the action field of a message to `timeout` to end immediately and indicate that the conversation has timed out.
 
-After the conversation ends, these values will be available in the `convo.status` field. This field can then be used to check the final outcome of a conversation. See [handling the end of conversations](#handling-the-end-of-conversation).
+After the conversation ends, these values will be available in the `convo.status` field. This field can then be used to check the final outcome of a conversation. See [handling the end of conversations](#handling-end-of-conversation).
 
 ### Using Variable Tokens and Templates in Conversation Threads
 


### PR DESCRIPTION
#handling-the-end-of-conversation --> #handling-end-of-conversation