### PR TITLE
should use value not payload as keyname

### DIFF
--- a/lib/Teams.js
+++ b/lib/Teams.js
@@ -267,7 +267,7 @@ function TeamsBot(configuration) {
                     this.content.text = v;
                     return this;
                 },
-                button: function(type, title, payload) {
+                button: function(type, title, value) {
                     if (!this.content.buttons) {
                         this.content.buttons = [];
                     }
@@ -275,7 +275,7 @@ function TeamsBot(configuration) {
                     var button_obj = (typeof(type) === 'object') ? type : {
                         type: type,
                         title: title,
-                        payload: payload,
+                        value: value,
                     };
 
                     this.content.buttons.push(button_obj);


### PR DESCRIPTION
@peterswimm @benbrown fix for openUrl action of the hero cards, doesn't currently work but will when you use value over payload for the keyname.