### PR TITLE
Add Messenger code API

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -517,6 +517,40 @@ function Facebookbot(configuration) {
                         }
                     });
             }
+        },
+        get_messenger_code: function(image_size, cb) {
+            var message = {
+                'type': 'standard',
+                'image_size': image_size || 1000
+            };
+            request.post('https://graph.facebook.com/v2.6/me/messenger_codes?access_token=' + configuration.access_token,
+                {form: message},
+                function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not configure get messenger code');
+                        cb(err);
+                    } else {
+
+                        var results = null;
+                        try {
+                            results = JSON.parse(body);
+                        } catch (err) {
+                            facebook_botkit.log('ERROR in messenger code API call: Could not parse JSON', err, body);
+                            cb(err);
+                        }
+
+                        if (results) {
+                            if (results.error) {
+                                facebook_botkit.log('ERROR in messenger code API call: ', results.error.message);
+                                cb(results.error);
+                            } else {
+                                var uri = results.uri;
+                                facebook_botkit.log('Successfully got messenger code', uri);
+                                cb(null, uri);
+                            }
+                        }
+                    }
+                });
         }
     };
 

--- a/readme-facebook.md
+++ b/readme-facebook.md
@@ -294,6 +294,21 @@ reply_message = {
 bot.reply(message, reply_message)
 ```
 
+
+## Messenger code API
+
+Messenger Codes can be scanned in Messenger to instantly link the user to your bot, no typing needed. They're great for sticking on fliers, ads, or anywhere in the real world where you want people to try your bot.
+
+```javascript
+controller.api.get_messenger_code(2000, function (err, uri) {
+    if(err) {
+        // Error
+    } else {
+        // uri
+    }
+});
+```
+
 ## Thread Settings API
 
 Facebook offers a "Thread Settings" API to customize special bot features


### PR DESCRIPTION
Hello,

Messenger Codes can be scanned in Messenger to instantly link the user to your bot, no typing needed. They're great for sticking on fliers, ads, or anywhere in the real world where you want people to try your bot.

This PR add the ability to programmatically get your bot's Messenger Code.

Enjoy,