### PR TITLE
validate twilio signature for webhook endpoints in twilioSMSBot

### DIFF
--- a/examples/twilio_sms_bot.js
+++ b/examples/twilio_sms_bot.js
@@ -1,4 +1,4 @@
-var Botkit = require('./lib/Botkit.js');
+var Botkit = require('../lib/Botkit.js');
 var os = require('os');
 
 var controller = Botkit.twiliosmsbot({

--- a/lib/TwilioSMSBot.js
+++ b/lib/TwilioSMSBot.js
@@ -161,6 +161,10 @@ function TwilioSMS(configuration) {
 
         var endpoint = twilioSMS.config.endpoint || '/sms/receive';
 
+        if (twilioSMS.config.validate_requests === true) {
+            webserver.post(endpoint, verifyRequest);
+        }
+
         webserver.post(endpoint, function(req, res) {
             twilioSMS.handleWebhookPayload(req, res, bot);
 
@@ -174,6 +178,20 @@ function TwilioSMS(configuration) {
 
         return twilioSMS;
     };
+
+    // validate that requests are coming from twilio
+    function verifyRequest(req, res, next) {
+        var twilioSignature = req.headers['x-twilio-signature'];
+        var url = (req.headers['x-forwarded-proto'] || req.protocol) + '://' + req.hostname + req.originalUrl;
+        if (twilio.validateRequest(twilioSMS.config.auth_token, twilioSignature, url, req.body)) {
+            next();
+        } else {
+            twilioSMS.log('** Invalid twilio signature on incoming request!');
+            res.status(400).send({
+                error: 'Invalid signature.'
+            });
+        }
+    }
 
     twilioSMS.startTicking();
 

--- a/lib/TwilioSMSBot.js
+++ b/lib/TwilioSMSBot.js
@@ -182,8 +182,11 @@ function TwilioSMS(configuration) {
     // validate that requests are coming from twilio
     function verifyRequest(req, res, next) {
         var twilioSignature = req.headers['x-twilio-signature'];
-        var url = (req.headers['x-forwarded-proto'] || req.protocol) + '://' + req.hostname + req.originalUrl;
-        if (twilio.validateRequest(twilioSMS.config.auth_token, twilioSignature, url, req.body)) {
+
+        var validation_url = twilioSMS.config.validation_url ||
+            ((req.headers['x-forwarded-proto'] || req.protocol) + '://' + req.hostname + req.originalUrl);
+
+        if (twilio.validateRequest(twilioSMS.config.auth_token, twilioSignature, validation_url, req.body)) {
             next();
         } else {
             twilioSMS.log('** Invalid twilio signature on incoming request!');


### PR DESCRIPTION
This is a fix for issue https://github.com/howdyai/botkit/issues/1107

Purpose: twilio signature validation feature needed for webhook endpoint in twilio-sms-bot
Changes: as suggested in https://www.twilio.com/docs/api/security