### PR TITLE
Show status on conversation end debug message

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -487,7 +487,7 @@ function Botkit(configuration) {
             this.handler = null;
             this.messages = [];
             this.status = status || 'stopped';
-            botkit.debug('Conversation is over!');
+            botkit.debug('Conversation is over with status ' + this.status);
             this.task.conversationEnded(this);
         };
 


### PR DESCRIPTION
Minor change - debug message: Show the status when the conversation is over. I need this for debugging an edge case in my bot an I suspect it might be useful to others.