### PR TITLE
Add support for channels.replies method

### DIFF
--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -32,6 +32,7 @@ module.exports = function(bot, config) {
         'channels.list',
         'channels.mark',
         'channels.rename',
+        'channels.replies',
         'channels.setPurpose',
         'channels.setTopic',
         'channels.unarchive',


### PR DESCRIPTION
Please add support for [channels.replies](https://api.slack.com/methods/channels.replies). As I understand it, this method can work with the default behaviour from `slack_api.callAPI`, at least it works fine for my app.