### PR TITLE
Fix slack auth issue, caused by auth middleware being applied globally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ examples/db_team_bot/
 .DS_Store
 */.DS_Store
 .env
+.vscode/settings.json

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -126,7 +126,7 @@ function Slackbot(configuration) {
 
         if (authenticationTokens !== undefined && arguments.length > 1 && arguments[1].length) {
             var args = Array.prototype.slice.call(arguments);
-            Array.prototype.unshift.call(args, webhookEndpoint);
+            args.unshift(webhookEndpoint);
             secureWebhookEndpoints.apply(null, args);
         }
 

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -107,28 +107,33 @@ function Slackbot(configuration) {
     function secureWebhookEndpoints() {
         var authenticationMiddleware = require(__dirname + '/middleware/slack_authentication.js');
         // convert a variable argument list to an array, drop the webserver argument
-        var tokens = Array.prototype.slice.call(arguments);
-        var webserver = tokens.shift();
+        var args = Array.prototype.slice.call(arguments);
+        var endpoint = args.shift();
+        var webserver = args.shift();
 
         slack_botkit.log(
             '** Requiring token authentication for webhook endpoints for Slash commands ' +
-            'and outgoing webhooks; configured ' + tokens.length + ' token(s)'
+            'and outgoing webhooks; configured ' + args.length + ' token(s)'
         );
 
-        webserver.use(authenticationMiddleware(tokens));
+        webserver.use(endpoint, authenticationMiddleware(args));
     }
 
     // set up a web route for receiving outgoing webhooks and/or slash commands
     slack_botkit.createWebhookEndpoints = function(webserver, authenticationTokens) {
 
+        var webhookEndpoint = '/slack/receive';
+
         if (authenticationTokens !== undefined && arguments.length > 1 && arguments[1].length) {
-            secureWebhookEndpoints.apply(null, arguments);
+            var args = Array.prototype.slice.call(arguments);
+            Array.prototype.unshift.call(args, webhookEndpoint);
+            secureWebhookEndpoints.apply(null, args);
         }
 
         slack_botkit.log(
             '** Serving webhook endpoints for Slash commands and outgoing ' +
-            'webhooks at: http://' + slack_botkit.config.hostname + ':' + slack_botkit.config.port + '/slack/receive');
-        webserver.post('/slack/receive', function(req, res) {
+            'webhooks at: http://' + slack_botkit.config.hostname + ':' + slack_botkit.config.port + webhookEndpoint);
+        webserver.post(webhookEndpoint, function(req, res) {
 
             // respond to Slack that the webhook has been received.
             res.status(200);


### PR DESCRIPTION
It's a fix for issue #601, this is specific to slack, in case of setting up webhook endpoint with verififcationToken enabled, slack auth middleware was getting applied globally for all the endpoints which was causing all requests getting refused with 401 response code.

Ideally this middleware should only be enabled for webhook endpoint, which is called by slack and verification token would be provided