### PR TITLE
Slack fix: properly ignore all messages with bot_id

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -725,7 +725,7 @@ function Slackbot(configuration) {
                     return false;
 
                 } else {
-                    if (message.user == bot.identity.id && message.bot_id) {
+                    if (message.user == bot.identity.id || message.bot_id) {
                         return false;
                     }
                     if (!message.text) {

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -707,7 +707,7 @@ function Slackbot(configuration) {
                     return false;
                 } else if (message.channel.match(/^D/)) {
                     // this is a direct message
-                    if (message.user == bot.identity.id && message.bot_id) {
+                    if (message.user == bot.identity.id || message.bot_id) {
                         return false;
                     }
                     if (!message.text) {


### PR DESCRIPTION
Filter out any message that comes in with `bot_id` on the body. Currently we are filtering out messages that have `message.user === bot.identity.id && message.bot_id` but as @sporkd pointed out, bot_id is not always present, so messages from our/other bots can slip through. 

This essentially makes our bots deaf to other bots, for now.

Extends #268 
Closes #663 