### PR TITLE
Properly format fb messages with tags request

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -67,7 +67,7 @@ function Facebookbot(configuration) {
             }
 
             if (message.tag) {
-                platform_message.message.tag = message.tag;
+                platform_message.tag = message.tag;
             }
 
             if (message.sticker_id) {


### PR DESCRIPTION
Hi,

This PR is about fixing the fb messages with tags request as documentation said, the request must be like that :

````
{
  "recipient": { 
    "id": "<PSID>"
  },
  "message":{
    ...
  },
  "tag": "SHIPPING_UPDATE"
}
````

Instead of that : 

````
{
  "recipient": { 
    "id": "<PSID>"
  },
  "message":{
    ...
    "tag": "SHIPPING_UPDATE"
  }
}    
````

Enjoy :flushed:
