### PR TITLE
call startRTM callback on websocket errors

### DIFF
--- a/__test__/lib/Slackbot_worker.test.js
+++ b/__test__/lib/Slackbot_worker.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const util = require('util');
+const EventEmitter = require('events').EventEmitter;
+
+let mockWs;
+function MockWs(url) {
+    this.url = url;
+    mockWs = this;
+}
+util.inherits(MockWs, EventEmitter);
+
+jest.mock('ws', () => MockWs);
+
+let mockResponse;
+let mockRequest = {
+    post: jest.fn().mockImplementation((params, cb) => {
+        cb(null, mockResponse, mockResponse.body);
+    })
+};
+jest.mock('request', () => mockRequest);
+
+// these need to be required after mocks are set up
+const CoreBot = require('../../lib/CoreBot');
+const Slackbot_worker = require('../../lib/Slackbot_worker');
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('startRTM', () => {
+    it('connects to rtm url and calls callback function', () => {
+        const botkit = CoreBot({});
+        const bot = Slackbot_worker(botkit, {});
+
+        mockResponse = {
+            statusCode: 200,
+            body: JSON.stringify({
+                ok: true,
+                url: 'http://mockurl',
+                self: {
+                    name: 'botkit'
+                }
+            })
+        };
+
+        const cb = jest.fn();
+        bot.startRTM(cb);
+        mockWs.emit('open');
+        expect(mockRequest.post).toHaveBeenCalledTimes(1);
+        expect(mockWs.url).toBe('http://mockurl');
+        expect(cb).toHaveBeenCalledTimes(1);
+
+        const errorArg = cb.mock.calls[0][0];
+        expect(errorArg).toBeNull();
+    });
+    it('handles Slack API rtm.connect errors', () => {
+        const botkit = CoreBot({});
+        const bot = Slackbot_worker(botkit, {});
+
+        mockResponse = {
+            statusCode: 200,
+            body: JSON.stringify({
+                ok: false,
+                error: 'test_error'
+            })
+        };
+
+        const cb = jest.fn();
+        bot.startRTM(cb);
+        expect(mockRequest.post).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenCalledTimes(1);
+
+        const errorArg = cb.mock.calls[0][0];
+        expect(errorArg).toBe('test_error');
+    });
+    it('handles websocket connection errors', () => {
+        const botkit = CoreBot({});
+        const bot = Slackbot_worker(botkit, {});
+
+        mockResponse = {
+            statusCode: 200,
+            body: JSON.stringify({
+                ok: true,
+                url: 'http://mockurl',
+                self: {
+                    name: 'botkit'
+                }
+            })
+        };
+
+        const cb = jest.fn();
+        bot.startRTM(cb);
+        mockWs.emit('error', 'test websocket error');
+        expect(mockRequest.post).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenCalledTimes(1);
+
+        const errorArg = cb.mock.calls[0][0];
+        expect(errorArg).toBe('test websocket error');
+    });
+});

--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -128,15 +128,22 @@ module.exports = function(botkit, config) {
         botkit.shutdown();
     };
 
-    bot.startRTM = function(cb) {
+    bot.startRTM = function(userCb) {
+        var userCbCalled = false;
+        var cb = function() {
+            if (!userCbCalled) {
+                userCbCalled = true;
+                userCb && userCb.apply(this, arguments);
+            }
+        };
         var lastPong = 0;
         bot.api.rtm.connect({}, function(err, res) {
             if (err) {
-                return cb && cb(err);
+                return cb(err);
             }
 
             if (!res) {
-                return cb && cb('Invalid response from rtm.start');
+                return cb('Invalid response from rtm.start');
             }
 
             bot.identity = res.self;
@@ -206,7 +213,7 @@ module.exports = function(botkit, config) {
 
                 botkit.startTicking();
 
-                cb && cb(null, bot, res);
+                cb(null, bot, res);
             });
 
             bot.rtm.on('error', function(err) {
@@ -214,6 +221,8 @@ module.exports = function(botkit, config) {
                 if (pingTimeoutId) {
                     clearTimeout(pingTimeoutId);
                 }
+
+                cb(err);
                 botkit.trigger('rtm_close', [bot, err]);
             });
 
@@ -222,6 +231,8 @@ module.exports = function(botkit, config) {
                 if (pingTimeoutId) {
                     clearTimeout(pingTimeoutId);
                 }
+
+                cb(message);
                 botkit.trigger('rtm_close', [bot]);
 
                 /**


### PR DESCRIPTION
Added test file for `lib/Slackbot_worker` that did not exist at all, that tests just `startRTM`.

Closes #1334 