### PR TITLE
[CoreBot] Hears Control Flow - Run Multiple Hears Matches

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -142,6 +142,43 @@ controller.hears(['keyword','^pattern$'],['message_received'],function(bot,messa
 });
 ```
 
+#### Control Flow
+
+By default, only the first succesfully matched hears handler is executed. Return `true` in your handler to stop executing the current handler and move on to the next hears match.
+
+Returning nothing, or `false`, will ensure no more handlers run, which is the default behavior.
+
+
+```javascript
+// sending 'bonjour' will respond in french if speaks.french is true
+// otherwise, the bot will respond with our catchall handler
+controller.hears(['^bonjour$'], 'direct_message', function(bot, message) {
+	if (speaks.french) {
+		bot.reply(message, 'Bonjour!')
+	} else {
+	// return true to move on to the next handler
+		return true
+	}
+})
+
+// sending hello will only respond with hello
+controller.hears(['^hello$'], 'direct_message', function(bot, message) {
+	bot.reply(message, 'Hello there!')
+})
+
+// sending howdy will give no response at all
+controller.hears(['^howdy$'], 'direct_message', function(bot, message) {
+	return false
+	bot.reply(message, 'nobody will ever see this')
+})
+
+controller.hears(['(.*)'], 'direct_message', function(bot, message){
+	bot.reply(message, 'I dont understand. (I respond to everything I hear)')
+})
+
+```
+
+
 When using the built in regular expression matching, the results of the expression will be stored in the `message.match` field and will match the expected output of normal Javascript `string.match(/pattern/i)`. For example:
 
 ```javascript

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -1014,12 +1014,13 @@ function Botkit(configuration) {
             (function(keywords, test_function) {
                 botkit.on(events[e], function(bot, message) {
                     if (test_function && test_function(keywords, message)) {
+						var triggerContinue
                         botkit.debug('I HEARD', keywords);
                         botkit.middleware.heard.run(bot, message, function(err, bot, message) {
-                            cb.apply(this, [bot, message]);
+                            triggerContinue = cb.apply(this, [bot, message]) ? true : false
                             botkit.trigger('heard_trigger', [bot, keywords, message]);
                         });
-                        return false;
+                        return triggerContinue;
                     }
                 });
             })(keywords, test_function);


### PR DESCRIPTION
This allows for returning early from a matched trigger, and continuing to the next (if any) matches.

This can be used to respond to a single input with multiple hears triggers, or allows you to ditch executing the current handler and either continue to your fallback handler, or another handler if present.

Ended up needing this for a project where bots are dynamically added to a server, and a bot can be either active or disabled, so if it's disabled I don't want to execute it's hears triggers. This allows me to add new bot skills to the server whenever, and enabled/disable the bots based on config details passed to them, so when a trigger fires they aren't configured for or have disabled, it will just keep executing and give the fallback.

closes #930 