### PR TITLE
[CoreBot] Don't suppress errors

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -1202,10 +1202,16 @@ function Botkit(configuration) {
             botkit.middleware.send.run(worker, message, function(err, worker, message) {
                 if (err) {
                     botkit.log('An error occured in the send middleware:: ' + err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     botkit.middleware.format.run(worker, message, platform_message, function(err, worker, message, platform_message) {
                         if (err) {
                             botkit.log('An error occured in the format middleware: ' + err);
+                            if (cb) {
+                                cb(err);
+                            }
                         } else {
                             worker.send(platform_message, cb);
                         }
@@ -1225,7 +1231,7 @@ function Botkit(configuration) {
 
         botkit.middleware.spawn.run(worker, function(err, worker) {
             if (err) {
-                botkit.log('Error in middlware.spawn.run: ' + err);
+                botkit.log('Error in middleware.spawn.run: ' + err);
             } else {
                 botkit.trigger('spawned', [worker]);
 
@@ -1336,6 +1342,9 @@ function Botkit(configuration) {
 
         this.say = function(message, cb) {
             botkit.debug('SAY:', message);
+            if (cb) {
+                cb();
+            }
         };
 
         this.replyWithQuestion = function(message, question, cb) {


### PR DESCRIPTION
I don't know if this change fixes any real issue, but not calling a callback when it is provided is obviously wrong.