### PR TITLE
add support for Slack dialogs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,12 +8,12 @@
 
 New: Support for [Slack Dialogs](https://api.slack.com/dialogs), including:
 
-    * `bot.createDialog()` function [Docs](docs/readme-slack.md#dialogs)
-    * `bot.replyWithDialog()` function [Docs](docs/readme-slack.md#botreplywithdialog)
-    * `bot.api.dialog.open()` function
-    * `dialog_submission` event [Docs](docs/readme-slack.md#receive-dialog-submissions)
-    * `bot.dialogOk()` function [Docs](docs/readme-slack.md#botdialogok)
-    * `bot.dialogError()` function [Docs](docs/readme-slack.md#botdialogerror)
+* `bot.createDialog()` function [Docs](docs/readme-slack.md#dialogs)
+* `bot.replyWithDialog()` function [Docs](docs/readme-slack.md#botreplywithdialog)
+* `bot.api.dialog.open()` function
+* `dialog_submission` event [Docs](docs/readme-slack.md#receive-dialog-submissions)
+* `bot.dialogOk()` function [Docs](docs/readme-slack.md#botdialogok)
+* `bot.dialogError()` function [Docs](docs/readme-slack.md#botdialogerror)
 
 Fix: Cisco Spark bots will once again receive `direct_message` and `direct_mention` events. (Fix for [#1059](https://github.com/howdyai/botkit/issues/1059))
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,14 +6,16 @@
 
 ## 0.6.3
 
-New: Support for Slack dialogs -
+New: Support for [Slack Dialogs](https://api.slack.com/dialogs), including:
 
-    * `bot.replyWithDialog()` function
-    * `bot.createDialog()` function
+    * `bot.createDialog()` function [Docs](docs/readme-slack.md#dialogs)
+    * `bot.replyWithDialog()` function [Docs](docs/readme-slack.md#botreplywithdialog)
     * `bot.api.dialog.open()` function
-    * `dialog_submission` event
-    * `bot.dialogOk()` function
-    * `bot.dialogError()` function
+    * `dialog_submission` event [Docs](docs/readme-slack.md#receive-dialog-submissions)
+    * `bot.dialogOk()` function [Docs](docs/readme-slack.md#botdialogok)
+    * `bot.dialogError()` function [Docs](docs/readme-slack.md#botdialogerror)
+
+Fix: Cisco Spark bots will once again receive `direct_message` and `direct_mention` events. (Fix for [#1059](https://github.com/howdyai/botkit/issues/1059))
 
 ## 0.6.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,10 +8,12 @@
 
 New: Support for Slack dialogs -
 
-    * `bot.api.dialog.open()` function
     * `bot.replyWithDialog()` function
     * `bot.createDialog()` function
+    * `bot.api.dialog.open()` function
     * `dialog_submission` event
+    * `bot.dialogOk()` function
+    * `bot.dialogError()` function
 
 ## 0.6.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,15 @@
 
 [Want to contribute? Read our guide!](https://github.com/howdyai/botkit/blob/master/CONTRIBUTING.md)
 
+## 0.6.3
+
+New: Support for Slack dialogs -
+
+    * `bot.api.dialog.open()` function
+    * `bot.replyWithDialog()` function
+    * `bot.createDialog()` function
+    * `dialog_submission` event
+
 ## 0.6.2
 
 Fix bug in Facebook connector: call `startTicking()` as part of object instantiation. This was missing in 0.6 and 0.6.1

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -244,7 +244,7 @@ function Slackbot(configuration) {
             // conditionally send a response back to Slack to acknowledge the message.
             // we do NOT want to respond to incoming webhooks or slash commands
             // as the response can be used by developers to actually deliver a reply
-            if (!message.command && !message.trigger_word) {
+            if (!message.command && !message.trigger_word & !message.submission) {
                 res.send('');
             }
         }
@@ -376,19 +376,22 @@ function Slackbot(configuration) {
 
             // put the action value in the text field
             // this allows button clicks to respond to asks
-            message.text = message.actions[0].value;
+            if (message.type == 'interactive_message') {
+                message.text = message.actions[0].value;
 
-            // handle menus too!
-            // take the first selected item
-            // TODO: When Slack supports multi-select menus, this will need an update!
-            if (message.actions[0].selected_options) {
-                message.text = message.actions[0].selected_options[0].value;
+                // handle menus too!
+                // take the first selected item
+                // TODO: When Slack supports multi-select menus, this will need an update!
+                if (message.actions[0].selected_options) {
+                    message.text = message.actions[0].selected_options[0].value;
+                }
+
+                message.type = 'interactive_message_callback';
+
+            } else if (message.type == 'dialog_submission') {
+                // message.submissions is where the stuff is
             }
-
-            message.type = 'interactive_message_callback';
-
         }
-
 
         next();
 

--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -3,7 +3,7 @@ var request = require('request');
 /**
  * Does nothing. Takes no params, returns nothing. It's a no-op!
  */
-function noop() { }
+function noop() {}
 
 /**
  * Returns an interface to the Slack API in the context of the given bot
@@ -61,6 +61,7 @@ module.exports = function(bot, config) {
         'conversations.setPurpose',
         'conversations.setTopic',
         'conversations.unarchive',
+        'dialog.open',
         'dnd.endDnd',
         'dnd.endSnooze',
         'dnd.info',
@@ -219,7 +220,7 @@ module.exports = function(bot, config) {
     };
 
     function sanitizeOptions(options) {
-        if (options.attachments && typeof (options.attachments) != 'string') {
+        if (options.attachments && typeof(options.attachments) != 'string') {
             try {
                 options.attachments = JSON.stringify(options.attachments);
             } catch (err) {

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -620,6 +620,122 @@ module.exports = function(botkit, config) {
         }
     };
 
+    bot.replyWithDialog = function(src, dialog_obj, cb) {
+
+        var msg = {
+            trigger_id: src.trigger_id,
+            dialog: JSON.stringify(dialog_obj)
+        };
+
+        botkit.middleware.send.run(bot, msg, function(err, bot, msg) {
+            bot.api.dialog.open(msg, cb);
+        });
+    };
+
+
+    /* helper functions for creating dialog attachments */
+    bot.createDialog = function(title, callback_id, submit_label, elements) {
+
+        var obj = {
+            data: {
+                title: title,
+                callback_id: callback_id,
+                submit_label: submit_label || null,
+                elements: elements || [],
+            },
+            title: function(v) {
+                this.data.title = v;
+                return this;
+            },
+            callback_id: function(v) {
+                this.data.callback_id = v;
+                return this;
+            },
+            submit_label: function(v) {
+                this.data.submit_label = v;
+                return this;
+            },
+            addText: function(label, name, value, options, subtype) {
+
+                var element = (typeof(label) === 'object') ? label : {
+                    label: label,
+                    name: name,
+                    value: value,
+                    type: 'text',
+                    subtype: subtype || null,
+                };
+
+                if (typeof(options) === 'object') {
+                    for (var key in options) {
+                        element[key] = options[key];
+                    }
+                }
+
+                this.data.elements.push(element);
+                return this;
+            },
+            addEmail: function(label, name, value, options) {
+                return this.addText(label, name, value, options, 'email');
+            },
+            addNumber: function(label, name, value, options) {
+                return this.addText(label, name, value, options, 'number');
+            },
+            addTel: function(label, name, value, options) {
+                return this.addText(label, name, value, options, 'tel');
+            },
+            addUrl: function(label, name, value, options) {
+                return this.addText(label, name, value, options, 'url');
+            },
+            addTextarea: function(label, name, value, options, subtype) {
+
+                var element = (typeof(label) === 'object') ? label : {
+                    label: label,
+                    name: name,
+                    value: value,
+                    type: 'textarea',
+                    subtype: subtype || null,
+                };
+
+                if (typeof(options) === 'object') {
+                    for (var key in options) {
+                        element[key] = options[key];
+                    }
+                }
+
+                this.data.elements.push(element);
+                return this;
+            },
+            addSelect: function(label, name, value, option_list, options) {
+                var element = {
+                    label: label,
+                    name: name,
+                    value: value,
+                    options: option_list,
+                    type: 'select',
+                };
+                if (typeof(options) === 'object') {
+                    for (var key in options) {
+                        element[key] = options[key];
+                    }
+                }
+
+
+                this.data.elements.push(element);
+                return this;
+            },
+            asString: function() {
+                return JSON.stringify(this.data, null, 2);
+            },
+            asObject: function() {
+                return this.data;
+            }
+        };
+
+        return obj;
+
+    };
+
+
     bot.reply = function(src, resp, cb) {
         var msg = {};
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -620,6 +620,19 @@ module.exports = function(botkit, config) {
         }
     };
 
+    bot.dialogOk = function() {
+        bot.res.send('');
+    };
+
+    bot.dialogError = function(errors) {
+        if (typeof(errors) === 'object') {
+            errors = [errors];
+        }
+        bot.res.json({
+            errors: errors
+        });
+    };
+
     bot.replyWithDialog = function(src, dialog_obj, cb) {
 
         var msg = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botkit",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Building blocks for Building Bots",
   "main": "lib/Botkit.js",
   "types": "lib/Botkit.d.ts",


### PR DESCRIPTION
In reference to:
https://github.com/howdyai/botkit/issues/1064

* adds support for the new `bot.api.dialog.open` API call
* adds a new convenience method `bot.replyWithDialog()`
* emit `dialog_submission` event with `message.submission` field
* adds `bot.createDialog()` helper
* adds ability to respond with an error with `bot.dialogError()`
* adds `bot.dialogOk()` to respond with success

TODO:
* add need documentation in the docs/readme-slack.md file
