### PR TITLE
ambiguity in signature of delete functions in simple storage

### DIFF
--- a/lib/storage/simple_storage.js
+++ b/lib/storage/simple_storage.js
@@ -57,7 +57,7 @@ module.exports = function(config) {
                 teams_db.save(team_data.id, team_data, cb);
             },
             delete: function(team_id, cb) {
-                teams_db.delete(team_id.id, cb);
+                teams_db.delete(team_id, cb);
             },
             all: function(cb) {
                 teams_db.all(objectsToList(cb));
@@ -71,7 +71,7 @@ module.exports = function(config) {
                 users_db.save(user.id, user, cb);
             },
             delete: function(user_id, cb) {
-                users_db.delete(user_id.id, cb);
+                users_db.delete(user_id, cb);
             },
             all: function(cb) {
                 users_db.all(objectsToList(cb));
@@ -85,7 +85,7 @@ module.exports = function(config) {
                 channels_db.save(channel.id, channel, cb);
             },
             delete: function(channel_id, cb) {
-                channels_db.delete(channel_id.id, cb);
+                channels_db.delete(channel_id, cb);
             },
             all: function(cb) {
                 channels_db.all(objectsToList(cb));


### PR DESCRIPTION
delete functions accept user/team/channel_id, but then treats arguments
as objects and try to get an id from them.