### PR TITLE
Add hears_regexp to TypeScript definition.

### DIFF
--- a/lib/Botkit.d.ts
+++ b/lib/Botkit.d.ts
@@ -87,7 +87,7 @@ declare namespace botkit {
   interface ConsoleSpawnConfiguration {
   }
   interface Controller<S, M extends Message, B extends Bot<S, M>> {
-    readonly changeEars: HearsFunction<M>;
+    readonly hears_regexp: HearsFunction<M>;
     readonly log: {
       (...params: any[]): void;
     }
@@ -111,6 +111,7 @@ declare namespace botkit {
       teams: Storage<Team>;
     };
     readonly studio: Studio<S, M, B>;
+    changeEars(new_test: HearsFunction<M>): void;
     hears(keywords: string | string[] | RegExp | RegExp[], events: string | string[], cb: HearsCallback<S, M, B>): this;
     hears(keywords: string | string[] | RegExp | RegExp[], events: string | string[], middleware_or_cb: HearsFunction<M>, cb: HearsCallback<S, M, B>): this;
     on(event: string, cb: HearsCallback<S, M, B>): this;


### PR DESCRIPTION
Add `hears_regexp` function, and fix wrong type definition on `changeEars`.

I want to create a bot which doesn't react on the `#general` channel:

```typescript
const controller: botkit.SlackController = botkit.slackbot(<botkit.Configuration>{});

function messageFilter(patterns: string | string[] | RegExp | RegExp[], message: botkit.Message): boolean {
    // hears default function + Check whether the channel of message is #general.
    return message.channel != "#general" && controller.hears_regexp(patterns, message);
};

controller.hears(["hello", "hi"], "direct_message", messageFilter, function(bot: botkit.SlackBot, message: botkit.Message) {
    bot.reply(message, "hello");
});
```