### PR TITLE
Customize FacebookAPI link

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -494,7 +494,7 @@ function Facebookbot(configuration) {
             facebook_botkit.api.messenger_profile.getAPI('whitelisted_domains', cb);
         },
         postAPI: function(message) {
-            request.post('https://graph.facebook.com/v2.6/me/messenger_profile?access_token=' + configuration.access_token,
+            request.post('https://' + api_host + '/v2.6/me/messenger_profile?access_token=' + configuration.access_token,
                 {form: message},
                 function(err, res, body) {
                     if (err) {
@@ -522,7 +522,7 @@ function Facebookbot(configuration) {
             var message = {
                 'fields': [type]
             };
-            request.delete('https://graph.facebook.com/v2.6/me/messenger_profile?access_token=' + configuration.access_token,
+            request.delete('https://' + api_host + '/v2.6/me/messenger_profile?access_token=' + configuration.access_token,
                 {form: message},
                 function(err, res, body) {
                     if (err) {
@@ -533,7 +533,7 @@ function Facebookbot(configuration) {
                 });
         },
         getAPI: function(fields, cb) {
-            request.get('https://graph.facebook.com/v2.6/me/messenger_profile?fields=' + fields + '&access_token=' + configuration.access_token,
+            request.get('https://' + api_host + '/v2.6/me/messenger_profile?fields=' + fields + '&access_token=' + configuration.access_token,
                 function(err, res, body) {
                     if (err) {
                         facebook_botkit.log('Could not get messenger profile');
@@ -549,7 +549,7 @@ function Facebookbot(configuration) {
                 'type': 'standard',
                 'image_size': image_size || 1000
             };
-            request.post('https://graph.facebook.com/v2.6/me/messenger_codes?access_token=' + configuration.access_token,
+            request.post('https://' + api_host + '/v2.6/me/messenger_codes?access_token=' + configuration.access_token,
                 {form: message},
                 function(err, res, body) {
                     if (err) {


### PR DESCRIPTION
When updating our Facebook bot to be conform to the latest Facebook changed, We have removed accidentally the customisation of Facebook API host (#567)

The aim of this PR is to bring it back.