### PR TITLE
added facebook bot multi tenancy mode

### DIFF
--- a/facebook_bot.js
+++ b/facebook_bot.js
@@ -27,6 +27,7 @@ This bot demonstrates many of the core features of Botkit:
 
     app_secret=<MY APP SECRET> page_token=<MY PAGE TOKEN> verify_token=<MY_VERIFY_TOKEN> node facebook_bot.js [--lt [--ltsubdomain LOCALTUNNEL_SUBDOMAIN]]
 
+  Use page_token='{<"PAGE_A_ID":"PAGE_A_TOKEN","PAGE_B_ID":"PAGE_B_TOKEN"}' to enable multi tenant
   Use the --lt option to make your bot available on the web through localtunnel.me.
 
 # USE THE BOT:
@@ -99,10 +100,18 @@ if(ops.lt === false && ops.ltsubdomain !== null) {
     process.exit();
 }
 
+var access_token = process.env.page_token;
+try {
+    var access_token = JSON.parse(access_token);
+    console.log("running on multi tenant mode", access_token);
+} catch (error) {
+    console.log("running on single tenant mode", access_token);
+}
+
 var controller = Botkit.facebookbot({
     debug: true,
     log: true,
-    access_token: process.env.page_token,
+    access_token: access_token,
     verify_token: process.env.verify_token,
     app_secret: process.env.app_secret,
     validate_requests: true, // Refuse any requests that don't come from FB on your receive webhook, must provide FB_APP_SECRET in environment variables

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -127,7 +127,7 @@ function Facebookbot(configuration) {
             }
 
             //Add Access Token to outgoing request
-            facebook_message.access_token = configuration.access_token;
+            facebook_message.access_token = (typeof (configuration.access_token) === 'string') ? configuration.access_token : configuration.access_token[message.page];
 
             request({
                 method: 'POST',
@@ -159,6 +159,7 @@ function Facebookbot(configuration) {
         bot.startTyping = function(src, cb) {
             var msg = {};
             msg.channel = src.channel;
+            msg.page = src.page;
             msg.sender_action = 'typing_on';
             bot.say(msg, cb);
         };
@@ -166,6 +167,7 @@ function Facebookbot(configuration) {
         bot.stopTyping = function(src, cb) {
             var msg = {};
             msg.channel = src.channel;
+            msg.page = src.page;
             msg.sender_action = 'typing_off';
             bot.say(msg, cb);
         };
@@ -206,7 +208,7 @@ function Facebookbot(configuration) {
             }
 
             msg.channel = src.channel;
-
+            msg.page = src.page;
             bot.say(msg, cb);
         };
 
@@ -407,17 +409,18 @@ function Facebookbot(configuration) {
                 if (cb) { cb(null, facebook_botkit.webserver); }
             });
 
-
-        request.post('https://' + api_host + '/me/subscribed_apps?access_token=' + configuration.access_token,
-            function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not subscribe to page messages');
-                } else {
-                    facebook_botkit.debug('Successfully subscribed to Facebook events:', body);
-                    facebook_botkit.startTicking();
-                }
-            });
-
+        var access_tokens = (typeof (configuration.access_token) === 'string') ? [configuration.access_token] : configuration.access_token;
+        Object.keys(access_tokens).forEach(function(page) {
+            request.post('https://' + api_host + '/me/subscribed_apps?access_token=' + access_tokens[page],
+                function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not subscribe to page messages with access_token', access_tokens[page]);
+                    } else {
+                        facebook_botkit.debug('Successfully subscribed to Facebook events with access_token', access_tokens[page], body);
+                    }
+                });
+        });
+        facebook_botkit.startTicking();
         return facebook_botkit;
 
     };
