### PR TITLE
Upgrade ws library

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -185,7 +185,7 @@ module.exports = function(botkit, config) {
                 pingTimeoutId = setTimeout(pinger, 5000);
 
                 botkit.trigger('rtm_open', [bot]);
-                bot.rtm.on('message', function(data, flags) {
+                bot.rtm.on('message', function(data) {
 
                     var message = null;
                     try {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "twilio": "^2.11.1",
     "vorpal": "^1.12.0",
     "ware": "^1.3.0",
-    "ws": "^2.2.2"
+    "ws": "^3.3.2"
   },
   "devDependencies": {
     "jest-cli": "^20.0.1",


### PR DESCRIPTION
Breaking changes in [3.0.0](https://github.com/websockets/ws/releases/tag/3.0.0) were:
```
    Removed the upgradeReq property (#1099).
    Removed unnecessary events (#1100).
    Removed the flags argument from the 'message', 'ping', and 'pong'
    events (#1101).
    The permessage-deflate extension is now disabled by default on the server
    (#1107).
```

Only flag argument change affects botkit, but flags argument was unused.