### PR TITLE
Securing FB Graph API Requests

### DIFF
--- a/docs/readme-facebook.md
+++ b/docs/readme-facebook.md
@@ -21,6 +21,9 @@ Table of Contents
 * [Silent and No Notifications](#silent-and-no-notifications)
 * [Messenger code API](#messenger-code-api)
 * [Attachment upload API](#attachment-upload-api)
+* [Built-in NLP](#built-in-nlp)
+* [Message Tags](#message-tags)
+* [App Secret Proof](#app-secret-proof )
 * [Running Botkit with an Express server](#use-botkit-for-facebook-messenger-with-an-express-web-server)
 
 ## Getting Started
@@ -570,6 +573,20 @@ var taggedMessage = {
 bot.reply(message, taggedMessage);
 ```
 
+## App Secret Proof 
+
+To improve security and prevent your bot against man in the middle attack, it's highly recommended to send an app secret proof : 
+
+```javascript
+var controller = Botkit.facebookbot({
+    access_token: process.env.page_token,
+    verify_token: process.env.verify_token,
+    app_secret: process.env.app_secret,
+    require_appsecret_proof: true // Enable send app secret proof
+});
+``` 
+
+More information about how to secure Graph API Requests [here](https://developers.facebook.com/docs/graph-api/securing-requests/)
 
 ## Use BotKit for Facebook Messenger with an Express web server
 Instead of the web server generated with setupWebserver(), it is possible to use a different web server to receive webhooks, as well as serving web pages.

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -2,7 +2,6 @@ var Botkit = require(__dirname + '/CoreBot.js');
 var request = require('request');
 var crypto = require('crypto');
 var bodyParser = require('body-parser');
-var shajs = require('sha.js');
 
 function Facebookbot(configuration) {
 

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -909,9 +909,9 @@ function Facebookbot(configuration) {
         return 'sha1=' + hmac.digest('hex');
     }
 
-    function getAppSecretProof(dataToHash, key) {
-        var hmac = crypto.createHmac('sha256', key);
-        return hmac.update(dataToHash).digest('hex');
+    function getAppSecretProof(access_token, app_secret) {
+        var hmac = crypto.createHmac('sha256', app_secret || "");
+        return hmac.update(access_token).digest('hex');
     }
 
     function abortOnValidationError(err, req, res, next) {

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -2,10 +2,13 @@ var Botkit = require(__dirname + '/CoreBot.js');
 var request = require('request');
 var crypto = require('crypto');
 var bodyParser = require('body-parser');
+var shajs = require('sha.js');
 
 function Facebookbot(configuration) {
 
     var api_host = configuration.api_host || 'graph.facebook.com';
+
+    var appsecret_proof = getAppSecretProof(configuration.access_token, configuration.app_secret);
 
     // Create a core botkit bot
     var facebook_botkit = Botkit(configuration || {});
@@ -138,6 +141,10 @@ function Facebookbot(configuration) {
             //Add Access Token to outgoing request
             message.access_token = configuration.access_token;
 
+            if (facebook_botkit.config.require_appsecret_proof) {
+                message.appsecret_proof = appsecret_proof;
+            }
+
             request({
                 method: 'POST',
                 json: true,
@@ -148,7 +155,6 @@ function Facebookbot(configuration) {
                 uri: 'https://' + api_host + '/v2.6/me/messages'
             },
                 function(err, res, body) {
-
 
                     if (err) {
                         botkit.debug('WEBHOOK ERROR', err);
@@ -286,12 +292,18 @@ function Facebookbot(configuration) {
     // so that we can use it before a bot is spawned!
     facebook_botkit.getInstanceInfo = function(cb) {
         return new Promise(function(resolve, reject) {
+            var uri = 'https://' + api_host + '/v2.6/me?access_token=' + configuration.access_token;
+
             var instance = {
                 identity: {},
                 team: {},
             };
 
-            request.get('https://' + api_host + '/v2.6/me?access_token=' + configuration.access_token,
+            if (facebook_botkit.config.require_appsecret_proof) {
+                uri += '&appsecret_proof=' + appsecret_proof
+            }
+
+            request.get(uri,
                 {},
                 function(err, res, body) {
                     if (err) {
@@ -566,7 +578,13 @@ function Facebookbot(configuration) {
             facebook_botkit.api.messenger_profile.getAPI('home_url', cb);
         },
         postAPI: function(message) {
-            request.post('https://' + api_host + '/v2.6/me/messenger_profile?access_token=' + configuration.access_token,
+            var uri = 'https://' + api_host + '/v2.6/me/messenger_profile?access_token=' + configuration.access_token;
+
+            if (facebook_botkit.config.require_appsecret_proof) {
+                uri += '&appsecret_proof=' + appsecret_proof;
+            }
+
+            request.post(uri,
                 {form: message},
                 function(err, res, body) {
                     if (err) {
@@ -591,10 +609,17 @@ function Facebookbot(configuration) {
                 });
         },
         deleteAPI: function(type) {
+            var uri = 'https://' + api_host + '/v2.6/me/messenger_profile?access_token=' + configuration.access_token;
+
             var message = {
                 'fields': [type]
             };
-            request.delete('https://' + api_host + '/v2.6/me/messenger_profile?access_token=' + configuration.access_token,
+
+            if (facebook_botkit.config.require_appsecret_proof) {
+                uri += '&appsecret_proof=' + appsecret_proof;
+            }
+
+            request.delete(uri,
                 {form: message},
                 function(err, res, body) {
                     if (err) {
@@ -605,7 +630,13 @@ function Facebookbot(configuration) {
                 });
         },
         getAPI: function(fields, cb) {
-            request.get('https://' + api_host + '/v2.6/me/messenger_profile?fields=' + fields + '&access_token=' + configuration.access_token,
+            var uri = 'https://' + api_host + '/v2.6/me/messenger_profile?fields=' + fields + '&access_token=' + configuration.access_token;
+
+            if (facebook_botkit.config.require_appsecret_proof) {
+                uri += '&appsecret_proof=' + appsecret_proof;
+            }
+
+            request.get(uri,
                 function(err, res, body) {
                     if (err) {
                         facebook_botkit.log('Could not get messenger profile');
@@ -617,6 +648,8 @@ function Facebookbot(configuration) {
                 });
         },
         get_messenger_code: function(image_size, cb, ref) {
+            var uri = 'https://' + api_host + '/v2.6/me/messenger_codes?access_token=' + configuration.access_token;
+
             var message = {
                 'type': 'standard',
                 'image_size': image_size || 1000
@@ -626,8 +659,11 @@ function Facebookbot(configuration) {
                 message.data = {'ref': ref};
             }
 
-            request.post('https://' + api_host + '/v2.6/me/messenger_codes?access_token=' + configuration.access_token,
+            if (facebook_botkit.config.require_appsecret_proof) {
+                uri += '&appsecret_proof=' + appsecret_proof;
+            }
 
+            request.post(uri,
                 {form: message},
                 function(err, res, body) {
                     if (err) {
@@ -660,13 +696,19 @@ function Facebookbot(configuration) {
 
     var attachment_upload_api = {
         upload: function(attachment, cb) {
+            var uri = 'https://' + api_host + '/v2.6/me/message_attachments?access_token=' + configuration.access_token;
+
             var message = {
                 message: {
                     attachment: attachment
                 }
             };
 
-            request.post('https://' + api_host + '/v2.6/me/message_attachments?access_token=' + configuration.access_token,
+            if (facebook_botkit.config.require_appsecret_proof) {
+                uri += '&appsecret_proof=' + appsecret_proof;
+            }
+
+            request.post(uri,
                 { form: message },
                 function(err, res, body) {
                     if (err) {
@@ -700,7 +742,13 @@ function Facebookbot(configuration) {
 
     var tags = {
         get_all: function(cb) {
-            request.get('https://' + api_host + '/v2.6/page_message_tags?access_token=' + configuration.access_token,
+            var uri = 'https://' + api_host + '/v2.6/page_message_tags?access_token=' + configuration.access_token;
+
+            if (facebook_botkit.config.require_appsecret_proof) {
+                uri += '&appsecret_proof=' + appsecret_proof;
+            }
+
+            request.get(uri,
                 function(err, res, body) {
                     if (err) {
                         facebook_botkit.log('Could not get tags list');
@@ -735,9 +783,15 @@ function Facebookbot(configuration) {
         },
         postAPI: function(value, custom_token) {
             var uri = 'https://' + api_host + '/v2.8/me/nlp_configs?nlp_enabled=' + value + '&access_token=' + configuration.access_token;
+
             if (custom_token) {
                 uri += '&custom_token=' + custom_token;
             }
+
+            if (facebook_botkit.config.require_appsecret_proof) {
+                uri += '&appsecret_proof=' + appsecret_proof;
+            }
+
             request.post(uri, {},
                 function(err, res, body) {
                     if (err) {
@@ -769,6 +823,11 @@ function Facebookbot(configuration) {
         }
         return new Promise(function(resolve, reject) {
             var uri = 'https://' + api_host + '/v2.6/' + uid + '?fields=' + fields + '&access_token=' + configuration.access_token;
+
+            if (facebook_botkit.config.require_appsecret_proof) {
+                uri += '&appsecret_proof=' + appsecret_proof;
+            }
+
             request.get(uri, {},
                 function(err, res, body) {
                     if (err) {
@@ -849,6 +908,11 @@ function Facebookbot(configuration) {
         var hmac = crypto.createHmac('sha1', facebook_botkit.config.app_secret);
         hmac.update(buf, 'utf-8');
         return 'sha1=' + hmac.digest('hex');
+    }
+
+    function getAppSecretProof(dataToHash, key) {
+        var hmac = crypto.createHmac('sha256', key);
+        return hmac.update(dataToHash).digest('hex');
     }
 
     function abortOnValidationError(err, req, res, next) {


### PR DESCRIPTION
Hello,

Almost every Graph API call requires an access token. Malicious developers can steal access tokens and use them to send spam from your bot with malicious software on a person's computer or a man in the middle attack. 

To prevent that, Facebook recommend sending an app secret proof parameter to every API call. 

This PR add a new configuration attribute ```require_appsecret_proof``` to enable sending the sha256 proof each call Botkit makes.

````
var controller = Botkit.facebookbot({
    debug: true,
    log: true,
    access_token: process.env.page_token,
    verify_token: process.env.verify_token,
    app_secret: process.env.app_secret,
    require_appsecret_proof: true
});
````

Enjoy :v: