### PR TITLE
add mrkdwn_in to SlackAttachment in TypeScript definition

### DIFF
--- a/lib/Botkit.d.ts
+++ b/lib/Botkit.d.ts
@@ -231,6 +231,7 @@ declare namespace botkit {
     footer?: string;
     footer_icon?: string;
     image_url?: string;
+    mrkdwn_in?: string[];
     pretext?: string;
     text?: string;
     thumb_url?: string;


### PR DESCRIPTION
Documentation: https://api.slack.com/docs/formatting#message_formatting

Test Page: https://api.slack.com/docs/messages/builder?msg=%7B%22attachments%22%3A%5B%7B%22title%22%3A%22Title%22%2C%22pretext%22%3A%22Pretext%20_supports_%20mrkdwn%22%2C%22text%22%3A%22Testing%20*right%20now!*%22%2C%22mrkdwn_in%22%3A%5B%22text%22%2C%22pretext%22%5D%7D%5D%7D