### PR TITLE
fix(CoreBot): guard array length access in replaceAttachmentTokens

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -438,7 +438,7 @@ function Botkit(configuration) {
 
         this.replaceAttachmentTokens = function(attachments) {
 
-            if (attachments.length) {
+            if (attachments && attachments.length) {
                 for (var a = 0; a < attachments.length; a++) {
                     for (var key in attachments[a]) {
                         if (typeof(attachments[a][key]) == 'string') {


### PR DESCRIPTION
This fixes an error, if attachment is not defined.

    /home/m/www/netwoRHk/node_modules/botkit/lib/CoreBot.js:441
                if (attachments.length) {
                            ^

    TypeError: Cannot read property 'length' of undefined
        at Conversation.replaceAttachmentTokens (/home/m/www/netwoRHk/node_modules/botkit/lib/CoreBot.js:441:28)
        at Conversation.replaceAttachmentTokens (/home/m/www/netwoRHk/node_modules/botkit/lib/CoreBot.js:447:56)
        at Conversation.cloneMessage (/home/m/www/netwoRHk/node_modules/botkit/lib/CoreBot.js:527:45)
        at Conversation.tick (/home/m/www/netwoRHk/node_modules/botkit/lib/CoreBot.js:622:53)
        at Task.tick (/home/m/www/netwoRHk/node_modules/botkit/lib/CoreBot.js:825:36)
        at Object.Botkit.botkit.tick (/home/m/www/netwoRHk/node_modules/botkit/lib/CoreBot.js:1099:29)
        at Timeout._onTimeout (/home/m/www/netwoRHk/node_modules/botkit/lib/CoreBot.js:1049:24)
        at ontimeout (timers.js:365:14)
        at tryOnTimeout (timers.js:237:5)
        at Timer.listOnTimeout (timers.js:207:5)