### PR TITLE
Log bad JSON received by Slack if Slack sends us bad JSON.

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -191,7 +191,7 @@ module.exports = function(botkit, config) {
                     try {
                         message = JSON.parse(data);
                     } catch (err) {
-                        console.log('** RECEIVED BAD JSON FROM SLACK');
+                        console.log(`** RECEIVED BAD JSON FROM SLACK: ${data}`);
                     }
                     /**
                      * Lets construct a nice quasi-standard botkit message


### PR DESCRIPTION
We recently hit an odd issue with Slack: Slack is sending us messages over RTM which are not valid JSON. In order to debug this and send a useful error report to the Slack platforms team, we needed the actual messages being received, to see if they're truncated, empty or something else. I've sent this PR because this change seems like it would be helpful to others, as well.

P.S. Unfortunately, I was unable to run the tests—when I tried, I got these errors:
```
 FAIL  __test__/lib/Botkit.test.js
  ● exports bot interfaces

    Cannot find module 'ltx' from 'JabberGroupManager.js'

      at Resolver.resolveModule (node_modules/jest-cli/node_modules/jest-runtime/node_modules/jest-resolve/build/index.js:179:17)
      at Object.<anonymous> (lib/JabberGroupManager.js:6:61)

  ● exports bot interfaces

    TypeError: Cannot read property 'core' of undefined

      at Object.<anonymous>.test (__test__/lib/Botkit.test.js:22:19)
          at new Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)
```
These appear to be unrelated to my change, so I'm going ahead and sending this pull request anyway. My apologies.

