### PR TITLE
Add support for Twilio SMS outgoing media attachments (MMS)

### DIFF
--- a/docs/readme-twiliosms.md
+++ b/docs/readme-twiliosms.md
@@ -59,8 +59,8 @@ Then you need to write your bot. First, create a TwilioSMSBot instance and pass 
 * `twilio_number`: your app's phone number, found in your [Phone Numbers Dashboard](https://www.twilio.com/console/phone-numbers/dashboard) **The phone number format must be: `+15551235555`**
 
 ```js
-const TwilioSMSBot = require('botkit-sms')
-const controller = TwilioSMSBot({
+const Botkit = require('botkit')
+const controller = Botkit.twiliosmsbot({
   account_sid: process.env.TWILIO_ACCOUNT_SID,
   auth_token: process.env.TWILIO_AUTH_TOKEN,
   twilio_number: process.env.TWILIO_NUMBER

--- a/docs/readme-twiliosms.md
+++ b/docs/readme-twiliosms.md
@@ -105,14 +105,14 @@ See full example in the `examples` directory of this repo.
 
 ### Sending media attachments (MMS)
 
-To send media attachments, pass a `mediaUrl` property to any of Botkit's outgoing messages functions (`reply`, `say`, `ask`, etc.) with an optional `body` property for text that goes along with your attachment.
+To send media attachments, pass a `mediaUrl` property to any of Botkit's outgoing messages functions (`reply`, `say`, `ask`, etc.) with an optional `text` property for text that goes along with your attachment.
 
 ```js
 /*
   Sending an attachment
 */
 bot.reply(message, {
-  body: 'Optional body to go with text',
+  text: 'Optional text to go with attachment',
   mediaUrl: 'https://i.imgur.com/9n3qoKx.png'
 })
 ```

--- a/docs/readme-twiliosms.md
+++ b/docs/readme-twiliosms.md
@@ -103,6 +103,23 @@ controller.hears('.*', 'message_received', (bot, message) => {
 
 See full example in the `examples` directory of this repo.
 
+### Sending media attachments (MMS)
+
+To send media attachments, pass a `mediaUrl` property to any of Botkit's outgoing messages functions (`reply`, `say`, `ask`, etc.) with an optional `body` property for text that goes along with your attachment.
+
+```js
+/*
+  Sending an attachment
+*/
+bot.reply(message, {
+  body: 'Optional body to go with text',
+  mediaUrl: 'https://i.imgur.com/9n3qoKx.png'
+})
+```
+
+> Note: your Twilio number as well as the recipient's phone must support MMS for media attachments to work
+
+For more details on outgoing media attachments and a full list of accepted MIME types, go to [Twilio's docs on media attachment](https://www.twilio.com/docs/api/rest/accepted-mime-types).
 
 ## Documentation
 

--- a/lib/TwilioSMSBot.js
+++ b/lib/TwilioSMSBot.js
@@ -54,9 +54,12 @@ function TwilioSMS(configuration) {
             var sms = {
                 body: message.text,
                 from: configuration.twilio_number,
-                to: message.channel,
-                mediaUrl: message.mediaUrl
+                to: message.channel
             };
+
+            if (message.hasOwnProperty('medaUrl')) {
+              sms.mediaUrl = message.mediaUrl
+            }
 
             client.messages.create(sms, function(err, message) {
 

--- a/lib/TwilioSMSBot.js
+++ b/lib/TwilioSMSBot.js
@@ -54,7 +54,8 @@ function TwilioSMS(configuration) {
             var sms = {
                 body: message.text,
                 from: configuration.twilio_number,
-                to: message.channel
+                to: message.channel,
+                mediaUrl: message.mediaUrl
             };
 
             client.messages.create(sms, function(err, message) {


### PR DESCRIPTION
Hello Botkit team :wave:

## PR Summary

This PR adds support for Twilio SMS outgoing media attachments (MMS) along with documentation on how use the feature.

--- 

### Sending media attachments (MMS)

To send media attachments, pass a `mediaUrl` property to any of Botkit's outgoing messages functions (`reply`, `say`, `ask`, etc.) with an optional `text` property for text that goes along with your attachment.

```js
/*
  Sending an attachment
*/
bot.reply(message, {
  text: 'Optional text to go with attachment',
  mediaUrl: 'https://i.imgur.com/9n3qoKx.png'
})
```

> Note: your Twilio number as well as the recipient's phone must support MMS for media attachments to work

For more details on outgoing media attachments and a full list of accepted MIME types, go to [Twilio's docs on media attachment](https://www.twilio.com/docs/api/rest/accepted-mime-types).
