### PR TITLE
add bot.createConversation to ConsoleBot.js

### DIFF
--- a/lib/ConsoleBot.js
+++ b/lib/ConsoleBot.js
@@ -23,6 +23,10 @@ function TextBot(configuration) {
             utterances: botkit.utterances,
         };
 
+        bot.createConversation = function(message, cb) {
+            botkit.createConversation(this, message, cb)
+        };
+
         bot.startConversation = function(message, cb) {
             botkit.startConversation(this, message, cb);
         };


### PR DESCRIPTION
`bot.createConversation` is not implemented in Console Bot, but `bot.startConversation` is. PR adds `createConversation()` to console bot object.

Somebody ran into this on dev4slack testing an existing bot on the command line.