### PR TITLE
Fix #1279

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -55,37 +55,8 @@ function Facebookbot(configuration) {
                 platform_message.message.sticker_id = message.sticker_id;
             }
 
-            if (message.quick_replies) {
+            if (message.quick_replies) platform_message.message.quick_replies = message.quick_replies;
 
-                // sanitize the length of the title to maximum of 20 chars
-                var titleLimit = function(title) {
-                    if (title.length > 20) {
-                        var newTitle = title.substring(0, 16) + '...';
-                        return newTitle;
-                    } else {
-                        return title;
-                    }
-                };
-
-                platform_message.message.quick_replies = message.quick_replies.map(function(item) {
-                    var quick_reply = {};
-                    if (item.content_type === 'text' || !item.content_type) {
-                        quick_reply = {
-                            content_type: 'text',
-                            title: titleLimit(item.title),
-                            payload: item.payload,
-                            image_url: item.image_url,
-                        };
-                    } else if (item.content_type === 'location') {
-                        quick_reply = {
-                            content_type: 'location'
-                        };
-                    } else {
-                        // Future quick replies types
-                    }
-                    return quick_reply;
-                });
-            }
         } else {
             platform_message.sender_action = message.sender_action;
         }

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -2,6 +2,7 @@ var Botkit = require(__dirname + '/CoreBot.js');
 var request = require('request');
 var crypto = require('crypto');
 var bodyParser = require('body-parser');
+var clone = require('clone');
 
 function Facebookbot(configuration) {
 
@@ -55,7 +56,13 @@ function Facebookbot(configuration) {
                 platform_message.message.sticker_id = message.sticker_id;
             }
 
-            if (message.quick_replies) platform_message.message.quick_replies = message.quick_replies;
+            if (message.quick_replies) {
+                platform_message.message.quick_replies = message.quick_replies.map(function(item) {
+                    var quick_reply = clone(item);
+                    if (!item.content_type) quick_reply.content_type = 'text';
+                    return quick_reply;
+                });
+            }
 
         } else {
             platform_message.sender_action = message.sender_action;


### PR DESCRIPTION
Hello,

In this PR i replaced the internat core quick replies format mechanism by quick replies from message object.

This way will prevent us adding new supported quick replies each time fb adds ones.

FYI FB truncates the quick reply title by default, i also removed ````titleLimit````

WDYT ?