### PR TITLE
encrypt team and user tokens before storing to db

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -4,6 +4,7 @@ var express = require('express');
 var bodyParser = require('body-parser');
 var querystring = require('querystring');
 var async = require('async');
+var Cryptr = require('cryptr');
 
 function Slackbot(configuration) {
 
@@ -77,6 +78,10 @@ function Slackbot(configuration) {
                 slack_botkit.config.scopes = slack_app_config.scopes.split(/\,/);
             } else {
                 slack_botkit.config.scopes = slack_app_config.scopes;
+            }
+            if (slack_app_config.encrypt && slack_app_config.encryptKey) {
+                slack_botkit.config.encrypt = slack_app_config.encrypt;
+                slack_botkit.config.cryptr = new Cryptr(slack_app_config.encryptKey);
             }
             if (cb) cb(null);
         }
@@ -335,7 +340,13 @@ function Slackbot(configuration) {
      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
     slack_botkit.saveTeam = function(team, cb) {
-        slack_botkit.storage.teams.save(team, cb);
+        var aTeam = Object.assign({}, team);
+        if (slack_botkit.config.encrypt) {
+            aTeam.bot.token = slack_botkit.config.cryptr.encrypt(team.bot.token);
+            aTeam.bot.app_token = slack_botkit.config.cryptr.encrypt(team.bot.app_token);
+
+        }
+        slack_botkit.storage.teams.save(aTeam, cb);
     };
 
     // look up a team's memory and configuration and return it, or
@@ -614,7 +625,12 @@ function Slackbot(configuration) {
 
                                             // Always update these because the token could become invalid
                                             // and scopes could change.
-                                            user.access_token = auth.access_token;
+                                            if (slack_botkit.config.encrypt) {
+                                                user.access_token = slack_botkit.config.cryptr.encrypt(auth.access_token);
+                                            } else {
+                                                user.access_token = auth.access_token;
+                                            }
+
                                             user.scopes = scopes;
 
                                             slack_botkit.storage.users.save(user, function(err, id) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "clone": "2.1.1",
     "command-line-args": "^4.0.2",
     "crypto": "0.0.3",
+    "cryptr": "^2.0.0",
     "express": "^4.15.2",
     "https-proxy-agent": "^1.0.0",
     "jfs": "^0.2.6",


### PR DESCRIPTION
This is to provide functionality to encrypt the token before we store it in underline botkit storage. 