### PR TITLE
Add FB request thread control

### DIFF
--- a/docs/readme-facebook.md
+++ b/docs/readme-facebook.md
@@ -637,6 +637,18 @@ controller.api.handover.pass_thread_control('<RECIPIENT_PSID>', '<TARGET_PSID>',
 });
 ```
 
+### Request Thread Control
+
+The Request Thread Control API allows a Secondary Receiver app to notify the Primary Receiver that it wants control of the chat : 
+
+- To pass thread control:
+```javascript
+controller.api.handover.request_thread_control('<RECIPIENT_PSID>', 'String to pass to request the thread control', function (result) {
+   
+});
+```
+
+
 ## Messaging type
 
 You can identify the purpose of the message being sent to Facebook by adding `messaging_type: <MESSAGING_TYPE>` property when sending the message:

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -497,6 +497,9 @@ function Facebookbot(configuration) {
         if (message.take_thread_control) {
             message.type = 'facebook_lose_thread_control';
         }
+        if (message.request_thread_control) {
+            message.type = 'facebook_request_thread_control';
+        }
 
         next();
 
@@ -1128,6 +1131,47 @@ function Facebookbot(configuration) {
                         }
                     } else {
                         facebook_botkit.debug('Successfully past thread control', body);
+                        if (cb) {
+                            cb(null, body);
+                        }
+                    }
+                }
+            });
+        },
+        request_thread_control: function(recipient, metadata, cb) {
+            var uri = 'https://' + api_host + '/' + api_version + '/me/request_thread_control';
+
+            if (facebook_botkit.config.require_appsecret_proof) {
+                uri += '&appsecret_proof=' + appsecret_proof;
+            }
+
+            var request_body = {
+                recipient: {
+                    id: recipient
+                },
+                metadata: metadata
+            };
+            request.post({
+                url: uri,
+                qs: {
+                    access_token: configuration.access_token
+                },
+                body: request_body,
+                json: true
+            }, function(err, res, body) {
+                if (err) {
+                    facebook_botkit.log('Could not request thread control');
+                    if (cb) {
+                        cb(err);
+                    }
+                } else {
+                    if (body.error) {
+                        facebook_botkit.log('ERROR in request thread control API call: ', body.error.message);
+                        if (cb) {
+                            cb(body.error);
+                        }
+                    } else {
+                        facebook_botkit.debug('Successfully requested thread control', body);
                         if (cb) {
                             cb(null, body);
                         }


### PR DESCRIPTION
Hello,

FB recently added the ````/request_thread_control```` endpoint that allows secondary receiver apps to request thread control from the primary receiver app, that's what i tried to introduce by this PR.

Enjoy