### PR TITLE
[Slack] Fix whisper v0.6

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -460,7 +460,6 @@ function Slackbot(configuration) {
         platform_message.text =  message.text || null;
         platform_message.username =  message.username || null;
 		platform_message.user = message.to || null;
-		platform_message.as_user = message.as_user || true;
         platform_message.thread_ts =  message.thread_ts || null;
         platform_message.reply_broadcast =  message.reply_broadcast || null;
         platform_message.parse =  message.parse || null;

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -459,6 +459,8 @@ function Slackbot(configuration) {
         platform_message.channel =  message.channel;
         platform_message.text =  message.text || null;
         platform_message.username =  message.username || null;
+		platform_message.user = message.to || null;
+		platform_message.as_user = message.as_user || true;
         platform_message.thread_ts =  message.thread_ts || null;
         platform_message.reply_broadcast =  message.reply_broadcast || null;
         platform_message.parse =  message.parse || null;

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -331,91 +331,68 @@ module.exports = function(botkit, config) {
     };
 
     bot.send = function(message, cb) {
-        if (message.ephemeral) {
-            bot.sendEphemeral(message, cb);
-            return;
-        }
-        botkit.debug('SAY', message);
 
-        bot.msgcount++;
-
-        /**
-         * Use the web api to send messages unless otherwise specified
-         * OR if one of the fields that is only supported by the web api is present
-         */
-        if (
-            botkit.config.send_via_rtm !== true && message.type !== 'typing' ||
-            message.attachments || message.icon_emoji ||
-            message.username || message.icon_url) {
-
-            if (!bot.config.token) {
-                throw new Error('Cannot use web API to send messages.');
-            }
-
-            bot.api.chat.postMessage(message, function(err, res) {
-                if (err) {
-                    cb && cb(err);
-                } else {
-                    cb && cb(null, res);
-                }
-            });
-
+        if (message.type === 'ephemeral') {
+			bot.api.chat.postEphemeral(slack_message, function(err, res) {
+				if (err) {
+					cb && cb(err);
+				} else {
+					cb && cb(null, res);
+				}
+			});
         } else {
-            if (!bot.rtm)
-                throw new Error('Cannot use the RTM API to send messages.');
 
-            message.id = message.id || bot.msgcount;
+			botkit.debug('SAY', message);
+
+			bot.msgcount++;
+
+			/**
+			* Use the web api to send messages unless otherwise specified
+			* OR if one of the fields that is only supported by the web api is present
+			*/
+			if (
+				botkit.config.send_via_rtm !== true && message.type !== 'typing' ||
+				message.attachments || message.icon_emoji ||
+				message.username || message.icon_url) {
+
+				if (!bot.config.token) {
+					throw new Error('Cannot use web API to send messages.');
+				}
+
+				bot.api.chat.postMessage(message, function(err, res) {
+					if (err) {
+						cb && cb(err);
+					} else {
+						cb && cb(null, res);
+					}
+				});
+
+			} else {
+				if (!bot.rtm)
+					throw new Error('Cannot use the RTM API to send messages.');
+
+				message.id = message.id || bot.msgcount;
 
 
-            try {
-                bot.rtm.send(JSON.stringify(message), function(err) {
-                    if (err) {
-                        cb && cb(err);
-                    } else {
-                        cb && cb(null, message);
-                    }
-                });
-            } catch (err) {
-                /**
-                 * The RTM failed and for some reason it didn't get caught
-                 * elsewhere. This happens sometimes when the rtm has closed but
-                 * We are sending messages anyways.
-                 * Bot probably needs to reconnect!
-                 */
-                cb && cb(err);
-            }
-        }
-    };
-    bot.sendEphemeral = function(message, cb) {
-        botkit.debug('SAY EPHEMERAL', message);
-
-        /**
-         * Construct a valid slack message.
-         */
-        var slack_message = {
-            type: message.type || 'message',
-            channel: message.channel,
-            text: message.text || null,
-            user: message.user,
-            as_user: message.as_user || false,
-            parse: message.parse || null,
-            link_names: message.link_names || null,
-            attachments: message.attachments ?
-                JSON.stringify(message.attachments) : null,
-        };
-        bot.msgcount++;
-
-        if (!bot.config.token) {
-            throw new Error('Cannot use web API to send messages.');
-        }
-
-        bot.api.chat.postEphemeral(slack_message, function(err, res) {
-            if (err) {
-                cb && cb(err);
-            } else {
-                cb && cb(null, res);
-            }
-        });
+				try {
+					bot.rtm.send(JSON.stringify(message), function(err) {
+						if (err) {
+							cb && cb(err);
+						} else {
+							cb && cb(null, message);
+						}
+					});
+				} catch (err) {
+					/**
+					* The RTM failed and for some reason it didn't get caught
+					* elsewhere. This happens sometimes when the rtm has closed but
+					* We are sending messages anyways.
+					* Bot probably needs to reconnect!
+					*/
+					cb && cb(err);
+				}
+			}
+		}
     };
 
     /**
@@ -765,9 +742,8 @@ module.exports = function(botkit, config) {
         if (src.thread_ts) {
             msg.thread_ts = src.thread_ts;
         }
-        if (msg.ephemeral && !msg.user) {
+        if (msg.type === 'ephemeral' || msg.ephemeral && !msg.user) {
             msg.user = src.user;
-            msg.as_user = true;
         }
 
         bot.say(msg, cb);
@@ -783,9 +759,8 @@ module.exports = function(botkit, config) {
         }
 
         msg.channel = src.channel;
-        msg.user = src.user;
-        msg.as_user = true;
-        msg.ephemeral = true;
+        msg.to = src.user;
+        msg.type = 'ephemeral';
 
         bot.say(msg, cb);
     };

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -742,9 +742,6 @@ module.exports = function(botkit, config) {
         if (src.thread_ts) {
             msg.thread_ts = src.thread_ts;
         }
-        if (msg.type === 'ephemeral' || msg.ephemeral && !msg.user) {
-            msg.user = src.user;
-        }
 
         bot.say(msg, cb);
     };


### PR DESCRIPTION
#1071 Says it all

This PR is not working, wanted to share my progress before going to sleep in my TZ

Currently ephemeral message info is not making it out of format middleware

I changed whisper to just set message type to `'ephemeral'` and set the `user` field on outgoing request to slack (required info for ephemeral messages).

But I ran into this error and I can't find where slack_message is referenced at all in format:
`info: An error occured in the format middleware: ReferenceError: slack_message is not defined`
