### PR TITLE
Include 'template' to possible FacebookAttachment types

### DIFF
--- a/lib/Botkit.d.ts
+++ b/lib/Botkit.d.ts
@@ -145,7 +145,7 @@ declare namespace botkit {
     multiple?: boolean;
   }
   interface FacebookAttachment {
-    type: 'audio' | 'file' | 'image' | 'video';
+    type: 'audio' | 'file' | 'image' | 'template' | 'video';
     payload: any;
   }
   interface FacebookBot extends Bot<FacebookSpawnConfiguration, FacebookMessage> {


### PR DESCRIPTION
A attachment may have one of the following types: "image", "audio", "video", "file" or "template", as defined here: https://developers.facebook.com/docs/messenger-platform/reference/send-api/#attachment