### PR TITLE
Normalize Code Syntax Highlighting in /Docs

### DIFF
--- a/docs/readme-botframework.md
+++ b/docs/readme-botframework.md
@@ -75,7 +75,7 @@ To connect your bot to the Bot Framework follow the step by step guide outlined 
 
 Here is the complete code for a basic Bot Framework bot:
 
-```javascript
+~~~ javascript
 var Botkit = require('botkit');
 var controller = Botkit.botframeworkbot({
 });
@@ -111,7 +111,8 @@ controller.hears(['cookies'], 'message_received', function(bot, message) {
         });
     });
 });
-```
+~~~
+
 #### Botkit.botframeworkbot()
 | Argument | Description
 |---  |---
@@ -151,7 +152,7 @@ One of the more complicated aspects of building a bot that supports multiple cha
 
 The frameworks [attachment schema](https://docs.botframework.com/en-us/node/builder/chat-reference/interfaces/_botbuilder_d_.iattachment.html) lets you send a single image/file using `contentType` and `contentUrl` fields:
 
-```javascript
+~~~ javascript
     bot.reply(message, {
         attachments: [
             {
@@ -161,13 +162,13 @@ The frameworks [attachment schema](https://docs.botframework.com/en-us/node/buil
             }
         ]
     });
-```
+~~~
 
 #### Sending Cards
 
 Rich cards can be expressed as attachments by changing the `contentType` and using the `content` field to pass a JSON object defining the card:
 
-```javascript
+~~~ javascript
     bot.reply(message, {
         attachments: [
             {
@@ -190,7 +191,7 @@ Rich cards can be expressed as attachments by changing the `contentType` and usi
             }
         ]
     });
-```
+~~~
 
 The full list of supported card types and relevant schema can be found [here](https://docs.botframework.com/en-us/csharp/builder/sdkreference/attachments.html)
 
@@ -202,9 +203,9 @@ There may be times where the Bot Frameworks cross platform attachment schema doe
 
 You can easily turn on the typing indicator on platforms that support that behaviour by sending an empty message of type "typing":
 
-```javascript
+~~~ javascript
     bot.reply(message, { type: "typing" });
-```
+~~~
 
 
 ## Documentation

--- a/docs/readme-ciscospark.md
+++ b/docs/readme-ciscospark.md
@@ -55,7 +55,7 @@ This will configure your bot to respond only to messages from members of the spe
 
 The full code for a simple Cisco Spark bot is below:
 
-```
+~~~ javascript
 var Botkit = require('./lib/Botkit.js');
 
 var controller = Botkit.sparkbot({
@@ -87,7 +87,7 @@ controller.on('direct_mention', function(bot, message) {
 controller.on('direct_message', function(bot, message) {
     bot.reply(message, 'I got your private message. You said, "' + message.text + '"');
 });
-```
+~~~
 
 ## Controller Options
 
@@ -103,7 +103,7 @@ When creating the Botkit controller, there are several platform-specific options
 | `limit_to_org` | _optional_ organization id in which the bot should exist. If user from outside org sends message, it is ignored
 | `limit_to_domain` | _optional_ email domain (@howdy.ai) or array of domains [@howdy.ai, @botkit.ai] from which messages can be received
 
-```
+~~~ javascript
 var controller = Botkit.sparkbot({
     debug: true,
     log: true,
@@ -114,8 +114,7 @@ var controller = Botkit.sparkbot({
     limit_to_org: 'my_spark_org_id',
     limit_to_domain: ['@howdy.ai','@cisco.com'],
 });
-```
-
+~~~
 
 ## Spark Specific Events
 
@@ -140,9 +139,9 @@ Cisco Spark supports both a `text` field and a `markdown` field for outbound mes
 
 To specify a markdown version, add it to your message object:
 
-```
+~~~ javascript
 bot.reply(message,{text: 'Hello', markdown: '*Hello!*'});
-```
+~~~
 
 ## Attaching Files
 
@@ -152,18 +151,18 @@ Files can be attached to outgoing messages in one of two ways.
 
 If the file you wish to attach is already available online, simply specify the URL in the `files` field of the outgoing message:
 
-```
+~~~ javascript
 bot.reply(message,{text:'Here is your file!', files:['http://myserver.com/file.pdf']});
-```
+~~~
 
 *Send Local File*
 
 If the file you wish to attach is present only on the local server, attach it to the message as a readable stream:
 
-```
+~~~ javascript
 var fs = require('fs');
 bot.reply(message,{text: 'I made this file for you.', files:[fs.createReadStream('./newfile.txt')]});
-```
+~~~
 
 ## Receiving files
 
@@ -179,7 +178,7 @@ Botkit provides 2 methods for retrieving information about the file.
 
 The callback function will receive an object with fields like `filename`, `content-type`, and `content-length`.
 
-```
+~~~ javascript
 controller.on('direct_message', function(bot, message) {
     bot.reply(message, 'I got your private message. You said, "' + message.text + '"');
     if (message.original_message.files) {
@@ -188,7 +187,7 @@ controller.on('direct_message', function(bot, message) {
         });
     }
 });
-```
+~~~
 
 ### bot.retrieveFile(url, cb)
 | Parameter | Description
@@ -198,7 +197,7 @@ controller.on('direct_message', function(bot, message) {
 
 The callback function will receive the full content of the file.
 
-```
+~~~ javascript
 controller.on('direct_message', function(bot, message) {
     bot.reply(message, 'I got your private message. You said, "' + message.text + '"');
     if (message.original_message.files) {
@@ -211,7 +210,7 @@ controller.on('direct_message', function(bot, message) {
         });
     }
 });
-```
+~~~
 
 ## Starting Direct Messages
 
@@ -236,9 +235,9 @@ and will create a direct message thread with the sender of the incoming_message.
 Use this function to send a direct message to a user by their personId, which
 can be found in message and event payloads at the following location:
 
-```
+~~~ javascript
 var personId = message.original_message.actorId;
-```
+~~~
 
 ### bot.startPrivateConversationWithActor())
 | Parameter | Description
@@ -246,13 +245,13 @@ var personId = message.original_message.actorId;
 | incoming_message | a message or event that has an actorId defined in message.original_message.actorId
 | cb | callback function in the form function(err, file_content)
 
-```
+~~~ javascript
 controller.on('bot_space_join', function(bot, message) {
   bot.startPrivateConversationWithActor(message, function(err, convo) {
     convo.say('The bot you invited has joined the channel.');
   });
 });
-```
+~~~
 
 
 


### PR DESCRIPTION
Some of the code examples didn't have any code highlighting, this PR fixes it.