### PR TITLE
FB require_delivery: Remove use of message.delivery.mids because not guaranteed

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -511,24 +511,19 @@ function Facebookbot(configuration) {
     facebook_botkit.middleware.receive.use(function handleDelivery(bot, message, next) {
 
         if (message.type === 'message_delivered' && facebook_botkit.config.require_delivery) {
-            // get list of mids in this message
-            for (var m = 0; m < message.delivery.mids.length; m++) {
-                var mid = message.delivery.mids[m];
-
-                // loop through all active conversations this bot is having
-                // and mark messages in conversations as delivered = true
-                // note: we don't pass the real event in here because message_delivered events are excluded from conversations and won't ever match!
-                bot.findConversation({user: message.user}, function(convo) {
-                    if (convo) {
-                        for (var s = 0; s < convo.sent.length; s++) {
-                            if (convo.sent[s].sent_timestamp <= message.delivery.watermark ||
-                          (convo.sent[s].api_response && convo.sent[s].api_response.message_id == mid)) {
-                                convo.sent[s].delivered = true;
-                            }
+            // loop through all active conversations this bot is having
+            // and mark messages in conversations as delivered = true
+            // note: we don't pass the real event in here because message_delivered events are excluded from conversations and won't ever match!
+            // also note: we only use message.delivery.watermark since message.delivery.mids can sometimes not be in the payload (#1311)
+            bot.findConversation({user: message.user}, function(convo) {
+                if (convo) {
+                    for (var s = 0; s < convo.sent.length; s++) {
+                        if (convo.sent[s].sent_timestamp <= message.delivery.watermark) {
+                            convo.sent[s].delivered = true;
                         }
                     }
-                });
-            }
+                }
+            });
         }
 
         next();


### PR DESCRIPTION
Fixes #1311 