### PR TITLE
[CiscoSpark] Fix direct_mention bot username replace

### DIFF
--- a/lib/CiscoSparkbot.js
+++ b/lib/CiscoSparkbot.js
@@ -210,7 +210,7 @@ function Sparkbot(configuration) {
                 if (message.original_message.html) {
 
                     // strip the mention & HTML from the message
-                    var pattern = new RegExp('^\<p\>\<spark\-mention .*?data\-object\-id\=\"' + controller.identity.id + '\".*\>.*?\<\/spark\-mention\>');
+                    var pattern = new RegExp('^(\<p\>)?\<spark\-mention .*?data\-object\-id\=\"' + controller.identity.id + '\".*\>.*?\<\/spark\-mention\>');
                     var action = message.original_message.html.replace(pattern, '');
 
                     // strip the remaining HTML tags


### PR DESCRIPTION
Regex pattern was failing on message html matching, made the leading p tag an optional capture group.