### PR TITLE
fix bug when using Facebook Checkbox Plugin the message.sender.id is …

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -287,6 +287,11 @@ function Facebookbot(configuration) {
     // handle normal messages from users (text, stickers, files, etc count!)
     facebook_botkit.middleware.normalize.use(function normalizeMessage(bot, message, next) {
 
+    	// in case of Checkbox Plug-in sender.id is not present, instead we should look at optin.user_ref
+    	if(!message.sender && message.optin && message.optin.user_ref){
+            message.sender = {id: message.optin.user_ref};
+        }
+
         // capture the user ID
         message.user = message.sender.id;
 


### PR DESCRIPTION
…not present. fix #834