### PR TITLE
Fixes slash commands when using internal webserver

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -17,7 +17,7 @@ function Slackbot(configuration) {
     // This allows an RTM connection to be kept alive (so bot appears online)
     // but receive messages only via events api
     if (slack_botkit.config.rtm_receive_messages === undefined) {
-        slack_botkit.config.rtm_receive_messages = true;ˆ
+        slack_botkit.config.rtm_receive_messages = true;
     }
 
     var spawned_bots = [];

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -17,7 +17,7 @@ function Slackbot(configuration) {
     // This allows an RTM connection to be kept alive (so bot appears online)
     // but receive messages only via events api
     if (slack_botkit.config.rtm_receive_messages === undefined) {
-        slack_botkit.config.rtm_receive_messages = true;
+        slack_botkit.config.rtm_receive_messages = true;ˆ
     }
 
     var spawned_bots = [];
@@ -205,10 +205,22 @@ function Slackbot(configuration) {
 
                 // Identify the bot from either team storage or identifyBot()
                 bot.team_info = team;
-                bot.identity = {
-                    id: team.bot.user_id,
-                    name: team.bot.name
-                };
+
+                // The bot identity is only used in handleEventsAPI during this flow
+                // Recent changes in Slack will break other integrations as they no longer
+                // require a bot and therefore Slack won't send the bot information.
+                if ( payload.type === 'event_callback' ) {
+
+                    if( !team.bot ) {
+                        slack_botkit.log.error('No bot identity found.');
+                        return;
+                    }
+
+                    bot.identity = {
+                        id: team.bot.user_id,
+                        name: team.bot.name
+                    };
+                }
             }
 
             bot.res = res;


### PR DESCRIPTION
The latest changes of Slack removed the concept of a bot from things like slash command. Botkit was still assuming that slack will send the `bot` key in the webhook payload which is not the case.

This is a simple fix that will remove the requirement for that information to be present for slash command, outgoing webhooks and interactive messages. The `handleEventsAPI` method will actually try to use that data so I still included it for that case but fail if we don't find it in the payload.

It was a blocker for us at message.io so we fixed and tested it in our own fork.
Should solve https://github.com/howdyai/botkit/issues/590#issuecomment-285186862