### PR TITLE
apply verification middleware only on the webhook endpoint

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -117,7 +117,7 @@ function Slackbot(configuration) {
         var endpoint = '/slack/receive';
         if (authenticationTokens !== undefined && arguments.length > 1 && arguments[1].length) {
             //botkit allows an array of tokens or multiple tokens as variable length params
-            var tokens = Array.prototype.slice.call(arguments).slice(1);
+            var tokens = Array.prototype.slice.call(arguments, 1);
             secureWebhookEndpoints(webserver, endpoint, tokens);
         }
 

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -101,31 +101,30 @@ function Slackbot(configuration) {
 
 
     // adds the webhook authentication middleware module to the webserver
-    function secureWebhookEndpoints() {
+    function secureWebhookEndpoints(webserver, endpoint, tokens) {
         var authenticationMiddleware = require(__dirname + '/middleware/slack_authentication.js');
-        // convert a variable argument list to an array, drop the webserver argument
-        var tokens = Array.prototype.slice.call(arguments);
-        var webserver = tokens.shift();
-
+        
         slack_botkit.log(
             '** Requiring token authentication for webhook endpoints for Slash commands ' +
             'and outgoing webhooks; configured ' + tokens.length + ' token(s)'
         );
 
-        webserver.use(authenticationMiddleware(tokens));
+        webserver.use(endpoint, authenticationMiddleware(tokens));
     }
 
     // set up a web route for receiving outgoing webhooks and/or slash commands
     slack_botkit.createWebhookEndpoints = function(webserver, authenticationTokens) {
-
+        var endpoint = '/slack/receive';
         if (authenticationTokens !== undefined && arguments.length > 1 && arguments[1].length) {
-            secureWebhookEndpoints.apply(null, arguments);
+            //botkit allows an array of tokens or multiple tokens as variable length params
+            var tokens = Array.prototype.slice.call(arguments).slice(1);
+            secureWebhookEndpoints(webserver, endpoint, tokens);
         }
 
         slack_botkit.log(
             '** Serving webhook endpoints for Slash commands and outgoing ' +
             'webhooks at: http://' + slack_botkit.config.hostname + ':' + slack_botkit.config.port + '/slack/receive');
-        webserver.post('/slack/receive', function(req, res) {
+        webserver.post(endpoint, function(req, res) {
 
             // respond to Slack that the webhook has been received.
             res.status(200);


### PR DESCRIPTION
This is a fix for issue https://github.com/howdyai/botkit/issues/601

Root cause of the Issue:
issue occurs because when we enable token verification for the slack webhook endpoint, verification middleware get's applied to all the endpoints (including "/login" and others) since middleware is mounted at the root .

Fix:
Changes in this PR ensure that verification middleware only get's applied to slack webhook endpoint (i.e. `/slack/receive`)


  