### PR TITLE
Make Interactive Slack Menus Work - fixes for #768

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -738,6 +738,16 @@ module.exports = function(botkit, config) {
 
                         var direct_mention = new RegExp('^\<\@' + bot.identity.id + '\>', 'i');
 
+                        if( message.actions ) {
+                            
+                            try {
+                                message.text = message.actions[0].selected_options[0].value;
+                            } catch(e) {
+                                botkit.debug('ERROR GETTING VALUE FROM SELECT');    
+                            }
+
+                        }
+
                         message.text = message.text.replace(direct_mention, '')
                         .replace(/^\s+/, '').replace(/^\:\s+/, '').replace(/^\s+/, '');
 


### PR DESCRIPTION
Added a fix for #768. As far as I know slack menu's don't support multiple select values so this seems to work. There might be a smarter way to handle this case I'm just not totally privy to all of the workings in the library.