### PR TITLE
memory store: don't log warning after each save

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -971,7 +971,6 @@ function Botkit(configuration) {
                 cb(null, botkit.memory_store.teams[team_id]);
             },
             save: function(team, cb) {
-                botkit.log('Warning: using temporary storage. Data will be lost when process restarts.');
                 if (team.id) {
                     botkit.memory_store.teams[team.id] = team;
                     cb(null, team.id);
@@ -988,7 +987,6 @@ function Botkit(configuration) {
                 cb(null, botkit.memory_store.users[user_id]);
             },
             save: function(user, cb) {
-                botkit.log('Warning: using temporary storage. Data will be lost when process restarts.');
                 if (user.id) {
                     botkit.memory_store.users[user.id] = user;
                     cb(null, user.id);
@@ -1005,7 +1003,6 @@ function Botkit(configuration) {
                 cb(null, botkit.memory_store.channels[channel_id]);
             },
             save: function(channel, cb) {
-                botkit.log('Warning: using temporary storage. Data will be lost when process restarts.');
                 if (channel.id) {
                     botkit.memory_store.channels[channel.id] = channel;
                     cb(null, channel.id);


### PR DESCRIPTION
It is annoying, one warning on startup is enough.

```js
botkit.log('** No persistent storage method specified! Data may be lost when process shuts down.');
```
https://github.com/howdyai/botkit/blob/v0.6.6/lib/CoreBot.js#L1458

## Background

I am using botkit-middleware-watson in my projects, it passes each message to Watson Conversation and stores current state to botkit storage after receiving response from Conversation.

At first I used file storage (default option from starter-kit).
Then I started writing tests with testmybot and found that memory storage fits my needs better.
But getting `Warning: using temporary storage. Data will be lost when process restarts.` line after each passed message pollutes test output quite a lot.

When we got ready to deploy in production, we discussed things with our security person and he wasn't very happy that we are storing sensitive data in plain text files (name and email address are sensitive according to GDPR regulations), using memory storage is good enough alternative.
But now our production logs are full of these annoying temporary warnings.

I think that one warning on startup is enough.
