### PR TITLE
send a 200 response when receiving a slash command

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -235,6 +235,7 @@ function Slackbot(configuration) {
                 return handleInteractiveMessage(payload, bot);
             } else if (payload.command) {
                 // this is a slash command
+                res.send('');
                 return handleSlashCommand(payload, bot);
             } else if (payload.trigger_word) {
                 return handleOutgoingWebhook(payload, bot);


### PR DESCRIPTION
sends an empty status 200 response when a slash command is received so that slack doesn't freak out