### PR TITLE
Add bot.getMessageUser function to primary platforms

### DIFF
--- a/lib/CiscoSparkbot.js
+++ b/lib/CiscoSparkbot.js
@@ -481,7 +481,7 @@ function Sparkbot(configuration) {
               }
               resolve(profile);
 
-            }).catch(err) {
+            }).catch(function(err) {
               if (cb) {
                 cb(err);
               }

--- a/lib/CiscoSparkbot.js
+++ b/lib/CiscoSparkbot.js
@@ -459,14 +459,14 @@ function Sparkbot(configuration) {
 
         };
 
-        bot.getUser = function(user, cb) {
+        bot.getMessageUser = function(message, cb) {
             return new Promise(function(resolve, reject) {
 
-                controller.api.people.get(user).then(function(identity) {
+                controller.api.people.get(message.raw_message.actorId).then(function(identity) {
 
                     // normalize this into what botkit wants to see
                     var profile = {
-                        id: user,
+                        id: message.raw_message.actorId,
                         username: identity.displayName,
                         first_name: identity.firstName,
                         last_name: identity.lastName,

--- a/lib/CiscoSparkbot.js
+++ b/lib/CiscoSparkbot.js
@@ -459,6 +459,38 @@ function Sparkbot(configuration) {
 
         };
 
+        bot.getUser = function(user, cb) {
+          return new Promise(function(resolve, reject) {
+
+            controller.api.people.get(user).then(function(identity) {
+
+              // normalize this into what botkit wants to see
+              var profile = {
+                id: user,
+                username: identity.displayName,
+                first_name: identity.firstName,
+                last_name: identity.lastName,
+                full_name: identity.firstName + ' ' + identity.lastName,
+                email: identity.emails[0],
+                gender: null, // no source for this info
+                timezone: null, // no source for this info
+              }
+
+              if (cb) {
+                cb(null, profile);
+              }
+              resolve(profile);
+
+            }).catch(err) {
+              if (cb) {
+                cb(err);
+              }
+              reject(err);
+            });
+          })
+
+        }
+
         return bot;
 
     });

--- a/lib/CiscoSparkbot.js
+++ b/lib/CiscoSparkbot.js
@@ -460,36 +460,36 @@ function Sparkbot(configuration) {
         };
 
         bot.getUser = function(user, cb) {
-          return new Promise(function(resolve, reject) {
+            return new Promise(function(resolve, reject) {
 
-            controller.api.people.get(user).then(function(identity) {
+                controller.api.people.get(user).then(function(identity) {
 
-              // normalize this into what botkit wants to see
-              var profile = {
-                id: user,
-                username: identity.displayName,
-                first_name: identity.firstName,
-                last_name: identity.lastName,
-                full_name: identity.firstName + ' ' + identity.lastName,
-                email: identity.emails[0],
-                gender: null, // no source for this info
-                timezone: null, // no source for this info
-              }
+                    // normalize this into what botkit wants to see
+                    var profile = {
+                        id: user,
+                        username: identity.displayName,
+                        first_name: identity.firstName,
+                        last_name: identity.lastName,
+                        full_name: identity.firstName + ' ' + identity.lastName,
+                        email: identity.emails[0],
+                        gender: null, // no source for this info
+                        timezone: null, // no source for this info
+                    };
 
-              if (cb) {
-                cb(null, profile);
-              }
-              resolve(profile);
+                    if (cb) {
+                        cb(null, profile);
+                    }
+                    resolve(profile);
 
-            }).catch(function(err) {
-              if (cb) {
-                cb(err);
-              }
-              reject(err);
+                }).catch(function(err) {
+                    if (cb) {
+                        cb(err);
+                    }
+                    reject(err);
+                });
             });
-          })
 
-        }
+        };
 
         return bot;
 

--- a/lib/CiscoSparkbot.js
+++ b/lib/CiscoSparkbot.js
@@ -462,18 +462,28 @@ function Sparkbot(configuration) {
         bot.getMessageUser = function(message, cb) {
             return new Promise(function(resolve, reject) {
 
-                controller.api.people.get(message.raw_message.actorId).then(function(identity) {
+                controller.api.people.list({email: message.user}).then(function(identity) {
+                    if (identity.length) {
+                        identity = identity.items[0];
+                    } else {
+                        if (cb) {
+                            cb('User not found');
+                        }
+
+                        return reject('User not found');
+                    }
 
                     // normalize this into what botkit wants to see
                     var profile = {
-                        id: message.raw_message.actorId,
+                        id: identity.id,
                         username: identity.displayName,
                         first_name: identity.firstName,
                         last_name: identity.lastName,
                         full_name: identity.firstName + ' ' + identity.lastName,
                         email: identity.emails[0],
                         gender: null, // no source for this info
-                        timezone: null, // no source for this info
+                        timezone_offset: null, // no source for this info
+                        timezone: identity.timezone, // this MAY be set depending on user settings
                     };
 
                     if (cb) {

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -668,9 +668,12 @@ function Facebookbot(configuration) {
         }
     };
 
-    var user_profile = function(uid, cb) {
+    var user_profile = function(uid, fields, cb) {
+        if (!fields) {
+          fields = 'first_name,last_name,timezone,gender,locale';
+        }
         return new Promise(function(resolve, reject) {
-            var uri = 'https://' + api_host + '/v2.6/' + uid + '&access_token=' + configuration.access_token;
+            var uri = 'https://' + api_host + '/v2.6/' + uid + '?fields=' + fields + '&access_token=' + configuration.access_token;
             request.post(uri, {},
                 function(err, res, body) {
                     if (err) {

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -258,7 +258,7 @@ function Facebookbot(configuration) {
               }
               resolve(profile);
 
-            }).catch(err) {
+            }).catch(function(err) {
               if (cb) {
                 cb(err);
               }

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -250,7 +250,7 @@ function Facebookbot(configuration) {
                         full_name: identity.first_name + ' ' + identity.last_name,
                         email: null, // no source for this info
                         gender: identity.gender,
-                        timezone: identity.timezone
+                        timezone_offset: identity.timezone,
                     };
 
                     if (cb) {

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -668,13 +668,72 @@ function Facebookbot(configuration) {
         }
     };
 
+    var user_profile = function(uid, cb) {
+        return new Promise(function(resolve, reject) {
+            var uri = 'https://' + api_host + '/v2.6/' + uid + '&access_token=' + configuration.access_token;
+            request.post(uri, {},
+                function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not get user profile:', err);
+                        if (cb) {
+                            cb(err);
+                        } else {
+                            reject(err);
+                        }
+                        return;
+                    } else {
+
+                        var results = null;
+                        try {
+                            results = JSON.parse(body);
+                        } catch (err) {
+                            facebook_botkit.log('ERROR in user profile call: Could not parse JSON', err, body);
+                            if (cb) {
+                                cb(err);
+                            } else {
+                                reject(err);
+                            }
+                            return;
+                        }
+
+                        if (results) {
+                            if (results.error) {
+                                facebook_botkit.log('ERROR in user profile API call: ', results.error.message);
+                                if (cb) {
+                                    cb(results.error);
+                                } else {
+                                    reject(results.error);
+                                }
+                            } else {
+                                if (cb) {
+                                    cb(null, results);
+                                } else {
+                                    resolve(results);
+                                }
+                            }
+                        }
+                    }
+                });
+        });
+    };
+
+
+
+
+
+
     facebook_botkit.api = {
+        'user_profile': user_profile,
         'messenger_profile': messenger_profile_api,
         'thread_settings': messenger_profile_api,
         'attachment_upload': attachment_upload_api,
         'nlp': nlp,
         'tags': tags,
     };
+
+
+
+
 
     // Verifies the SHA1 signature of the raw request payload before bodyParser parses it
     // Will abort parsing if signature is invalid, and pass a generic error to response

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -237,13 +237,13 @@ function Facebookbot(configuration) {
             cb();
         };
 
-        bot.getUser = function(user, cb) {
+        bot.getMessageUser = function(message, cb) {
             return new Promise(function(resolve, reject) {
-                facebook_botkit.api.user_profile(user).then(function(identity) {
+                facebook_botkit.api.user_profile(message.user).then(function(identity) {
 
                     // normalize this into what botkit wants to see
                     var profile = {
-                        id: user,
+                        id: message.user,
                         username: identity.first_name + ' ' + identity.last_name,
                         first_name: identity.first_name,
                         last_name: identity.last_name,

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -238,35 +238,35 @@ function Facebookbot(configuration) {
         };
 
         bot.getUser = function(user, cb) {
-          return new Promise(function(resolve, reject) {
-            facebook_botkit.api.user_profile(user).then(function(identity) {
+            return new Promise(function(resolve, reject) {
+                facebook_botkit.api.user_profile(user).then(function(identity) {
 
-              // normalize this into what botkit wants to see
-              var profile = {
-                id: user,
-                username: identity.first_name + ' ' + identity.last_name,
-                first_name: identity.first_name,
-                last_name: identity.last_name,
-                full_name: identity.first_name + ' ' + identity.last_name,
-                email: null, // no source for this info
-                gender: identity.gender,
-                timezone: identity.timezone
-              }
+                    // normalize this into what botkit wants to see
+                    var profile = {
+                        id: user,
+                        username: identity.first_name + ' ' + identity.last_name,
+                        first_name: identity.first_name,
+                        last_name: identity.last_name,
+                        full_name: identity.first_name + ' ' + identity.last_name,
+                        email: null, // no source for this info
+                        gender: identity.gender,
+                        timezone: identity.timezone
+                    };
 
-              if (cb) {
-                cb(null, profile);
-              }
-              resolve(profile);
+                    if (cb) {
+                        cb(null, profile);
+                    }
+                    resolve(profile);
 
-            }).catch(function(err) {
-              if (cb) {
-                cb(err);
-              }
-              reject(err);
+                }).catch(function(err) {
+                    if (cb) {
+                        cb(err);
+                    }
+                    reject(err);
+                });
             });
-          })
 
-        }
+        };
 
 
 
@@ -705,7 +705,7 @@ function Facebookbot(configuration) {
 
     var user_profile = function(uid, fields, cb) {
         if (!fields) {
-          fields = 'first_name,last_name,timezone,gender,locale';
+            fields = 'first_name,last_name,timezone,gender,locale';
         }
         return new Promise(function(resolve, reject) {
             var uri = 'https://' + api_host + '/v2.6/' + uid + '?fields=' + fields + '&access_token=' + configuration.access_token;

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -239,7 +239,7 @@ function Facebookbot(configuration) {
 
         bot.getUser = function(user, cb) {
           return new Promise(function(resolve, reject) {
-            controller.api.user_profile(user).then(function(identity) {
+            facebook_botkit.api.user_profile(user).then(function(identity) {
 
               // normalize this into what botkit wants to see
               var profile = {

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -236,6 +236,41 @@ function Facebookbot(configuration) {
 
             cb();
         };
+
+        bot.getUser = function(user, cb) {
+          return new Promise(function(resolve, reject) {
+            controller.api.user_profile(user).then(function(identity) {
+
+              // normalize this into what botkit wants to see
+              var profile = {
+                id: user,
+                username: identity.first_name + ' ' + identity.last_name,
+                first_name: identity.first_name,
+                last_name: identity.last_name,
+                full_name: identity.first_name + ' ' + identity.last_name,
+                email: null, // no source for this info
+                gender: identity.gender,
+                timezone: identity.timezone
+              }
+
+              if (cb) {
+                cb(null, profile);
+              }
+              resolve(profile);
+
+            }).catch(err) {
+              if (cb) {
+                cb(err);
+              }
+              reject(err);
+            });
+          })
+
+        }
+
+
+
+
         return bot;
     });
 
@@ -674,7 +709,7 @@ function Facebookbot(configuration) {
         }
         return new Promise(function(resolve, reject) {
             var uri = 'https://' + api_host + '/v2.6/' + uid + '?fields=' + fields + '&access_token=' + configuration.access_token;
-            request.post(uri, {},
+            request.get(uri, {},
                 function(err, res, body) {
                     if (err) {
                         facebook_botkit.log('Could not get user profile:', err);

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -899,9 +899,9 @@ module.exports = function(botkit, config) {
     };
 
 
-    bot.getUser = function(user, cb) {
+    bot.getMessageUser = function(message, cb) {
         return new Promise(function(resolve, reject) {
-            bot.api.users.info({user: user}, function(err, identity) {
+            bot.api.users.info({user: message.user}, function(err, identity) {
                 if (err) {
                     if (cb) {
                         cb(err);
@@ -910,7 +910,7 @@ module.exports = function(botkit, config) {
                 }
                 // normalize this into what botkit wants to see
                 var profile = {
-                    id: user,
+                    id: message.user,
                     username: identity.user.profile.display_name,
                     first_name: identity.user.profile.first_name,
                     last_name: identity.user.profile.last_name,

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -898,6 +898,41 @@ module.exports = function(botkit, config) {
         cb();
     };
 
+
+    bot.getUser = function(user, cb) {
+        return new Promise(function(resolve, reject) {
+            bot.api.user.info(user).then(function(identity) {
+
+                // normalize this into what botkit wants to see
+                var profile = {
+                    id: user,
+                    username: identity.user.profile.display_name,
+                    first_name: identity.user.profile.first_name,
+                    last_name: identity.user.profile.last_name,
+                    full_name: identity.user.profile.real_name,
+                    email: identity.user.profile.email, // may be blank
+                    gender: null, // no source for this info
+                    timezone: (identity.user.tz_offset / (60 * 60)) // convert from seconds to hours
+                };
+
+                if (cb) {
+                    cb(null, profile);
+                }
+                resolve(profile);
+
+            }).catch(function(err) {
+                if (cb) {
+                    cb(err);
+                }
+                reject(err);
+            });
+        });
+
+    };
+
+
+
+
     if (bot.config.incoming_webhook)
         bot.configureIncomingWebhook(config.incoming_webhook);
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -901,8 +901,13 @@ module.exports = function(botkit, config) {
 
     bot.getUser = function(user, cb) {
         return new Promise(function(resolve, reject) {
-            bot.api.user.info(user).then(function(identity) {
-
+            bot.api.users.info({user: user}, function(err, identity) {
+                if (err) {
+                    if (cb) {
+                        cb(err);
+                    }
+                    return reject(err);
+                }
                 // normalize this into what botkit wants to see
                 var profile = {
                     id: user,
@@ -914,17 +919,10 @@ module.exports = function(botkit, config) {
                     gender: null, // no source for this info
                     timezone: (identity.user.tz_offset / (60 * 60)) // convert from seconds to hours
                 };
-
                 if (cb) {
                     cb(null, profile);
                 }
                 resolve(profile);
-
-            }).catch(function(err) {
-                if (cb) {
-                    cb(err);
-                }
-                reject(err);
             });
         });
 

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -917,7 +917,8 @@ module.exports = function(botkit, config) {
                     full_name: identity.user.profile.real_name,
                     email: identity.user.profile.email, // may be blank
                     gender: null, // no source for this info
-                    timezone: (identity.user.tz_offset / (60 * 60)) // convert from seconds to hours
+                    timezone_offset: (identity.user.tz_offset / (60 * 60)), // convert from seconds to hours
+                    timezone: identity.user.tz, 
                 };
                 if (cb) {
                     cb(null, profile);

--- a/lib/Teams.js
+++ b/lib/Teams.js
@@ -209,6 +209,7 @@ function TeamsBot(configuration) {
                         email: identity.email, // may be blank
                         gender: null, // no source for this info
                         timezone: null, //  no source for this info
+                        timezone_offset: null, // no source for this info
                     };
                     if (cb) {
                         cb(null, profile);

--- a/lib/Teams.js
+++ b/lib/Teams.js
@@ -190,6 +190,34 @@ function TeamsBot(configuration) {
             cb();
         };
 
+        bot.getMessageUser = function(message, cb) {
+            return new Promise(function(resolve, reject) {
+                bot.api.getUserById(message.channel,  message.user, function(err, identity) {
+                    if (err) {
+                        if (cb) {
+                            cb(err);
+                        }
+                        return reject(err);
+                    }
+                    // normalize this into what botkit wants to see
+                    var profile = {
+                        id: message.user,
+                        username: identity.name,
+                        first_name: identity.givenName,
+                        last_name: identity.surname,
+                        full_name: identity.givenName + ' ' + identity.surname,
+                        email: identity.email, // may be blank
+                        gender: null, // no source for this info
+                        timezone: null, //  no source for this info
+                    };
+                    if (cb) {
+                        cb(null, profile);
+                    }
+                    resolve(profile);
+                });
+            });
+
+        };
 
         /* helper functions for creating attachments */
         bot.createAttachment = function(type, title, subtitle, text, images, buttons, tap) {


### PR DESCRIPTION
Adds a standardized mechanism for loading a standardized user profile for Slack, Teams, Cisco Spark and Facebook.

As a promise:
`bot.getMessageUser(message).then(function(profile) { ... });`

As a callback:
`bot.getMessageUser(message, function(err, profile {...});`

`profile` object will contain:

`{
username:
first_name:
last_name:
full_name:
gender:
timezone:
timezone_offset:
email:
}`