### PR TITLE
customizable webhook endpoint path

### DIFF
--- a/lib/CiscoSparkbot.js
+++ b/lib/CiscoSparkbot.js
@@ -44,6 +44,7 @@ function Sparkbot(configuration) {
             throw new Error('Please specify an SSL-enabled url for your public address: ' + controller.config.public_address);
         } else {
             controller.config.public_address = endpoint.hostname + (endpoint.port ? ':' + endpoint.port : '');
+				controller.config.public_path = endpoint.path;
         }
 
     }
@@ -74,8 +75,8 @@ function Sparkbot(configuration) {
 
         controller.log(
             '** Serving webhook endpoints for Cisco Spark Platform at: ' +
-            'http://' + controller.config.hostname + ':' + controller.config.port + '/ciscospark/receive');
-        webserver.post('/ciscospark/receive', function(req, res) {
+            'http://' + controller.config.hostname + ':' + controller.config.port + controller.config.public_path);
+        webserver.post(controller.config.public_path, function(req, res) {
 
             controller.handleWebhookPayload(req, res, bot);
 
@@ -91,7 +92,7 @@ function Sparkbot(configuration) {
                 }
             }
 
-            var hook_url = 'https://' + controller.config.public_address + '/ciscospark/receive';
+				var hook_url = 'https://' + controller.config.public_address + controller.config.public_path;
 
             console.log('Cisco Spark: incoming webhook url is ', hook_url);
 


### PR DESCRIPTION
Cisco Spark webhook endpoint path was hardcoded as /ciscospark/receive. Ideally, it should be based on the public_address env variable.