### PR TITLE
Add support for new messenger 2.0 profile home_url

### DIFF
--- a/docs/readme-facebook.md
+++ b/docs/readme-facebook.md
@@ -400,6 +400,23 @@ Remove all domains
 
 Get a list of the whitelisted domains.
 
+### controller.api.messenger_profile.home_url()
+| Argument | Description
+|---  |---
+| payload | A home_url object with the properties `url`, `webview_height_ratio`, `in_test`
+
+View the facebook documentation for details of the [home_url](https://developers.facebook.com/docs/messenger-platform/messenger-profile/home-url) payload object.
+
+*NB.* The value of the `url` property must be present in the domain_whitelist array
+
+### controller.api.messenger_profile.delete_home_url()
+
+Remove the home_url setting
+
+### controller.api.messenger_profile.get_home_url()
+
+Get the home_url
+
 #### Using the The Messenger Profile API
 
 ```js
@@ -451,6 +468,17 @@ controller.api.messenger_profile.get_domain_whitelist(function (err, data)  {
     console.log('****** Whitelisted domains :', data);
 });
 
+controller.api.messenger_profile.home_url({
+    "url": 'https://mydomain.com',
+    "webview_height_ratio": 'tall',
+    "in_test": false
+})
+
+controller.api.messenger_profile.get_home_url(function (err, data)  {
+    console.log('****** Home url :', data);
+});
+
+controller.api.messenger_profile.delete_home_url();
 
 controller.hears(['hello'],'facebook_postback', function(bot, message) {
     //...

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -963,8 +963,8 @@ function Botkit(configuration) {
             keywords = [keywords];
         }
 
-        if(keywords instanceof RegExp) {
-            keywords = [keywords]
+        if (keywords instanceof RegExp) {
+            keywords = [keywords];
         }
 
         if (typeof(events) == 'string') {

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -493,6 +493,18 @@ function Facebookbot(configuration) {
         get_domain_whitelist: function(cb) {
             facebook_botkit.api.messenger_profile.getAPI('whitelisted_domains', cb);
         },
+        home_url: function(payload) {
+            var message = {
+                home_url: payload
+            };
+            facebook_botkit.api.messenger_profile.postAPI(message);
+        },
+        delete_home_url: function() {
+            facebook_botkit.api.messenger_profile.deleteAPI('home_url');
+        },
+        get_home_url: function(cb) {
+            facebook_botkit.api.messenger_profile.getAPI('home_url', cb);
+        },
         postAPI: function(message) {
             request.post('https://graph.facebook.com/v2.6/me/messenger_profile?access_token=' + configuration.access_token,
                 {form: message},

--- a/lib/Tropo.js
+++ b/lib/Tropo.js
@@ -34,15 +34,15 @@ function Tropobot(configuration) {
 
     controller.handleWebhookPayload = function(req, res, bot) {
 
-      console.log('GOT PAYLOAD', req.body);
-      var payload = req.body.session;
-      var msg = {
-        user: payload.from.id,
-        text: payload.initialText,
-        channel: payload.from.id,
-      }
+        console.log('GOT PAYLOAD', req.body);
+        var payload = req.body.session;
+        var msg = {
+            user: payload.from.id,
+            text: payload.initialText,
+            channel: payload.from.id,
+        };
 
-      controller.receiveMessage(bot, msg);
+        controller.receiveMessage(bot, msg);
 
     };
 
@@ -157,7 +157,7 @@ function Tropobot(configuration) {
                 ciscospark_message[k] = message[k];
             }
 
-            console.log("SAY", message);
+            console.log('SAY', message);
 
 
             // controller.api.messages.create(ciscospark_message).then(function(message) {

--- a/tests/Facebook.js
+++ b/tests/Facebook.js
@@ -18,6 +18,65 @@ describe('FacebookBot', function() {
         });
     });
 
+    describe('messenger profile api', function(done) {
+        var facebook_bot = Botkit.facebookbot({});
+        describe('home_url', function(done) {
+            it('home_url should be a function', function(done) {
+                facebook_bot.api.messenger_profile.home_url.should.be.a.Function();
+                done();
+            });
+            it('home_url should post a payload', function(done) {
+                var expectedPayload = {
+                    home_url: {
+                        url: 'https://testurl.com',
+                        webview_height_ratio: 'tall',
+                        in_test: true
+                    }
+                };
+
+                var expectedApiCall = sinon.spy();
+                facebook_bot.api.messenger_profile.postAPI = expectedApiCall;
+                facebook_bot.api.messenger_profile.home_url({
+                    url: 'https://testurl.com',
+                    webview_height_ratio: 'tall',
+                    in_test: true
+                });
+                expectedApiCall.should.be.calledWith(expectedPayload);
+                done();
+            });
+            it('get_home_url should be a function', function(done) {
+                facebook_bot.api.messenger_profile.get_home_url.should.be.a.Function();
+                done();
+            });
+            it('get_home_url should trigger a callback', function(done) {
+                var apiGet = sinon.stub(facebook_bot.api.messenger_profile, 'getAPI').callsFake(function fakeFn(fields, cb) {
+                    return cb(null, {
+                        "home_url" : {
+                            "url": "http://petershats.com/send-a-hat",
+                            "webview_height_ratio": "tall",
+                            "in_test":true
+                        }
+                    });
+                });
+                facebook_bot.api.messenger_profile.get_home_url(function(err, result) {
+                    done();
+                });
+            });
+            it('delete_home_url should be a function', function(done) {
+                facebook_bot.api.messenger_profile.get_home_url.should.be.a.Function();
+                done();
+            });
+            it('delete_home_url should trigger a delete api call', function(done) {
+                var expectedApiCall = sinon.spy();
+                facebook_bot.api.messenger_profile.deleteAPI = expectedApiCall;
+                facebook_bot.api.messenger_profile.delete_home_url();
+                expectedApiCall.should.be.calledWith('home_url');
+                done();
+            })
+        });
+
+
+    });
 
     describe('handleWebhookPayload()', function(done) {
         it('Should be function', function(done) {


### PR DESCRIPTION
Adds api support for the home_url in messenger 2.0
https://developers.facebook.com/docs/messenger-platform/messenger-profile/home-url/