### PR TITLE
#737 Update Slack docs to include `startTicking` when using Events API

### DIFF
--- a/docs/readme-slack.md
+++ b/docs/readme-slack.md
@@ -924,6 +924,8 @@ Developers may want to create an RTM connection in order to make the bot appear 
 4. Select the specific events you would like to subscribe to with your bot. Slack only sends your webhook the events you subscribe to. Read more about Event Types [here](https://api.slack.com/events)
 5. When running your bot, you must configure the slack app, setup webhook endpoints, and oauth endpoints.
 
+Note:  If you are not also establishing an RTM connection, you will need to manually run the `controller.startTicking()` method for conversations to work properly.
+
 ```javascript
 var controller = Botkit.slackbot({
     debug: false,
@@ -947,6 +949,9 @@ controller.setupWebserver(process.env.port, function(err, webserver) {
             res.send('Success!');
         }
     });
+    
+    // If not also opening an RTM connection
+    controller.startTicking();
 });
 ```
 


### PR DESCRIPTION
The code built into the Slack bot will call `controller.startTicking()` when calling `controller.startRTM()`; however, when using the Events API only `startTicking` will never get called and begin responding to conversations and threads.

There may be a better place to handle this via code, but a workaround is to manually call `startTicking` in this case.  The documentation could use an update to reflect this and prevent others from spending hours debugging why their conversations aren't working.