### PR TITLE
pass error object to the callbacks for failed send Api calls

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -157,7 +157,7 @@ function Facebookbot(configuration) {
 
                     if (body.error) {
                         botkit.debug('API ERROR', body.error);
-                        return cb && cb(body.error.message);
+                        return cb && cb(body.error);
                     }
 
                     botkit.debug('WEBHOOK SUCCESS', body);


### PR DESCRIPTION
Fix for #1146 