### PR TITLE
Call FaceBook call back functions if error has occurred

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -699,10 +699,14 @@ function Facebookbot(configuration) {
                 function(err, res, body) {
                     if (err) {
                         facebook_botkit.log('Could not get messenger profile');
-                        cb(err);
+                        if (cb) {
+                            cb(err);
+                        }
                     } else {
                         facebook_botkit.debug('Successfully got messenger profile ', body);
-                        cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 });
         },
@@ -726,7 +730,9 @@ function Facebookbot(configuration) {
                 function(err, res, body) {
                     if (err) {
                         facebook_botkit.log('Could not configure get messenger code');
-                        cb(err);
+                        if (cb) {
+                            cb(err);
+                        }
                     } else {
 
                         var results = null;
@@ -734,17 +740,23 @@ function Facebookbot(configuration) {
                             results = JSON.parse(body);
                         } catch (err) {
                             facebook_botkit.log('ERROR in messenger code API call: Could not parse JSON', err, body);
-                            cb(err);
+                            if (cb) {
+                                cb(err);
+                            }
                         }
 
                         if (results) {
                             if (results.error) {
                                 facebook_botkit.log('ERROR in messenger code API call: ', results.error.message);
-                                cb(results.error);
+                                if (cb) {
+                                    cb(results.error);
+                                }
                             } else {
                                 var uri = results.uri;
                                 facebook_botkit.log('Successfully got messenger code', uri);
-                                cb(null, uri);
+                                if (cb) {
+                                    cb(null, uri);
+                                }
                             }
                         }
                     }
@@ -771,7 +783,9 @@ function Facebookbot(configuration) {
                 function(err, res, body) {
                     if (err) {
                         facebook_botkit.log('Could not upload attachment');
-                        cb(err);
+                        if (cb) {
+                            cb(err);
+                        }
                     } else {
 
                         var results = null;
@@ -779,17 +793,23 @@ function Facebookbot(configuration) {
                             results = JSON.parse(body);
                         } catch (err) {
                             facebook_botkit.log('ERROR in attachment upload API call: Could not parse JSON', err, body);
-                            cb(err);
+                            if (cb) {
+                                cb(err);
+                            }
                         }
 
                         if (results) {
                             if (results.error) {
                                 facebook_botkit.log('ERROR in attachment upload API call: ', results.error.message);
-                                cb(results.error);
+                                if (cb) {
+                                    cb(results.error);
+                                }
                             } else {
                                 var attachment_id = results.attachment_id;
                                 facebook_botkit.log('Successfully got attachment id ', attachment_id);
-                                cb(null, attachment_id);
+                                if (cb) {
+                                    cb(null, attachment_id);
+                                }
                             }
                         }
                     }
@@ -829,11 +849,13 @@ function Facebookbot(configuration) {
                             if (results.error) {
                                 facebook_botkit.log('ERROR in page message tags: ', results.error.message);
                                 if (cb) {
-                                    cb(esults.error);
+                                    cb(results.error);
                                 }
                             } else {
                                 facebook_botkit.debug('Successfully call page message tags', body);
-                                cb(results);
+                                if (cb) {
+                                    cb(results);
+                                }
                             }
                         }
                     }
@@ -972,14 +994,20 @@ function Facebookbot(configuration) {
             }, function(err, res, body) {
                 if (err) {
                     facebook_botkit.log('Could not call Facebook Insights API', err);
-                    cb(err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     if (body.error) {
                         facebook_botkit.log('ERROR in Facebook Insights API call: ', body.error.message);
-                        cb(body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
                     } else {
                         facebook_botkit.log('Successfully got Facebook Insights API');
-                        cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 }
             });
@@ -1006,14 +1034,20 @@ function Facebookbot(configuration) {
             }, function(err, res, body) {
                 if (err) {
                     facebook_botkit.log('Could not get secondary receivers list');
-                    cb && cb(err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     if (body.error) {
                         facebook_botkit.log('ERROR in secondary receivers list: ', body.error.message);
-                        cb && cb(body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
                     } else {
                         facebook_botkit.debug('Successfully getting secondary receivers list', body);
-                        cb && cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 }
             });
@@ -1041,14 +1075,20 @@ function Facebookbot(configuration) {
             }, function(err, res, body) {
                 if (err) {
                     facebook_botkit.log('Could not take thread control');
-                    cb && cb(err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     if (body.error) {
                         facebook_botkit.log('ERROR in take thread control API call: ', body.error.message);
-                        cb && cb(body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
                     } else {
                         facebook_botkit.debug('Successfully taken thread control', body);
-                        cb && cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 }
             });
@@ -1077,14 +1117,20 @@ function Facebookbot(configuration) {
             }, function(err, res, body) {
                 if (err) {
                     facebook_botkit.log('Could not pass thread control');
-                    cb && cb(err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     if (body.error) {
                         facebook_botkit.log('ERROR in pass thread control API call: ', body.error.message);
-                        cb && cb(body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
                     } else {
                         facebook_botkit.debug('Successfully past thread control', body);
-                        cb && cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 }
             });
@@ -1118,14 +1164,20 @@ function Facebookbot(configuration) {
             }, function(err, res, body) {
                 if (err) {
                     facebook_botkit.log('Could not Create a broadcast message');
-                    cb(err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     if (body.error) {
                         facebook_botkit.log('ERROR in creating a broadcast message call: ', body.error);
-                        cb(body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
                     } else {
                         facebook_botkit.debug('Successfully create a broadcast message', body);
-                        cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 }
             });
@@ -1153,14 +1205,20 @@ function Facebookbot(configuration) {
             }, function(err, res, body) {
                 if (err) {
                     facebook_botkit.log('Could not send the broadcast message');
-                    cb(err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     if (body.error) {
                         facebook_botkit.log('ERROR in sending the broadcast message call : ', body.error);
-                        cb(body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
                     } else {
                         facebook_botkit.debug('Successfully send the broadcast message', body);
-                        cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 }
             });
@@ -1179,14 +1237,20 @@ function Facebookbot(configuration) {
             }, function(err, res, body) {
                 if (err) {
                     facebook_botkit.log('Could not send a broadcast message');
-                    cb(err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     if (body.error) {
                         facebook_botkit.log('ERROR in getting broadcast metrics call : ', body.error.message);
-                        cb(body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
                     } else {
                         facebook_botkit.log('Successfully get broadcast metrics ');
-                        cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 }
             });
@@ -1210,14 +1274,20 @@ function Facebookbot(configuration) {
             }, function(err, res, body) {
                 if (err) {
                     facebook_botkit.log('Could not create label to target broadcast messages');
-                    cb(err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     if (body.error) {
                         facebook_botkit.log('ERROR in creating label to target broadcast messages call : ', body.error);
-                        cb(body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
                     } else {
                         facebook_botkit.debug('Successfully create label to target broadcast messages', body);
-                        cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 }
             });
@@ -1241,14 +1311,20 @@ function Facebookbot(configuration) {
             }, function(err, res, body) {
                 if (err) {
                     facebook_botkit.log('Could not add a user to a label');
-                    cb(err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     if (body.error) {
                         facebook_botkit.log('ERROR in adding a user to a label API call : ', body.error);
-                        cb(body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
                     } else {
                         facebook_botkit.debug('Successfully add a user to a label', body);
-                        cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 }
             });
@@ -1272,14 +1348,20 @@ function Facebookbot(configuration) {
             }, function(err, res, body) {
                 if (err) {
                     facebook_botkit.log('Could not remove a user from a label');
-                    cb(err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     if (body.error) {
                         facebook_botkit.log('ERROR in removing a user from a label API call : ', body.error);
-                        cb(body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
                     } else {
                         facebook_botkit.debug('Successfully remove a user from a label', body);
-                        cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 }
             });
@@ -1298,14 +1380,20 @@ function Facebookbot(configuration) {
             }, function(err, res, body) {
                 if (err) {
                     facebook_botkit.log('Could not get user associated labels');
-                    cb(err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     if (body.error) {
                         facebook_botkit.log('ERROR in getting user associated labels API call : ', body.error.message);
-                        cb(body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
                     } else {
                         facebook_botkit.log('Successfully get user associated labels');
-                        cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 }
             });
@@ -1328,14 +1416,20 @@ function Facebookbot(configuration) {
             }, function(err, res, body) {
                 if (err) {
                     facebook_botkit.log('Could not get label details');
-                    cb(err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     if (body.error) {
                         facebook_botkit.log('ERROR in getting label details call : ', body.error.message);
-                        cb(body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
                     } else {
                         facebook_botkit.log('Successfully get label details');
-                        cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 }
             });
@@ -1358,14 +1452,20 @@ function Facebookbot(configuration) {
             }, function(err, res, body) {
                 if (err) {
                     facebook_botkit.log('Could not get labels');
-                    cb(err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     if (body.error) {
                         facebook_botkit.log('ERROR in getting labels call : ', body.error.message);
-                        cb(body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
                     } else {
                         facebook_botkit.log('Successfully get labels');
-                        cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 }
             });
@@ -1385,14 +1485,20 @@ function Facebookbot(configuration) {
             }, function(err, res, body) {
                 if (err) {
                     facebook_botkit.log('Could not remove label');
-                    cb(err);
+                    if (cb) {
+                        cb(err);
+                    }
                 } else {
                     if (body.error) {
                         facebook_botkit.log('ERROR in removing label API call : ', body.error);
-                        cb(body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
                     } else {
                         facebook_botkit.debug('Successfully remove label', body);
-                        cb(null, body);
+                        if (cb) {
+                            cb(null, body);
+                        }
                     }
                 }
             });

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -810,6 +810,9 @@ function Facebookbot(configuration) {
                 function(err, res, body) {
                     if (err) {
                         facebook_botkit.log('Could not get tags list');
+                        if (cb) {
+                            cb(err);
+                        }
                     } else {
 
                         var results = null;
@@ -817,11 +820,17 @@ function Facebookbot(configuration) {
                             results = JSON.parse(body);
                         } catch (err) {
                             facebook_botkit.log('ERROR in page message tags call: Could not parse JSON', err, body);
+                            if (cb) {
+                                cb(err);
+                            }
                         }
 
                         if (results) {
                             if (results.error) {
                                 facebook_botkit.log('ERROR in page message tags: ', results.error.message);
+                                if (cb) {
+                                    cb(esults.error);
+                                }
                             } else {
                                 facebook_botkit.debug('Successfully call page message tags', body);
                                 cb(results);


### PR DESCRIPTION
Hello,

While error in getting tags list, Botkit doesn't call cb function with the error. this PR allows ````tags.get_all```` to handle the cb function with ````err```` parameter, it also check if ````cb```` exists before calling it.

Enjoy,




