### PR TITLE
Store state parameter from oauth against team

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -526,6 +526,8 @@ function Slackbot(configuration) {
                                         name: identity.team,
                                     };
                                 }
+                                
+                                team.state = state;
 
                                 var bot = slack_botkit.spawn(team);
 


### PR DESCRIPTION
I display the 'Add to slack' button on my website and submit the logged in user's id using the `state` parameter when clicked. However, it appears that parameter is currently not accessible in botkit. This fix works locally in my certain case, but as I'm new to botkit there may be issues with this implementation that I'm unaware of so I'd appreciate any feedback.

Thanks