### PR TITLE
Remove HTTPS governor

### DIFF
--- a/lib/CiscoSparkbot.js
+++ b/lib/CiscoSparkbot.js
@@ -38,8 +38,6 @@ function Sparkbot(configuration) {
         var endpoint = url.parse(controller.config.public_address);
         if (!endpoint.hostname) {
             throw new Error('Could not determine hostname of public address: ' + controller.config.public_address);
-        } else if (endpoint.protocol != 'https:') {
-            throw new Error('Please specify an SSL-enabled url for your public address: ' + controller.config.public_address);
         } else {
             controller.config.public_address = endpoint.hostname + (endpoint.port ? ':' + endpoint.port : '');
         }


### PR DESCRIPTION
Botkit forced https, but Spark doesn't require it