### PR TITLE
add Slack token verification

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -72,6 +72,7 @@ function Slackbot(configuration) {
         } else {
             slack_botkit.config.clientId = slack_app_config.clientId;
             slack_botkit.config.clientSecret = slack_app_config.clientSecret;
+            slack_botkit.config.clientVerificationToken = slack_app_config.clientVerificationToken;
             if (slack_app_config.redirectUri) slack_botkit.config.redirectUri = slack_app_config.redirectUri;
             if (typeof(slack_app_config.scopes) == 'string') {
                 slack_botkit.config.scopes = slack_app_config.scopes.split(/\,/);
@@ -130,13 +131,11 @@ function Slackbot(configuration) {
             '** Serving webhook endpoints for Slash commands and outgoing ' +
             'webhooks at: http://' + slack_botkit.config.hostname + ':' + slack_botkit.config.port + '/slack/receive');
         webserver.post('/slack/receive', function(req, res) {
-
             // respond to Slack that the webhook has been received.
             res.status(200);
 
             // Now, pass the webhook into be processed
             slack_botkit.handleWebhookPayload(req, res);
-
         });
 
         return slack_botkit;
@@ -176,11 +175,16 @@ function Slackbot(configuration) {
     };
 
     slack_botkit.handleWebhookPayload = function(req, res) {
-
         // is this an events api url handshake?
         if (req.body.type === 'url_verification') {
             slack_botkit.debug('Received url handshake');
             res.json({ challenge: req.body.challenge });
+            return;
+        }
+        // is this an events api ssl varification?
+        if (req.body.ssl_check === '1') {
+            slack_botkit.debug('Received ssl check');
+            res.json({ ok: true });
             return;
         }
 
@@ -188,6 +192,14 @@ function Slackbot(configuration) {
         if (payload.payload) {
             payload = JSON.parse(payload.payload);
         }
+
+        // is this an varified request from slack?
+        if (slack_botkit.config.clientVerificationToken && payload.token !== slack_botkit.config.clientVerificationToken) {
+            slack_botkit.debug('Token varification failed, Ignoring message');
+            res.status(401);
+            return;
+        }
+
 
         slack_botkit.findAppropriateTeam(payload, function(err, team) {
             if (err) {


### PR DESCRIPTION
Slack provides a token to verify that requests are indeed coming from slack. 

I have put a optional test for this. If config has `clientVarificationToken` it will be tested against all the slash command and interactive requests. 

In addition to that when we set a new `ngrok` url in Slack, Slack does a ssl check and that breaks code. I have handled that too. 