### PR TITLE
 Add missing user methods for slack api

### DIFF
--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -110,7 +110,12 @@ module.exports = function(bot, config) {
         'users.info',
         'users.list',
         'users.setActive',
-        'users.setPresence'
+        'users.setPresence',
+        'users.deletePhoto',
+        'users.identity',
+        'users.setPhoto',
+        'users.profile.get',
+        'users.profile.set'
     ];
 
     /**


### PR DESCRIPTION
- users.deletePhoto
- users.identity
- users.setPhoto
- users.profile.get
- users.profile.set
taken from: https://api.slack.com/methods