### PR TITLE
[Typescript] Add actionParams attribute to Message interface

### DIFF
--- a/lib/Botkit.d.ts
+++ b/lib/Botkit.d.ts
@@ -212,6 +212,9 @@ declare namespace botkit {
   }
   interface Message {
     action?: string;
+    actionParams ?: {
+      [index: string]: any
+    };
     channel?: string;
     match?: RegExpMatchArray;
     text?: string;


### PR DESCRIPTION
Sometimes adding action attribute is not enough and additional parameters has to be set.
This change allows to set additional parameters in actionParams field.

The alternative solution would be to allow adding any parameters to Message, by setting `[index: string]: any` at the top level.