### PR TITLE
Add native facebook "quick_reply" support as "facebook_quick_reply"

### DIFF
--- a/docs/readme-facebook.md
+++ b/docs/readme-facebook.md
@@ -89,10 +89,10 @@ Normal messages will be sent to your bot using the `message_received` event.  In
 | facebook_quick_reply | A user clicked a "quick reply" and triggered a quick reply message.
 | message_delivered | A confirmation from Facebook that a message has been received.
 | message_echo | If enabled in Facebook, an "echo" of any message sent by the bot.
-| message_read | A confirmation from Facebook that a message has been read
-| facebook_account_linking | A user has started the account linking
-| facebook_optin | A user has clicked the [Send-to-Messenger plugin](https://developers.facebook.com/docs/messenger-platform/implementation#send_to_messenger_plugin).
-| facebook_referral | A user has clicked on a [m.me URL with a referral param](https://developers.facebook.com/docs/messenger-platform/referral-params).
+| message_read | A confirmation from Facebook that a message has been read.
+| facebook_account_linking | A user has started the account linking.
+| facebook_optin | A user has clicked the [Send-to-Messenger plugin].(https://developers.facebook.com/docs/messenger-platform/implementation#send_to_messenger_plugin).
+| facebook_referral | A user has clicked on a [m.me URL with a referral param].(https://developers.facebook.com/docs/messenger-platform/referral-params).
 | facebook_app_roles | This callback will occur when a page admin changes the role of your application.
 | standby | This callback will occur when a message has been sent to your page, but your application is not the current thread owner. (Subscribe to the `standby` webhook to receive this event.)
 | facebook_receive_thread_control | This callback will occur when thread ownership for a user has been passed to your application. (Subscribe to the `messaging_handovers` webhook to receive this event.)

--- a/docs/readme-facebook.md
+++ b/docs/readme-facebook.md
@@ -84,14 +84,15 @@ Normal messages will be sent to your bot using the `message_received` event.  In
 
 | Event | Description
 |--- |---
-| message_received | a message was received by the bot
-| facebook_postback | user clicked a button in an attachment and triggered a webhook postback
-| message_delivered | a confirmation from Facebook that a message has been received
-| message_echo | if enabled in Facebook, an "echo" of any message sent by the bot
-| message_read | a confirmation from Facebook that a message has been read
-| facebook_account_linking | a user has started the account linking
-| facebook_optin | a user has clicked the [Send-to-Messenger plugin](https://developers.facebook.com/docs/messenger-platform/implementation#send_to_messenger_plugin)
-| facebook_referral | a user has clicked on a [m.me URL with a referral param](https://developers.facebook.com/docs/messenger-platform/referral-params)
+| message_received | A message was received by the bot.
+| facebook_postback | A user clicked a button in an attachment and triggered a webhook postback.
+| facebook_quick_reply | A user clicked a "quick reply" and triggered a quick reply message.
+| message_delivered | A confirmation from Facebook that a message has been received.
+| message_echo | If enabled in Facebook, an "echo" of any message sent by the bot.
+| message_read | A confirmation from Facebook that a message has been read
+| facebook_account_linking | A user has started the account linking
+| facebook_optin | A user has clicked the [Send-to-Messenger plugin](https://developers.facebook.com/docs/messenger-platform/implementation#send_to_messenger_plugin).
+| facebook_referral | A user has clicked on a [m.me URL with a referral param](https://developers.facebook.com/docs/messenger-platform/referral-params).
 | facebook_app_roles | This callback will occur when a page admin changes the role of your application.
 | standby | This callback will occur when a message has been sent to your page, but your application is not the current thread owner. (Subscribe to the `standby` webhook to receive this event.)
 | facebook_receive_thread_control | This callback will occur when thread ownership for a user has been passed to your application. (Subscribe to the `messaging_handovers` webhook to receive this event.)

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -431,7 +431,8 @@ function Facebookbot(configuration) {
 
         if (message.quick_reply) {
             message.payload = message.quick_reply.payload;
-            message.text = message.quick_reply.text;
+            message.text = message.quick_reply.payload;
+            message.label = message.quick_reply.text;
 
             message.type = 'facebook_quick_reply';
         }

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -422,18 +422,21 @@ function Facebookbot(configuration) {
     facebook_botkit.middleware.normalize.use(function handlePostback(bot, message, next) {
 
         if (message.postback) {
-
             message.text = message.postback.payload;
             message.payload = message.postback.payload;
-
             message.referral = message.postback.referral;
 
             message.type = 'facebook_postback';
+        }
 
+        if (message.quick_reply) {
+            message.payload = message.quick_reply.payload;
+            message.text = message.quick_reply.text;
+
+            message.type = 'facebook_quick_reply';
         }
 
         next();
-
     });
 
     // handle message sub-types


### PR DESCRIPTION
I've noticed that the quick_reply is perceived as a "message_received" event, where as the "facebook_postback" is a native event type. This is confusing for initial users unless time is spent reading through issues or the source code (#1224 + including myself).

This pull request adds "quick_reply" as a native facebook event. I've also assigned the `quick_reply.payload` to `message.text` as this would make it easier for creating proper listeners when combined with RegEx versus the quick_reply button text.

Example:
```js
// Can listen to both types of payloads with similar payloads
controller.hears("foo:.*", ['facebook_quick_reply', 'facebook_postback'], (bot, message) => {
    bot.reply(message, "You say foo, I say bar");
});