### PR TITLE
adds use strict directive to test files that use ES6

### DIFF
--- a/__test__/lib/Botkit.test.js
+++ b/__test__/lib/Botkit.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 let botkit;
 
 jest.mock('../../lib/CoreBot', () => 'corebot');

--- a/__test__/lib/Slack_web_api.test.js
+++ b/__test__/lib/Slack_web_api.test.js
@@ -174,7 +174,20 @@ describe('postForm', () => {
             expect(cb).toHaveBeenCalledWith(error);
         });
 
-        test(`${methodName}: handles non 200 response code`, () => {
+        test(`${methodName}: handles 429 response code`, () => {
+            mockRequest.post.mockImplementation((params, callback) => {
+                callback(null, { statusCode: 429 }, null);
+            });
+
+            method('some.action', 'data', cb);
+
+            expect(mockRequest.post).toHaveBeenCalledTimes(1);
+            expect(cb).toHaveBeenCalledTimes(1);
+            const firstArg = cb.mock.calls[0][0];
+            expect(firstArg.message).toBe('Rate limit exceeded');
+        });
+
+        test(`${methodName}: handles other response codes`, () => {
             mockRequest.post.mockImplementation((params, callback) => {
                 callback(null, { statusCode: 400 }, null);
             });

--- a/__test__/lib/Slack_web_api.test.js
+++ b/__test__/lib/Slack_web_api.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 let slackWebApi;
 let mockRequest;
 let mockResponse;
@@ -206,7 +208,7 @@ describe('postForm', () => {
             method('some.action', 'data', cb);
 
             expect(mockRequest.post).toHaveBeenCalledTimes(1);
-            expect(cb).toHaveBeenCalledWith('not ok', { ok: false, error: 'not ok'});
+            expect(cb).toHaveBeenCalledWith('not ok', { ok: false, error: 'not ok' });
         });
     });
 });
