### PR TITLE
Make custom auth available to the user of the OAuth endpoint.

### DIFF
--- a/docs/readme-slack.md
+++ b/docs/readme-slack.md
@@ -786,7 +786,19 @@ controller.on('create_user', function(bot, user, redirect_params) {
         // continue processing the slash command for the user
     }
 });
+
 ```
+In addition to these `createOauthEndpoints` also has `identity` and `auth` objects accessable. These can be use to handle edge cases like [sign in with slack](https://api.slack.com/docs/sign-in-with-slack) in auth flow gracefully.
+
+```
+createOauthEndpoints(controller.webserver,function(err,req,res) {
+    if(req.auth) {
+     // process
+     res.redirect(...);
+    }
+})
+```
+
 
 ### How to identify what team your message came from
 ```javascript

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -504,6 +504,7 @@ function Slackbot(configuration) {
                     }
                     slack_botkit.trigger('oauth_error', [err]);
                 } else {
+                    req.auth = auth;
 
                     // auth contains at least:
                     // { access_token, scope, team_name}


### PR DESCRIPTION
Slack now has a full identity scope with things like email, avatar. These are
not available via req.identity