### PR TITLE
allow to access global config in every bot spawned

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -1082,7 +1082,7 @@ function Botkit(configuration) {
 
     botkit.spawn = function(config, cb) {
 
-
+        var config = config || this.config;
         var worker = new this.worker(this, config);
         // mutate the worker so that we can call middleware
         worker.say = function(message, cb) {


### PR DESCRIPTION
I require some global config parameters to be used in bot instance then these parameters can passed in configuration. 

```javascript
ar Botkit = require('botkit');

var configuration = {
  "foo": "bar"
}
var controller = Botkit.socketbot(configuration);

// give the bot something to listen for.
controller.hears('hello',['direct_message','direct_mention','mention'],function(bot,message) {
  // now foo value is accessible here
  console.log('foo: '+ bot.config.foo)  
  bot.reply(message,'Hello yourself.');

});

```