@@ -219,7 +221,7 @@ describe('api methods', () => {
         instance = slackWebApi(mockBot, {});
         cb = jest.fn();
         jest.spyOn(instance, 'callAPI');
-        instance.callAPI.mockImplementation(() => {});
+        instance.callAPI.mockImplementation(() => { });
     });
 
     afterEach(() => {
@@ -253,41 +255,41 @@ describe('api methods', () => {
     describe('special cases', () => {
 
         test('chat.postMessage stringifies attachments', () => {
-            instance.chat.postMessage({attachments: []}, cb);
-            expect(instance.callAPI).toHaveBeenCalledWith('chat.postMessage', {attachments: '[]'}, cb);
+            instance.chat.postMessage({ attachments: [] }, cb);
+            expect(instance.callAPI).toHaveBeenCalledWith('chat.postMessage', { attachments: '[]' }, cb);
         });
 
         test('chat.postMessage handles attachments as Strings', () => {
             jest.spyOn(JSON, 'stringify');
-            instance.chat.postMessage({attachments: 'string'}, cb);
-            expect(instance.callAPI).toHaveBeenCalledWith('chat.postMessage', {attachments: 'string'}, cb);
+            instance.chat.postMessage({ attachments: 'string' }, cb);
+            expect(instance.callAPI).toHaveBeenCalledWith('chat.postMessage', { attachments: 'string' }, cb);
             expect(JSON.stringify).not.toHaveBeenCalled();
         });
 
         test('chat.postMessage handles attachments stringification errors', () => {
             const error = new Error('WHOOPSIE');
             jest.spyOn(JSON, 'stringify').mockImplementation(() => { throw error; });
-            instance.chat.postMessage({attachments: []}, cb);
+            instance.chat.postMessage({ attachments: [] }, cb);
             expect(instance.callAPI).toHaveBeenCalledWith('chat.postMessage', {}, cb);
             expect(JSON.stringify).toHaveBeenCalled();
         });
 
         test('chat.update stringifies attachments', () => {
-            instance.chat.update({attachments: []}, cb);
-            expect(instance.callAPI).toHaveBeenCalledWith('chat.update', {attachments: '[]'}, cb);
+            instance.chat.update({ attachments: [] }, cb);
+            expect(instance.callAPI).toHaveBeenCalledWith('chat.update', { attachments: '[]' }, cb);
         });
 
         test('chat.update handles attachments as Strings', () => {
             jest.spyOn(JSON, 'stringify');
-            instance.chat.update({attachments: 'string'}, cb);
-            expect(instance.callAPI).toHaveBeenCalledWith('chat.update', {attachments: 'string'}, cb);
+            instance.chat.update({ attachments: 'string' }, cb);
+            expect(instance.callAPI).toHaveBeenCalledWith('chat.update', { attachments: 'string' }, cb);
             expect(JSON.stringify).not.toHaveBeenCalled();
         });
 
         test('chat.postMessage handles attachments stringification errors', () => {
             const error = new Error('WHOOPSIE');
             jest.spyOn(JSON, 'stringify').mockImplementation(() => { throw error; });
-            instance.chat.update({attachments: []}, cb);
+            instance.chat.update({ attachments: [] }, cb);
             expect(instance.callAPI).toHaveBeenCalledWith('chat.update', {}, cb);
             expect(JSON.stringify).toHaveBeenCalled();
         });

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -1007,7 +1007,7 @@ function Botkit(configuration) {
         }
 
         if (typeof(events) == 'string') {
-            events = events.split(/\,/g).map(function(str) { return str.trim() })
+            events = events.split(/\,/g).map(function(str) { return str.trim(); });
         }
 
         for (var e = 0; e < events.length; e++) {

--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -227,7 +227,7 @@ module.exports = function(bot, config) {
 
         request.post(params, function(error, response, body) {
             bot.debug('Got response', error, body);
-            if(response.statusCode == 429) {
+            if (response.statusCode == 429) {
                 return cb(new Error('Rate limit exceeded'));
             }
             if (!error && response.statusCode == 200) {

--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -3,7 +3,7 @@ var request = require('request');
 /**
  * Does nothing. Takes no params, returns nothing. It's a no-op!
  */
-function noop() {}
+function noop() { }
 
 /**
  * Returns an interface to the Slack API in the context of the given bot
@@ -187,7 +187,7 @@ module.exports = function(bot, config) {
     };
 
     function sanitizeOptions(options) {
-        if (options.attachments && typeof(options.attachments) != 'string') {
+        if (options.attachments && typeof (options.attachments) != 'string') {
             try {
                 options.attachments = JSON.stringify(options.attachments);
             } catch (err) {
@@ -227,10 +227,11 @@ module.exports = function(bot, config) {
 
         request.post(params, function(error, response, body) {
             bot.debug('Got response', error, body);
-            if (response.statusCode == 429) {
-                return cb(new Error('Rate limit exceeded'));
+            if (error) {
+                return cb(error);
             }
-            if (!error && response.statusCode == 200) {
+
+            if (response.statusCode == 200) {
                 var json;
                 try {
                     json = JSON.parse(body);
@@ -239,8 +240,11 @@ module.exports = function(bot, config) {
                 }
 
                 return cb((json.ok ? null : json.error), json);
+            } else if (response.statusCode == 429) {
+                return cb(new Error('Rate limit exceeded'));
+            } else {
+                return cb(new Error('Invalid response'));
             }
-            return cb(error || new Error('Invalid response'));
         });
     }
 };


### PR DESCRIPTION
I think Node 4 requires the `use strict` directive to use `let`, `const`, and some other keywords. Under Node4 you will probably see this error:

```
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode

      at ScriptTransformer._transformAndBuildScript (node_modules/jest-cli/node_modules/jest-runtime/build/ScriptTransformer.js:289:17)
      at emitTwo (events.js:87:13)
```

This PR adds the `use strict` directive to fix these types of errors.