### PR TITLE
Remove the second delete api

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -577,18 +577,7 @@ function Facebookbot(configuration) {
                         }
                     }
                 });
-        },
-        deleteAPI: function(message) {
-                request.delete('https://' + api_host + '/v2.6/me/thread_settings?access_token=' + configuration.access_token,
-                    {form: message},
-                    function(err, res, body) {
-                        if (err) {
-                            facebook_botkit.log('Could not configure thread settings');
-                        } else {
-                            facebook_botkit.debug('Successfully configured thread settings', message);
-                        }
-                    });
-            }
+        }
     };
 
     facebook_botkit.api = {


### PR DESCRIPTION
This fix #795 

I removed the seconde deleteAPI from Facebook profile API section.