### PR TITLE
Fix typo preventing Twilio Media Urls

### DIFF
--- a/lib/TwilioSMSBot.js
+++ b/lib/TwilioSMSBot.js
@@ -143,7 +143,7 @@ function TwilioSMS(configuration) {
         platform_message.from = configuration.twilio_number;
         platform_message.to = message.channel;
 
-        if (message.hasOwnProperty('medaUrl')) {
+        if (message.hasOwnProperty('mediaUrl')) {
             platform_message.mediaUrl = message.mediaUrl;
         }
 


### PR DESCRIPTION
Hey there,

Just found a small typo in the Twillio SMS lib.  You can work around it if you set both `mediaUrl` and `medaUrl` like:

```convo.say({text: 'Here\'s your URL', mediaUrl: url, medaUrl: url})```

But that makes me sad.