### PR TITLE
Mount Slack auth middleware on the proper route

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -112,7 +112,7 @@ function Slackbot(configuration) {
             'and outgoing webhooks; configured ' + tokens.length + ' token(s)'
         );
 
-        webserver.use(authenticationMiddleware(tokens));
+        webserver.post('/slack/receive', authenticationMiddleware(tokens));
     }
 
     // set up a web route for receiving outgoing webhooks and/or slash commands


### PR DESCRIPTION
The Slack authentication middleware is wrongly mounted at application level, meaning it will handle all requests to any routes defined after a call to `createWebhookEndpoints`. To prevent this, we must ensure that the middleware is mounted only on the `/slack/receive` route.