### PR TITLE
Add Facebook thread setting account linking URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ examples/db_team_bot/
 .DS_Store
 */.DS_Store
 .env
+.idea

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -458,8 +458,12 @@ function Facebookbot(configuration) {
                 };
                 facebook_botkit.api.thread_settings.deleteAPI(message);
             },
-            account_linking: function() {
-
+            account_linking: function(payload) {
+                var message = {
+                    'setting_type': 'account_linking',
+                    'account_linking_url': payload
+                };
+                facebook_botkit.api.thread_settings.postAPI(message);
             },
             postAPI: function(message) {
                 request.post('https://graph.facebook.com/v2.6/me/thread_settings?access_token=' + configuration.access_token,

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -458,6 +458,9 @@ function Facebookbot(configuration) {
                 };
                 facebook_botkit.api.thread_settings.deleteAPI(message);
             },
+            account_linking: function() {
+
+            },
             postAPI: function(message) {
                 request.post('https://graph.facebook.com/v2.6/me/thread_settings?access_token=' + configuration.access_token,
                     {form: message},

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -465,6 +465,13 @@ function Facebookbot(configuration) {
                 };
                 facebook_botkit.api.thread_settings.postAPI(message);
             },
+            delete_account_linking: function() {
+                var message = {
+                    'setting_type': 'call_to_actions',
+                    'thread_state': 'existing_thread'
+                };
+                facebook_botkit.api.thread_settings.deleteAPI(message);
+            },
             postAPI: function(message) {
                 request.post('https://graph.facebook.com/v2.6/me/thread_settings?access_token=' + configuration.access_token,
                     {form: message},

--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -352,6 +352,8 @@ controller.api.thread_settings.menu([
       "url":"https://github.com/howdyai/botkit/blob/master/readme-facebook.md"
     },
 ]);
+controller.api.thread_settings.account_linking('https://www.yourAwesomSite.com/oauth?response_type=code&client_id=1234567890&scope=basic');
+
 
 controller.hears(['hello'],'facebook_postback', function(bot, message) {
     //...

--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -353,6 +353,7 @@ controller.api.thread_settings.menu([
     },
 ]);
 controller.api.thread_settings.account_linking('https://www.yourAwesomSite.com/oauth?response_type=code&client_id=1234567890&scope=basic');
+controller.api.thread_settings.delete_account_linking();
 
 
 controller.hears(['hello'],'facebook_postback', function(bot, message) {


### PR DESCRIPTION
Yo guys,

Facebook allow us to configure the thread to help users link or unlink their Messenger identity with their identity in our business (a.k.a Account Linking).

By this PR i added the possibility to configuring account linking on the thread (add & remove)

[Read more](https://developers.facebook.com/docs/messenger-platform/thread-settings/account-linking)