### PR TITLE
Add delete method to in-memory store

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -979,6 +979,10 @@ function Botkit(configuration) {
                     cb('No ID specified');
                 }
             },
+            delete: function(team_id, cb) {
+                delete(botkit.memory_store.teams[team_id]);
+                cb();
+            },
             all: function(cb) {
                 cb(null, botkit.memory_store.teams);
             }
@@ -996,6 +1000,10 @@ function Botkit(configuration) {
                     cb('No ID specified');
                 }
             },
+            delete: function(user_id, cb) {
+                delete(botkit.memory_store.users[user_id]);
+                cb();
+            },
             all: function(cb) {
                 cb(null, botkit.memory_store.users);
             }
@@ -1012,6 +1020,10 @@ function Botkit(configuration) {
                 } else {
                     cb('No ID specified');
                 }
+            },
+            delete: function(user_id, cb) {
+                delete(botkit.memory_store.channels[channel_id]);
+                cb();
             },
             all: function(cb) {
                 cb(null, botkit.memory_store.channels);


### PR DESCRIPTION
Most storage methods have no delete method,
but [simple_storage(files)](https://github.com/howdyai/botkit/blob/master/lib/storage/simple_storage.js#L59),  [couchdb](https://github.com/barlock/botkit-storage-couchdb/blob/master/lib/storage.js#L60) and [beepboop](https://github.com/BeepBoopHQ/botkit-storage-beepboop/blob/master/src/storage.js#L84) storage modules have it, so I am adding it to memory store.