### PR TITLE
Added files.sharedPublicURL to slack_web_api

### DIFF
--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -53,6 +53,7 @@ module.exports = function(bot, config) {
         'files.info',
         'files.list',
         'files.upload',
+        'files.sharedPublicURL',
         'groups.archive',
         'groups.close',
         'groups.create',


### PR DESCRIPTION
This API method is not available to bot tokens, but if you override the 

> bot.api.files.sharedPublicURL({token: team.bot.app_token, file: fileId},....

it works just fine on my forked version.