### PR TITLE
Support fb send upload

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -141,7 +141,7 @@ function Facebookbot(configuration) {
                 if (key !== 'filedata' && typeof facebook_message[key] === 'object') {
                   prepareFormdata[key] = JSON.stringify(facebook_message[key]);
                 } else if (key === 'filedata') {
-                  if (!fs.existSync(facebook_message[key])) return cb(new Error('filedata not exist'));
+                  if (!fs.existsSync(facebook_message[key])) return cb(new Error('filedata not exist'));
 
                   prepareFormdata[key] = fs.createReadStream(facebook_message[key]);
                 } else {

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -3,6 +3,7 @@ var request = require('request');
 var express = require('express');
 var bodyParser = require('body-parser');
 var crypto = require('crypto');
+var fs = require('fs');
 
 function Facebookbot(configuration) {
 
@@ -136,9 +137,13 @@ function Facebookbot(configuration) {
             var requestObj = {};
             if ('filedata' in facebook_message) {
               var prepareFormdata = {};
-              for (key in facebook_message && typeof facebook_message[key] === 'object') {
-                if (key !== 'filedata') {
+              for (key in facebook_message) {
+                if (key !== 'filedata' && typeof facebook_message[key] === 'object') {
                   prepareFormdata[key] = JSON.stringify(facebook_message[key]);
+                } else if (key === 'filedata') {
+                  if (!fs.existSync(facebook_message[key])) return cb(new Error('filedata not exist'));
+
+                  prepareFormdata[key] = fs.createReadStream(facebook_message[key]);
                 } else {
                   prepareFormdata[key] = facebook_message[key];
                 }

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -77,6 +77,10 @@ function Facebookbot(configuration) {
 
                 if (message.attachment) {
                     facebook_message.message.attachment = message.attachment;
+
+                    if (message.filedata) {
+                      facebook_message.filedata = message.filedata;
+                    }
                 }
 
                 if (message.sticker_id) {
@@ -129,31 +133,47 @@ function Facebookbot(configuration) {
             //Add Access Token to outgoing request
             facebook_message.access_token = configuration.access_token;
 
-            request({
-                method: 'POST',
-                json: true,
-                headers: {
+            var requestObj = {};
+            if ('filedata' in facebook_message) {
+              var prepareFormdata = {};
+              for (key in facebook_message && typeof facebook_message[key] === 'object') {
+                if (key !== 'filedata') {
+                  prepareFormdata[key] = JSON.stringify(facebook_message[key]);
+                } else {
+                  prepareFormdata[key] = facebook_message[key];
+                }
+              }
+              requestObj = {
+                  method: 'POST',
+                  formData: prepareFormdata,
+                  uri: 'https://' + api_host + '/v2.6/me/messages'
+              };
+            } else {
+              requestObj = {
+                  method: 'POST',
+                  json: true,
+                  headers: {
                     'content-type': 'application/json',
-                },
-                body: facebook_message,
-                uri: 'https://' + api_host + '/v2.6/me/messages'
-            },
-                function(err, res, body) {
+                  },
+                  body: facebook_message,
+                  uri: 'https://' + api_host + '/v2.6/me/messages'
+              };
+            }
 
+            request(requestObj, function(err, res, body) {
+                if (err) {
+                    botkit.debug('WEBHOOK ERROR', err);
+                    return cb && cb(err);
+                }
 
-                    if (err) {
-                        botkit.debug('WEBHOOK ERROR', err);
-                        return cb && cb(err);
-                    }
+                if (body.error) {
+                    botkit.debug('API ERROR', body.error);
+                    return cb && cb(body.error.message);
+                }
 
-                    if (body.error) {
-                        botkit.debug('API ERROR', body.error);
-                        return cb && cb(body.error.message);
-                    }
-
-                    botkit.debug('WEBHOOK SUCCESS', body);
-                    cb && cb(null, body);
-                });
+                botkit.debug('WEBHOOK SUCCESS', body);
+                cb && cb(null, body);
+            });
         };
 
         bot.startTyping = function(src, cb) {


### PR DESCRIPTION
Solved #233 

Use `filedata` to assign upload file/image describe on Content Types page in FB messenger doc. It will do a basic file validate (fs.existsSync) then stream the file using form-data.

e.g., upload png file
```
bot.reply(message, {
  attachment: {
    type: 'image',
    payload: {}
  },
  filedata: UPLOAD_FILE_PATH
})
```