### PR TITLE
Add missing error callback from team not found

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -168,6 +168,8 @@ function Slackbot(configuration) {
                             cb(null, found_team);
                         }
                     });
+                } else {
+                    cb(new Error(`could not find team ${team_id}`));
                 }
             }
         });


### PR DESCRIPTION
Not calling this error callback leads to a weird hard to debug state if you've changed your data store and forgot to re-auth the team for example.