### PR TITLE
Add functionality for typing in conversations

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -191,6 +191,10 @@ function Botkit(configuration) {
             this.addMessage(message);
         };
 
+        this.sayWithTyping = function(message) {
+            this.addMessage(message, null, true);
+        };
+
         this.sayFirst = function(message) {
             if (typeof(message) == 'string') {
                 message = {
@@ -245,7 +249,7 @@ function Botkit(configuration) {
             return;
         };
 
-        this.addQuestion = function(message, cb, capture_options, thread) {
+        this.addQuestion = function(message, cb, capture_options, thread, typing) {
             if (typeof(message) == 'string') {
                 message = {
                     text: message,
@@ -260,15 +264,18 @@ function Botkit(configuration) {
             }
 
             message.handler = cb;
-            this.addMessage(message, thread);
+            this.addMessage(message, thread, typing);
         };
-
 
         this.ask = function(message, cb, capture_options) {
-            this.addQuestion(message, cb, capture_options, this.thread || 'default');
+            this.addQuestion(message, cb, capture_options, this.thread || 'default', false);
         };
 
-        this.addMessage = function(message, thread) {
+        this.askWithTyping = function(message, cb, capture_options) {
+            this.addQuestion(message, cb, capture_options, this.thread || 'default', true);
+        };
+
+        this.addMessage = function(message, thread, typing) {
             if (!thread) {
                 thread = this.thread;
             }
@@ -281,15 +288,28 @@ function Botkit(configuration) {
                 message.channel = this.source_message.channel;
             }
 
-            if (!this.threads[thread]) {
-                this.threads[thread] = [];
-            }
-            this.threads[thread].push(message);
+            var typingLength = 0;
 
-            // this is the current topic, so add it here as well
-            if (this.thread == thread) {
-                this.messages.push(message);
+            if (typeof(typing) !== 'undefined' && typing) {
+                this.task.bot.reply(message, {
+                    type: 'typing'
+                })
+                typingLength = 1200 / 60 * message.text.length;
+                typingLength = typingLength > 2000 ? 2000 : typingLength;
             }
+
+            var convo = this;
+            setTimeout(function() {
+                if (!convo.threads[thread]) {
+                    convo.threads[thread] = [];
+                }
+                convo.threads[thread].push(message);
+
+                // this is the current topic, so add it here as well
+                if (convo.thread == thread) {
+                    convo.messages.push(message);
+                }
+            }, typingLength);
         };
 
         // how long should the bot wait while a user answers?


### PR DESCRIPTION
Issue - #674

This PR allows users to simulate typing in conversations, similar to what is being done with replyWithTyping. 
```
bot.startConversation(message, (err, convo) => {
        convo.askWithTyping('Are you sure?', [  {
                pattern: bot.utterances.no,
                default: true,
                callback: (response, convo) => {
                    convo.sayWithTyping('*Phew!*');
                    convo.next();
                }
            }
       ]);
});
```

I followed what was being done for replyWithTyping.