### PR TITLE
declare "that" in scope

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -125,7 +125,7 @@ function Botkit(configuration) {
 
         this.handle = function(message) {
 
-            that = this;
+            var that = this;
             this.lastActive = new Date();
             this.transcript.push(message);
             botkit.debug('HANDLING MESSAGE IN CONVO', message);


### PR DESCRIPTION
"that" is likely being declared on the global object, which may lead to leaks.