### PR TITLE
Extend Facebook's user profile object with locale.

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -241,6 +241,7 @@ function Facebookbot(configuration) {
                         full_name: identity.first_name + ' ' + identity.last_name,
                         email: identity.email || null,
                         gender: identity.gender,
+                        locale: identity.locale,
                         timezone_offset: identity.timezone,
                     };
 


### PR DESCRIPTION
There is a missing field, namely`locale` which is a part of the identity response object of `bot.getMessageUser`