@@ -494,101 +497,116 @@ function Facebookbot(configuration) {
             facebook_botkit.api.messenger_profile.getAPI('whitelisted_domains', cb);
         },
         postAPI: function(message) {
-            request.post('https://graph.facebook.com/v2.6/me/messenger_profile?access_token=' + configuration.access_token,
-                {form: message},
-                function(err, res, body) {
-                    if (err) {
-                        facebook_botkit.log('Could not configure messenger profile');
-                    } else {
+            var access_tokens = (typeof (configuration.access_token) === 'string') ? [configuration.access_token] : configuration.access_token;
+            Object.keys(access_tokens).forEach(function(page) {
+                request.post('https://graph.facebook.com/v2.6/me/messenger_profile?access_token=' + access_tokens[page],
+                    {form: message},
+                    function(err, res, body) {
+                        if (err) {
+                            facebook_botkit.log('Could not configure messenger profile with access_token', access_tokens[page]);
+                        } else {
 
-                        var results = null;
-                        try {
-                            results = JSON.parse(body);
-                        } catch (err) {
-                            facebook_botkit.log('ERROR in messenger profile API call: Could not parse JSON', err, body);
-                        }
+                            var results = null;
+                            try {
+                                results = JSON.parse(body);
+                            } catch (err) {
+                                facebook_botkit.log('ERROR in messenger profile API call: Could not parse JSON', err, body);
+                            }
 
-                        if (results) {
-                            if (results.error) {
-                                facebook_botkit.log('ERROR in messenger profile API call: ', results.error.message);
-                            } else {
-                                facebook_botkit.debug('Successfully configured messenger profile', body);
+                            if (results) {
+                                if (results.error) {
+                                    facebook_botkit.log('ERROR in messenger profile API call: ', access_tokens[page], results.error.message);
+                                } else {
+                                    facebook_botkit.debug('Successfully configured messenger profile with access_token', access_tokens[page], body);
+                                }
                             }
                         }
-                    }
-                });
+                    });
+            });
         },
         deleteAPI: function(type) {
             var message = {
                 'fields': [type]
             };
-            request.delete('https://graph.facebook.com/v2.6/me/messenger_profile?access_token=' + configuration.access_token,
-                {form: message},
-                function(err, res, body) {
-                    if (err) {
-                        facebook_botkit.log('Could not configure messenger profile');
-                    } else {
-                        facebook_botkit.debug('Successfully configured messenger profile', message);
-                    }
-                });
+            var access_tokens = (typeof (configuration.access_token) === 'string') ? [configuration.access_token] : configuration.access_token;
+            Object.keys(access_tokens).forEach(function(page) {
+                request.delete('https://graph.facebook.com/v2.6/me/messenger_profile?access_token=' + access_tokens[page],
+                    {form: message},
+                    function(err, res, body) {
+                        if (err) {
+                            facebook_botkit.log('Could not configure messenger profile with access_token', access_tokens[page]);
+                        } else {
+                            facebook_botkit.debug('Successfully configured messenger profile with access_token', access_tokens[page], message);
+                        }
+                    });
+            });
         },
         getAPI: function(fields, cb) {
-            request.get('https://graph.facebook.com/v2.6/me/messenger_profile?fields=' + fields + '&access_token=' + configuration.access_token,
-                function(err, res, body) {
-                    if (err) {
-                        facebook_botkit.log('Could not get messenger profile');
-                        cb(err);
-                    } else {
-                        facebook_botkit.debug('Successfully got messenger profile ', body);
-                        cb(null, body);
-                    }
-                });
+            var access_tokens = (typeof (configuration.access_token) === 'string') ? [configuration.access_token] : configuration.access_token;
+            Object.keys(access_tokens).forEach(function(page) {
+                request.get('https://graph.facebook.com/v2.6/me/messenger_profile?fields=' + fields + '&access_token=' + access_tokens[page],
+                    function(err, res, body) {
+                        if (err) {
+                            facebook_botkit.log('Could not get messenger profile with access_token', access_tokens[page]);
+                            cb(err);
+                        } else {
+                            facebook_botkit.debug('Successfully got messenger profile with access_token', access_tokens[page], body);
+                            cb(null, body);
+                        }
+                    });
+            });
         },
         get_messenger_code: function(image_size, cb) {
             var message = {
                 'type': 'standard',
                 'image_size': image_size || 1000
             };
-            request.post('https://graph.facebook.com/v2.6/me/messenger_codes?access_token=' + configuration.access_token,
-                {form: message},
-                function(err, res, body) {
-                    if (err) {
-                        facebook_botkit.log('Could not configure get messenger code');
-                        cb(err);
-                    } else {
-
-                        var results = null;
-                        try {
-                            results = JSON.parse(body);
-                        } catch (err) {
-                            facebook_botkit.log('ERROR in messenger code API call: Could not parse JSON', err, body);
-                            cb(err);
-                        }
-
-                        if (results) {
-                            if (results.error) {
-                                facebook_botkit.log('ERROR in messenger code API call: ', results.error.message);
-                                cb(results.error);
-                            } else {
-                                var uri = results.uri;
-                                facebook_botkit.log('Successfully got messenger code', uri);
-                                cb(null, uri);
-                            }
-                        }
-                    }
-                });
-        },
-        deleteAPI: function(message) {
-                request.delete('https://' + api_host + '/v2.6/me/thread_settings?access_token=' + configuration.access_token,
+            var access_tokens = (typeof (configuration.access_token) === 'string') ? [configuration.access_token] : configuration.access_token;
+            Object.keys(access_tokens).forEach(function(page) {
+                request.post('https://graph.facebook.com/v2.6/me/messenger_codes?access_token=' + configuration.access_token,
                     {form: message},
                     function(err, res, body) {
                         if (err) {
-                            facebook_botkit.log('Could not configure thread settings');
+                            facebook_botkit.log('Could not configure get messenger code with access_token', access_tokens[page]);
+                            cb(err);
                         } else {
-                            facebook_botkit.debug('Successfully configured thread settings', message);
+
+                            var results = null;
+                            try {
+                                results = JSON.parse(body);
+                            } catch (err) {
+                                facebook_botkit.log('ERROR in messenger code API call: Could not parse JSON', err, body);
+                                cb(err);
+                            }
+
+                            if (results) {
+                                if (results.error) {
+                                    facebook_botkit.log('ERROR in messenger code API call: ', access_tokens[page], results.error.message);
+                                    cb(results.error);
+                                } else {
+                                    var uri = results.uri;
+                                    facebook_botkit.log('Successfully got messenger code with access_token', access_tokens[page], uri);
+                                    cb(null, uri);
+                                }
+                            }
                         }
                     });
-            }
+            });
+        },
+        deleteAPI: function(message) {
+            var access_tokens = (typeof (configuration.access_token) === 'string') ? [configuration.access_token] : configuration.access_token;
+            Object.keys(access_tokens).forEach(function(page) {
+                request.delete('https://' + api_host + '/v2.6/me/thread_settings?access_token=' + access_tokens[page],
+                    {form: message},
+                    function(err, res, body) {
+                        if (err) {
+                            facebook_botkit.log('Could not configure thread settings with access token', access_tokens[page]);
+                        } else {
+                            facebook_botkit.debug('Successfully configured thread settings with access token', access_tokens[page], message);
+                        }
+                    });
+            });
+        }
     };
 
     facebook_botkit.api = {


### PR DESCRIPTION
- support access_token as object type (i.e. {"page_a_id":"page_a_token", "page_b_id":"page_b_token"} )
- backward compatible with current plain string page_token input, as of v0.5.2
- facebook_bot.js example updated