### PR TITLE
Update readme-facebook.md

### DIFF
--- a/docs/readme-facebook.md
+++ b/docs/readme-facebook.md
@@ -610,7 +610,7 @@ Allows the Primary Receiver app to retrieve the list of apps that are Secondary 
 
 - To retrieve the list of Secondary Receivers:
 ```javascript
-controller.api.handover.get_secondary_receivers_list('id,name', function (result) {
+controller.api.handover.get_secondary_receivers_list('id,name', function (err, result) {
    // result.data = list of Secondary Receivers
 });
 ```


### PR DESCRIPTION
fix code sample for handover protocol callback pattern to be (err, response). Could also be (null, response) as the actual method in Facebook.js is invoking as `cb(null, body);`