### PR TITLE
Add some Slack API methods

### DIFF
--- a/lib/Botkit.d.ts
+++ b/lib/Botkit.d.ts
@@ -302,11 +302,17 @@ declare namespace botkit {
     token: string;
   }
   interface SlackWebAPI {
+    api: {
+        test: SlackWebAPIMethod;
+    }
     auth: {
         test: SlackWebAPIMethod;
     },
     oauth: {
         access: SlackWebAPIMethod;
+    }
+    bots: {
+        info: SlackWebAPIMethod;
     }
     channels: {
         archive: SlackWebAPIMethod;
@@ -427,6 +433,7 @@ declare namespace botkit {
         getPresence: SlackWebAPIMethod;
         info: SlackWebAPIMethod;
         list: SlackWebAPIMethod;
+        lookupByEmail: SlackWebAPIMethod;
         setActive: SlackWebAPIMethod;
         setPresence: SlackWebAPIMethod;
         deletePhoto: SlackWebAPIMethod;

--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -22,8 +22,10 @@ module.exports = function(bot, config) {
 
     // Slack API methods: https://api.slack.com/methods
     var slackApiMethods = [
+        'api.test',
         'auth.test',
         'oauth.access',
+        'bots.info',
         'channels.archive',
         'channels.create',
         'channels.history',
@@ -138,6 +140,7 @@ module.exports = function(bot, config) {
         'users.info',
         'users.identity',
         'users.list',
+        'users.lookupByEmail',
         'users.setActive',
         'users.setPresence',
         'users.deletePhoto',


### PR DESCRIPTION
Slack added some bot api methods recently that were not in the list.
[https://api.slack.com/bot-users](API for bot users)