### PR TITLE
Change ping to an explicit message rather than ws protocol frame

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -186,7 +186,8 @@ module.exports = function(botkit, config) {
                         return;
                     }
 
-                    bot.rtm.ping(null, null, true);
+                    bot.msgcount++;
+                    bot.rtm.send(JSON.stringify({ id: bot.msgcount, type: 'ping' }));
                     pingTimeoutId = setTimeout(pinger, 5000);
                 };
 
@@ -207,7 +208,7 @@ module.exports = function(botkit, config) {
                      * but adds in additional fields for internal use!
                      * (including the teams api details)
                      */
-                    if (message != null && bot.botkit.config.rtm_receive_messages) {
+                    if (message != null && bot.botkit.config.rtm_receive_messages && message.type !== 'pong') {
                         botkit.receiveMessage(bot, message);
                     }
                 });


### PR DESCRIPTION
The current recommendation from Slack is to use a message to ping the websocket servers in addition to the protocol specific ping frames (the ws library can handle this all on its own and there's no need for code). Thus the ping code here was redundant since it was sending the same type of ping the server would have already been sending and the botkit client would have already been ponging. With this change, I also hope to resolve possible issues related to pings being an unmasked message and people getting abnormal terminations after that message was sent.