### PR TITLE
tests if errors is an array in dialogError

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -625,9 +625,14 @@ module.exports = function(botkit, config) {
     };
 
     bot.dialogError = function(errors) {
-        if (typeof(errors) === 'object') {
+        if (!errors) {
+            errors = [];
+        }
+
+        if (Object.prototype.toString.call(errors) !== '[object Array]') {
             errors = [errors];
         }
+
         bot.res.json({
             errors: errors
         });


### PR DESCRIPTION
Tests for errors array in a safe way. I used `Object.prototype.toString.call` to be backwards compatible with pre-6 versions of Node. Otherwise Array.isArray would be the preferred way. 

Closes #1079.