### PR TITLE
Removed crypto dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "ciscospark": "1.8.0",
     "clone": "2.1.1",
     "command-line-args": "^4.0.2",
-    "crypto": "0.0.3",
     "debug": "^2.6.6",
     "express": "^4.15.2",
     "https-proxy-agent": "^2.0.0",


### PR DESCRIPTION
Every time when I run `npm update` I get this warning.
> npm WARN deprecated crypto@0.0.3: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.

The only crypto method use by botkit is crypto.createHmac and it has never been provided by crypto package.
Crypto package provides implementation of md5 and sha1 functions: https://github.com/Gozala/crypto/tree/v0.0.3/