### PR TITLE
Add error management in CoreBot

### DIFF
--- a/__test__/lib/CoreBot.test.js
+++ b/__test__/lib/CoreBot.test.js
@@ -1,0 +1,65 @@
+var CoreBot = require('../../lib/CoreBot');
+
+describe('CoreBot', function() {
+    test('it should use the error middleware when an exception is thrown in a middleware', function() {
+        var bot = CoreBot({});
+        var errorHandler = jest.fn();
+
+        bot.middleware.heard.use(function() {
+            throw new Error('BAM!');
+        });
+        bot.middleware.error.use(errorHandler);
+
+        bot.hears('bla', 'direct_mention', function() {});
+        bot.trigger('direct_mention', [bot, { text: 'bla' }]);
+
+        expect(errorHandler).toBeCalled();
+    });
+
+    test('it should use the error middleware when an exception is passed to the "next" callback', function() {
+        var bot = CoreBot({});
+        var errorHandler = jest.fn();
+
+        bot.middleware.heard.use(function(bot, message, next) {
+            next(new Error('BAM!'));
+        });
+        bot.middleware.error.use(errorHandler);
+
+        bot.hears('bla', 'direct_mention', function() {});
+        bot.trigger('direct_mention', [bot, { text: 'bla' }]);
+
+        expect(errorHandler).toBeCalled();
+    });
+
+    test('it should NOT call the handler when an error occurs in the `heard` middleware', function() {
+        var bot = CoreBot({});
+        var messageHandler = jest.fn();
+
+        bot.middleware.heard.use(function(bot, message, next) {
+            next(new Error('BAM!'));
+        });
+
+        bot.hears('bla', 'direct_mention', messageHandler);
+        bot.trigger('direct_mention', [bot, { text: 'bla' }]);
+
+        expect(messageHandler).not.toBeCalled();
+    });
+
+    test('it should not call the error handlers recursively', function() {
+        var bot = CoreBot({});
+        var errorHandler = jest.fn();
+
+        bot.middleware.heard.use(function(bot, message, next) {
+            next(new Error('BAM!'));
+        });
+        bot.middleware.error.use(errorHandler);
+        bot.middleware.error.use(function() {
+            throw new Error('BIM!');
+        });
+
+        bot.hears('bla', 'direct_mention', function() {});
+        bot.trigger('direct_mention', [bot, { text: 'bla' }]);
+
+        expect(errorHandler).toHaveBeenCalledTimes(1);
+    });
+});

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -45,8 +45,19 @@ function Botkit(configuration) {
         spawn: ware(),
         heard: ware(),
         capture: ware(),
+        error: ware()
     };
 
+    function _errors(bot, middleware, error) {
+        botkit.log('ENTERING ERROR MIDDLEWARE AFTER AN ERROR IN A "' + middleware + '" middleware:', error.message);
+        botkit.debug(error.stack);
+        botkit.middleware.error.run(error, function(err) {
+            if (err && err !== error) {
+                botkit.log('ERROR IN ERROR MIDDLEWARE: ', err.message);
+                botkit.debug(err.stack);
+            }
+        });
+    }
 
     function Conversation(task, message) {
 
@@ -89,6 +100,9 @@ function Botkit(configuration) {
             var that = this;
             var capture_key = this.sent[this.sent.length - 1].text;
             botkit.middleware.capture.run(that.task.bot, response, that, function(err, bot, response, convo) {
+                if (err) {
+                    return _errors(botkit, 'capture', err);
+                }
                 if (response.text) {
                     response.text = response.text.trim();
                 } else {
@@ -144,6 +158,9 @@ function Botkit(configuration) {
                         for (var p = 0; p < patterns.length; p++) {
                             if (patterns[p].pattern && botkit.hears_test([patterns[p].pattern], message)) {
                                 botkit.middleware.heard.run(that.task.bot, message, function(err, bot, message) {
+                                    if (err) {
+                                        return _errors(botkit, 'heard', err);
+                                    }
                                     patterns[p].callback(message, that);
                                 });
                                 return;
@@ -155,6 +172,10 @@ function Botkit(configuration) {
                         for (var p = 0; p < patterns.length; p++) {
                             if (patterns[p].default) {
                                 botkit.middleware.heard.run(that.task.bot, message, function(err, bot, message) {
+                                    if (err) {
+                                        return _errors(botkit, 'heard', err);
+                                    }
+
                                     patterns[p].callback(message, that);
                                 });
                                 return;
@@ -1016,6 +1037,9 @@ function Botkit(configuration) {
                     if (test_function && test_function(keywords, message)) {
                         botkit.debug('I HEARD', keywords);
                         botkit.middleware.heard.run(bot, message, function(err, bot, message) {
+                            if (err) {
+                                return _errors(botkit, 'heard', err);
+                            }
                             cb.apply(this, [bot, message]);
                             botkit.trigger('heard_trigger', [bot, keywords, message]);
                         });
@@ -1089,6 +1113,7 @@ function Botkit(configuration) {
             botkit.middleware.send.run(worker, message, function(err, worker, message) {
                 if (err) {
                     botkit.log('Error in worker.say: ' + err);
+                    return _errors(botkit, 'send', err);
                 } else {
                     worker.send(message, cb);
                 }
@@ -1097,6 +1122,7 @@ function Botkit(configuration) {
         botkit.middleware.spawn.run(worker, function(err, worker) {
             if (err) {
                 botkit.log('Error in middlware.spawn.run: ' + err);
+                return _errors(botkit, 'spawn', err);
             } else {
                 botkit.trigger('spawned', [worker]);
 
@@ -1146,6 +1172,8 @@ function Botkit(configuration) {
         botkit.middleware.receive.run(bot, message, function(err, bot, message) {
             if (err) {
                 botkit.log('ERROR IN RECEIVE MIDDLEWARE: ', err);
+                return _errors(botkit, 'receive', err);
+
             } else {
                 botkit.debug('RECEIVED MESSAGE');
                 bot.findConversation(message, function(convo) {


### PR DESCRIPTION
tl;dr; This PR adds error management into BotKit.

Motivation: We are working on a bot for which we need to limit interactions with the bot to a certain list of users. Hence, we need to skip processing if the user is not in the list of "authorised" users, and the code related to this feature belongs in a middleware.

Implementation: I leveraged `ware` and its already available management of JS exceptions (see https://github.com/segmentio/ware/blob/master/test/index.js). The idea is as follows: any `Error` thrown or passed to `next()` stops the execution of the middleware, and the (BotKit) callback will then interrupt further processing and yield to the newly introduced `error` middleware.

I'll be happy to provide you with more details if required, but I'd prefer to wait for your initial comments instead of unnecessarily detailing :)