### PR TITLE
Add missing `fallback` in example

### DIFF
--- a/docs/readme-slack.md
+++ b/docs/readme-slack.md
@@ -854,6 +854,7 @@ controller.hears('interactive', 'direct_message', function(bot, message) {
         attachments:[
             {
                 title: 'Do you want to interact with my buttons?',
+                fallback: 'You need the Slack app to interact with these buttons',
                 callback_id: '123',
                 attachment_type: 'default',
                 actions: [


### PR DESCRIPTION
I am currently implementing some interactive messages and dialogs on a Slack Bot, heavily relying on your's and Slack's documentation. While implementing a button that triggers a dialog I found that this example was not showing any buttons. After comparing it with Slack's message builder found that `fallback` is a required field. 