### PR TITLE
Spawn only one bot per team

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -533,26 +533,40 @@ function Slackbot(configuration) {
                                     };
                                 }
 
-                                var bot = slack_botkit.spawn(team);
 
-                                if (auth.incoming_webhook) {
-                                    auth.incoming_webhook.token = auth.access_token;
-                                    auth.incoming_webhook.createdBy = identity.user_id;
-                                    team.incoming_webhook = auth.incoming_webhook;
-                                    bot.configureIncomingWebhook(team.incoming_webhook);
-                                    slack_botkit.trigger('create_incoming_webhook', [bot, team.incoming_webhook]);
-                                }
+                                var bot;
 
-                                if (auth.bot) {
+                                spawned_bots.forEach(localBot => {
+                                    if (localBot.config.id && localBot.config.id == team.id) {
+                                        // WAIT! We already have a bot spawned
+                                        // here. Instead of using the new one,
+                                        // use the exist one.
+                                        bot = localBot;
+                                    }
+                                });
 
-                                    team.bot = {
-                                        token: auth.bot.bot_access_token,
-                                        user_id: auth.bot.bot_user_id,
-                                        createdBy: identity.user_id,
-                                        app_token: auth.access_token,
-                                    };
-                                    bot.configureRTM(team.bot);
-                                    slack_botkit.trigger('create_bot', [bot, team.bot]);
+                                if (!bot) {
+                                    bot = slack_botkit.spawn(team);
+
+                                    if (auth.incoming_webhook) {
+                                        auth.incoming_webhook.token = auth.access_token;
+                                        auth.incoming_webhook.createdBy = identity.user_id;
+                                        team.incoming_webhook = auth.incoming_webhook;
+                                        bot.configureIncomingWebhook(team.incoming_webhook);
+                                        slack_botkit.trigger('create_incoming_webhook', [bot, team.incoming_webhook]);
+                                    }
+
+                                    if (auth.bot) {
+
+                                        team.bot = {
+                                            token: auth.bot.bot_access_token,
+                                            user_id: auth.bot.bot_user_id,
+                                            createdBy: identity.user_id,
+                                            app_token: auth.access_token,
+                                        };
+                                        bot.configureRTM(team.bot);
+                                        slack_botkit.trigger('create_bot', [bot, team.bot]);
+                                    }
                                 }
 
                                 slack_botkit.saveTeam(team, function(err, id) {


### PR DESCRIPTION
**Related Issue**
https://github.com/howdyai/botkit/issues/473#issuecomment-284810694

**What does this PR do?**
This Pr makes sure that only one bot is spun up per team. The issue that I was seeing before was that when the bot was authorized twice to the team, then when the bot posted in a channel, it would post multiple times (Note: this does not happen in a conversation)

**Description of Changes**
`lib/SlackBot.js`: updated the `ouath access` method to check if a bot has already been spawned for that team. If one has, then it will _not_ spawn another bot. If a bot has not been spawned, then it _will_ spawn a new one and set up all of the necessary hooks.

**What gif most accurately describes how I feel towards this PR?**
![](https://68.media.tumblr.com/74ade871ecf0fec339ead39da8c3685c/tumblr_nk4pdsYvoz1tj6mrto1_400.gif)