### PR TITLE
Add FaceBook parametric codes

### DIFF
--- a/docs/readme-facebook.md
+++ b/docs/readme-facebook.md
@@ -304,6 +304,7 @@ bot.reply(message, reply_message)
 
 Messenger Codes can be scanned in Messenger to instantly link the user to your bot, no typing needed. They're great for sticking on fliers, ads, or anywhere in the real world where you want people to try your bot.
 
+- Get Static Codes :
 ```javascript
 controller.api.messenger_profile.get_messenger_code(2000, function (err, url) {
     if(err) {
@@ -312,6 +313,17 @@ controller.api.messenger_profile.get_messenger_code(2000, function (err, url) {
         // url
     }
 });
+```
+
+- Get Parametric Codes :
+```javascript
+controller.api.messenger_profile.get_messenger_code(2000, function (err, url) {
+    if(err) {
+        // Error
+    } else {
+        // url
+    }
+}, 'billboard-ad');
 ```
 
 ## Thread Settings API

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -544,11 +544,16 @@ function Facebookbot(configuration) {
                     }
                 });
         },
-        get_messenger_code: function(image_size, cb) {
+        get_messenger_code: function(image_size, cb, ref) {
             var message = {
                 'type': 'standard',
                 'image_size': image_size || 1000
             };
+
+            if(ref) {
+                message.data = {'ref': ref};
+            }
+
             request.post('https://graph.facebook.com/v2.6/me/messenger_codes?access_token=' + configuration.access_token,
                 {form: message},
                 function(err, res, body) {


### PR DESCRIPTION
Yo,

Facebook just added (two days ago) the possibility to generate codes with ref parameters, So, the aim of this PR is to change on how we handle ```get_messenger_code``` to add support of parametric Codes.

Enjoy,