### PR TITLE
🐛 trim space characters in events string

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -1007,7 +1007,7 @@ function Botkit(configuration) {
         }
 
         if (typeof(events) == 'string') {
-            events = events.replace(/ /g, '').split(/\,/g);
+            events = events.split(/\,/g).map(function(str) { return str.trim() })
         }
 
         for (var e = 0; e < events.length; e++) {

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -1007,7 +1007,7 @@ function Botkit(configuration) {
         }
 
         if (typeof(events) == 'string') {
-            events = events.split(/\,/g);
+            events = events.replace(/ /g, '').split(/\,/g);
         }
 
         for (var e = 0; e < events.length; e++) {


### PR DESCRIPTION
Trims whitespace from the events string passed to hears function in corebot. Passing a string separated by commas and spaces would previously trigger only for the first event. This PR allows comma plus space separated strings of event names to register the events for each.

Previously, given `'ambient, direct_message'`, it would split the string into an array that looked like this: `['ambient', ' direct_message']` notice the extra space in direct_message string. It would then register a listener to that event, with the space included, which could never be triggered by botkit.

I'm afraid this might be breaking, or introduce unintended results for people. However, it still will only trigger events they have explicitly stated, but developers might get surprised by their inert code running where it was not before. 

Closes #807 