### PR TITLE
API updates to reflect Webex Teams rebrand

### DIFF
--- a/docs/readme-webex.md
+++ b/docs/readme-webex.md
@@ -93,7 +93,7 @@ controller.on('direct_message', function(bot, message) {
 
 When creating the Botkit controller, there are several platform-specific options available.
 
-### Botkit.webex
+### Botkit.webexbot
 | Argument | Description
 |--- |---
 | public_address | _required_ the root url of your application (https://mybot.com)
@@ -104,7 +104,7 @@ When creating the Botkit controller, there are several platform-specific options
 | `limit_to_domain` | _optional_ email domain (@howdy.ai) or array of domains [@howdy.ai, @botkit.ai] from which messages can be received
 
 ~~~ javascript
-var controller = Botkit.webex({
+var controller = Botkit.webexbot({
     debug: true,
     log: true,
     public_address: 'https://mybot.ngrok.io',
@@ -118,7 +118,7 @@ var controller = Botkit.webex({
 
 ### Webex rebrand
 
-Back in April 2018, Cisco announced a [rebrand from Cisco Spark to Webex]().
+Back in April 2018, Cisco announced a [rebrand from Cisco Spark to Webex](https://developer.webex.com/blog/blog-details-9738.html).
 In May 2018, starting with version **TODO**, Botkit reflected this rebrand by updated 'Spark' mentions from the framework API.
 
 **For backward compatibility purposes**, several references are now marked as deprecated, but still supported (except for Typescript code). Please migrate your code if your find references to:

--- a/docs/readme-webex.md
+++ b/docs/readme-webex.md
@@ -1,17 +1,17 @@
-# Botkit and Cisco Spark
+# Botkit and Webex Teams
 
-Botkit is designed to ease the process of designing and running useful, creative bots that live inside Cisco Spark.
+Botkit is designed to ease the process of designing and running useful, creative bots that live inside the Cisco Webex platform and the Webex Teams applications.
 
 Botkit features a comprehensive set of tools
-to deal with [Cisco's Spark platform](https://developer.ciscospark.com/), and allows
+to deal with [Webex's platform](https://developer.webex.com/), and allows
 developers to build interactive bots and applications that send and receive messages just like real humans.
 
-This document covers the Cisco Spark-specific implementation details only. [Start here](readme.md) if you want to learn about to develop with Botkit.
+This document covers the Webex-specific implementation details only. [Start here](readme.md) if you want to learn about to develop with Botkit.
 
 Table of Contents
 
 * [Getting Started](#getting-started)
-* [Spark-specific Events](#spark-specific-events)
+* [Webex-specific Events](#webex-specific-events)
 * [Message Formatting](#message-formatting)
 * [Attaching Files](#attaching-files)
 * [Receiving Files](#receiving-files)
@@ -22,7 +22,7 @@ Table of Contents
 
 1) Install Botkit [more info here](readme.md#installation)
 
-2) [Create a bot in the Spark for Developers site](https://developer.ciscospark.com/add-bot.html). You'll receive an `access token`.
+2) [Create a bot in the Webex for Developers site](https://developer.webex.com/add-bot.html). You'll receive an `access token`.
 
 Copy this token, you'll need it!
 
@@ -35,34 +35,34 @@ ngrok http 3000
 4) Run your bot application using the access token you received, the base url of your bot application, and a secret which is used to validate the origin of incoming webhooks:
 
 ```
-access_token=<MY ACCESS TOKEN> public_address=<https://my_bot_url> secret=<my_secret_phrase> node examples/spark_bot.js
+access_token=<MY ACCESS TOKEN> public_address=<https://my_bot_url> secret=<my_secret_phrase> node examples/webex_bot.js
 ```
 
-5) Your bot should now come online and respond to requests! Find it in Cisco Spark by searching for it's name.
+5) Your bot should now come online and respond to requests! Find it in your Webex Teams app by searching for it's name.
 
-## Working with Cisco Spark
+## Working with Webex
 
-Botkit receives messages from Cisco Spark using webhooks, and sends messages using their APIs. This means that your bot application must present a web server that is publicly addressable. Everything you need to get started is already included in Botkit.
+Botkit receives messages from the Cisco Webex cloud platform using webhooks, and sends messages using their APIs. This means that your bot application must present a web server that is publicly addressable. Everything you need to get started is already included in Botkit.
 
-To connect your bot to Cisco Spark, [get an access token here](https://developer.ciscospark.com/add-bot.html). In addition to the access token,
-Cisco Spark bots require a user-defined `secret` which is used to validate incoming webhooks, as well as a `public_address` which is the URL at which the bot application can be accessed via the internet.
+To connect your bot to Webex, [get an access token here](https://developer.webex.com/add-bot.html). In addition to the access token,
+Webex bots require a user-defined `secret` which is used to validate incoming webhooks, as well as a `public_address` which is the URL at which the bot application can be accessed via the internet.
 
 Each time the bot application starts, Botkit will register a webhook subscription.
 Botkit will automatically manage your bot's webhook subscriptions, but if you plan on having multiple instances of your bot application with different URLs (such as a development instance and a production instance), use the `webhook_name` field with a different value for each instance.
 
-Bots in Cisco Spark are identified by their email address, and can be added to any space in any team or organization. If your bot should only be available to users within a specific organization, use the `limit_to_org` or `limit_to_domain` options.
+Bots in Webex are identified by their email address, and can be added to any space in any team or organization. If your bot should only be available to users within a specific organization, use the `limit_to_org` or `limit_to_domain` options.
 This will configure your bot to respond only to messages from members of the specific organization, or whose email addresses match one of the specified domains.
 
-The full code for a simple Cisco Spark bot is below:
+The full code for a simple Webex bot is below:
 
 ~~~ javascript
 var Botkit = require('./lib/Botkit.js');
 
-var controller = Botkit.sparkbot({
+var controller = Botkit.webexbot({
     debug: true,
     log: true,
     public_address: process.env.public_address,
-    ciscospark_access_token: process.env.access_token,
+    access_token: process.env.access_token,
     secret: process.env.secret
 });
 
@@ -72,7 +72,7 @@ var bot = controller.spawn({
 
 controller.setupWebserver(process.env.PORT || 3000, function(err, webserver) {
     controller.createWebhookEndpoints(webserver, bot, function() {
-        console.log("SPARK: Webhooks set up!");
+        console.log("Webhooks set up!");
     });
 });
 
@@ -93,32 +93,46 @@ controller.on('direct_message', function(bot, message) {
 
 When creating the Botkit controller, there are several platform-specific options available.
 
-### Botkit.sparkbot
+### Botkit.webex
 | Argument | Description
 |--- |---
 | public_address | _required_ the root url of your application (https://mybot.com)
-| `ciscospark_access_token` | _required_ token provided by Cisco Spark for your bot
-| secret | _required_ secret for validating webhooks originate from Cisco Spark
-| webhook_name | _optional_ name for webhook configuration on Cisco Spark side. Providing a name here allows for multiple bot instances to receive the same messages. Defaults to 'Botkit Firehose'
+| `access_token` | _required_ token provided by Webex for your bot
+| secret | _required_ secret for validating webhooks originate from Webex
+| webhook_name | _optional_ name for webhook configuration on Webex side. Providing a name here allows for multiple bot instances to receive the same messages. Defaults to 'Botkit Firehose'
 | `limit_to_org` | _optional_ organization id in which the bot should exist. If user from outside org sends message, it is ignored
 | `limit_to_domain` | _optional_ email domain (@howdy.ai) or array of domains [@howdy.ai, @botkit.ai] from which messages can be received
 
 ~~~ javascript
-var controller = Botkit.sparkbot({
+var controller = Botkit.webex({
     debug: true,
     log: true,
     public_address: 'https://mybot.ngrok.io',
-    ciscospark_access_token: process.env.access_token,
+    access_token: process.env.access_token,
     secret: 'randomstringofnumbersandcharacters12345',
     webhook_name: 'dev',
-    limit_to_org: 'my_spark_org_id',
+    limit_to_org: 'my_webex_org_id',
     limit_to_domain: ['@howdy.ai','@cisco.com'],
 });
 ~~~
 
-## Spark Specific Events
+### Webex rebrand
 
- All events [listed here](https://developer.ciscospark.com/webhooks-explained.html#resources-events) should be expected, in the format `resource`.`event` - for example, `rooms.created`.  
+Back in April 2018, Cisco announced a [rebrand from Cisco Spark to Webex]().
+In May 2018, starting with version **TODO**, Botkit reflected this rebrand by updated 'Spark' mentions from the framework API.
+
+**For backward compatibility purposes**, several references are now marked as deprecated, but still supported (except for Typescript code). Please migrate your code if your find references to:
+- Botkit.sparkbot() => Botkit.webexbot()
+- controller.config.ciscospark_access_token => controller.config.access_token: a warning shows up in the console if your code is still using this option.
+
+**Breaking changes**
+- bot.type now equals 'webex' instead of 'ciscospark': there should not be any impact in your code.
+- the webhook HTTP endpoint automatically created and exposed by Botkit has been changed from '/ciscospark/receive' to '/webex/receive'. Note that this change can have an impact for the Webex Cloud platform to reach your bot if the traffic to your bot is routed by a reverse proxy. _To avoid any bot to break, the Botkit Webex connector will expose an HTTP endpoint with the deprecated '/ciscospark/receive' path if the 'ciscospark_access_token' configuration property is detected._
+
+
+## Webex Specific Events
+
+ All events [listed here](https://developer.webex.com/webhooks-explained.html#resources-events) should be expected, in the format `resource`.`event` - for example, `rooms.created`.  
 
  In addition, the following custom Botkit-specific events are fired:
 
@@ -135,7 +149,7 @@ var controller = Botkit.sparkbot({
 
 ## Message Formatting
 
-Cisco Spark supports both a `text` field and a `markdown` field for outbound messages. [Read here for details on Cisco Spark's markdown support.](https://developer.ciscospark.com/formatting-messages.html)
+Webex supports both a `text` field and a `markdown` field for outbound messages. [Read here for details on Webex's markdown support.](https://developer.webex.com/formatting-messages.html)
 
 To specify a markdown version, add it to your message object:
 
@@ -214,7 +228,7 @@ controller.on('direct_message', function(bot, message) {
 
 ## Starting Direct Messages
 
-Cisco Spark's API provides several ways to send private messages to users -
+Webex's API provides several ways to send private messages to users -
 by the user's email address, or by their user id. These may be used in the case where the
 user's email address is unknown or unavailable, or when the bot should respond to the `actor`
 instead of the `sender` of a message.
@@ -267,7 +281,7 @@ controller.on('bot_space_join', function(bot, message) {
 * Platforms
   * [Web and Apps](readme-web.md)
   * [Slack](readme-slack.md)
-  * [Cisco Spark](readme-ciscospark.md)
+  * [Webex](readme-webex.md)
   * [Microsoft Teams](readme-teams.md)
   * [Facebook Messenger](readme-facebook.md)
   * [Twilio SMS](readme-twiliosms.md)

--- a/examples/spark_bot.js
+++ b/examples/spark_bot.js
@@ -1,0 +1,99 @@
+  /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+           ______     ______     ______   __  __     __     ______
+          /\  == \   /\  __ \   /\__  _\ /\ \/ /    /\ \   /\__  _\
+          \ \  __<   \ \ \/\ \  \/_/\ \/ \ \  _"-.  \ \ \  \/_/\ \/
+           \ \_____\  \ \_____\    \ \_\  \ \_\ \_\  \ \_\    \ \_\
+            \/_____/   \/_____/     \/_/   \/_/\/_/   \/_/     \/_/
+
+
+This is a sample Cisco Spark bot built with Botkit.
+
+This bot demonstrates many of the core features of Botkit:
+
+* Connect to Cisco Spark's APIs
+* Receive messages based on "spoken" patterns
+* Reply to messages
+* Use the conversation system to ask questions
+* Use the built in storage system to store and retrieve information
+  for a user.
+
+# EXTEND THE BOT:
+
+  Botkit has many features for building cool and useful bots!
+
+  Read all about it here:
+
+    -> http://botkit.ai
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+var Botkit = require('../lib/Botkit.js');
+
+var controller = Botkit.sparkbot({
+    debug: false,
+    log: false,
+    public_address: process.env.public_address,
+    ciscospark_access_token: process.env.access_token,
+    studio_token: process.env.studio_token, // get one from studio.botkit.ai to enable content management, stats, message console and more
+    secret: process.env.secret, // this is an RECOMMENDED but optional setting that enables validation of incoming webhooks
+    webhook_name: 'Cisco Spark bot created with Botkit, override me before going to production',
+//    limit_to_domain: ['mycompany.com'],
+//    limit_to_org: 'my_cisco_org_id',
+});
+
+var bot = controller.spawn({});
+
+controller.setupWebserver(process.env.PORT || 3000, function(err, webserver) {
+    controller.createWebhookEndpoints(webserver, bot, function() {
+        console.log("Cisco Spark: Webhooks set up!");
+    });
+});
+
+controller.hears(['^markdown'], 'direct_message,direct_mention', function(bot, message) {
+
+    bot.reply(message, {text: '*this is cool*', markdown: '*this is super cool*'});
+
+});
+
+controller.on('user_space_join', function(bot, message) {
+    bot.reply(message, 'Welcome, ' + message.raw_message.data.personDisplayName);
+});
+
+controller.on('user_space_leave', function(bot, message) {
+    bot.reply(message, 'Bye, ' + message.raw_message.data.personDisplayName);
+});
+
+
+controller.on('bot_space_join', function(bot, message) {
+
+    bot.reply(message, 'This trusty bot is here to help.');
+
+});
+
+
+controller.on('direct_mention', function(bot, message) {
+    bot.reply(message, 'You mentioned me and said, "' + message.text + '"');
+});
+
+controller.on('direct_message', function(bot, message) {
+    bot.reply(message, 'I got your private message. You said, "' + message.text + '"');
+    if (message.raw_message.files) {
+        bot.retrieveFileInfo(message.raw_message.files[0], function(err, file) {
+            bot.reply(message,'I also got an attached file called ' + file.filename);
+        });
+    }
+});
+
+if (process.env.studio_token) {
+    controller.on('direct_message,direct_mention', function(bot, message) {
+        controller.studio.runTrigger(bot, message.text, message.user, message.channel).then(function(convo) {
+            if (!convo) {
+                // console.log('NO STUDIO MATCH');
+            } else {
+              // found a conversation
+            }
+        }).catch(function(err) {
+            console.error('Error with Botkit Studio: ', err);
+        });
+    });
+}

--- a/examples/webex_bot.js
+++ b/examples/webex_bot.js
@@ -6,11 +6,11 @@
             \/_____/   \/_____/     \/_/   \/_/\/_/   \/_/     \/_/
 
 
-This is a sample Cisco Spark bot built with Botkit.
+This is a sample Webex Teams bot built with Botkit.
 
 This bot demonstrates many of the core features of Botkit:
 
-* Connect to Cisco Spark's APIs
+* Connect to Cisco Webex Teams's APIs
 * Receive messages based on "spoken" patterns
 * Reply to messages
 * Use the conversation system to ask questions
@@ -29,14 +29,14 @@ This bot demonstrates many of the core features of Botkit:
 
 var Botkit = require('../lib/Botkit.js');
 
-var controller = Botkit.sparkbot({
+var controller = Botkit.webexbot({
     debug: false,
     log: false,
     public_address: process.env.public_address,
-    ciscospark_access_token: process.env.access_token,
+    access_token: process.env.access_token,
     studio_token: process.env.studio_token, // get one from studio.botkit.ai to enable content management, stats, message console and more
     secret: process.env.secret, // this is an RECOMMENDED but optional setting that enables validation of incoming webhooks
-    webhook_name: 'Cisco Spark bot created with Botkit, override me before going to production',
+    webhook_name: 'created with Botkit, override me before going to production',
 //    limit_to_domain: ['mycompany.com'],
 //    limit_to_org: 'my_cisco_org_id',
 });
@@ -45,7 +45,7 @@ var bot = controller.spawn({});
 
 controller.setupWebserver(process.env.PORT || 3000, function(err, webserver) {
     controller.createWebhookEndpoints(webserver, bot, function() {
-        console.log("Cisco Spark: Webhooks set up!");
+        console.log("Webex: Webhooks set up!");
     });
 });
 

--- a/lib/Botkit.d.ts
+++ b/lib/Botkit.d.ts
@@ -6,7 +6,7 @@ declare namespace botkit {
   function consolebot(configuration: ConsoleConfiguration): ConsoleController;
   function facebookbot(configuration: FacebookConfiguration): FacebookController;
   function slackbot(configuration: SlackConfiguration): SlackController;
-  function sparkbot(configuration: CiscoSparkConfiguration): CiscoSparkController;
+  function webexbot(configuration: WebexConfiguration): WebexController;
   function twilioipmbot(configuration: TwilioIPMConfiguration): TwilioIPMController;
   function twiliosmsbot(configuration: TwilioSMSConfiguration): TwilioSMSController;
   function socketbot(configuration: WebConfiguration): WebController;
@@ -40,34 +40,34 @@ declare namespace botkit {
   interface Channel {
     id: string;
   }
-  interface CiscoSparkBot extends Bot<CiscoSparkSpawnConfiguration, CiscoSparkMessage> {
+  interface WebexBot extends Bot<WebexSpawnConfiguration, WebexMessage> {
     retrieveFile(url: string, cb: (err: Error, body: any) => void): void;
     retrieveFileInfo(url: string, cb: (err: Error, obj: any) => void): void;
-    startPrivateConversation(message: CiscoSparkMessage, cb: (err: Error, convo: Conversation<CiscoSparkMessage>) => void): void;
-    startPrivateConversationWithActor(message: CiscoSparkMessage, cb: (err: Error, convo: Conversation<CiscoSparkMessage>) => void): void;
-    startPrivateConversationWithPersonId(personId: string, cb: (err: Error, convo: Conversation<CiscoSparkMessage>) => void): void;
+    startPrivateConversation(message: WebexMessage, cb: (err: Error, convo: Conversation<WebexMessage>) => void): void;
+    startPrivateConversationWithActor(message: WebexMessage, cb: (err: Error, convo: Conversation<WebexMessage>) => void): void;
+    startPrivateConversationWithPersonId(personId: string, cb: (err: Error, convo: Conversation<WebexMessage>) => void): void;
   }
-  interface CiscoSparkConfiguration extends Configuration {
-    ciscospark_access_token: string;
+  interface WebexConfiguration extends Configuration {
+    access_token: string;
     limit_to_domain?: string | string[];
     limit_to_org?: string;
     public_address: string;
     secret?: string;
     webhook_name?: string;
   }
-  interface CiscoSparkController extends Controller<CiscoSparkSpawnConfiguration, CiscoSparkMessage, CiscoSparkBot> {
-    createWebhookEndpoints(webserver: any, bot: CiscoSparkBot, cb?: () => void): this;
+  interface WebexController extends Controller<WebexSpawnConfiguration, WebexMessage, WebexBot> {
+    createWebhookEndpoints(webserver: any, bot: WebexBot, cb?: () => void): this;
   }
-  interface CiscoSparkMessage extends Message {
+  interface WebexMessage extends Message {
     actorId?: string;
     data?: {
       personDisplayName: string;
     };
     files?: any[];
     markdown?: string;
-    original_message?: CiscoSparkMessage;
+    original_message?: WebexMessage;
   }
-  interface CiscoSparkSpawnConfiguration {
+  interface WebexSpawnConfiguration {
   }
   interface Configuration {
     debug?: boolean;

--- a/lib/Botkit.js
+++ b/lib/Botkit.js
@@ -4,7 +4,7 @@ var Facebookbot = require(__dirname + '/Facebook.js');
 var TwilioIPMbot = require(__dirname + '/TwilioIPMBot.js');
 var TwilioSMSbot = require(__dirname + '/TwilioSMSBot.js');
 var BotFrameworkBot = require(__dirname + '/BotFramework.js');
-var SparkBot = require(__dirname + '/CiscoSparkbot.js');
+var WebexBot = require(__dirname + '/WebexBot.js');
 var ConsoleBot = require(__dirname + '/ConsoleBot.js');
 var JabberBot = require(__dirname + '/JabberBot.js');
 var WebBot = require(__dirname + '/Web.js');
@@ -12,7 +12,7 @@ var WebBot = require(__dirname + '/Web.js');
 module.exports = {
     core: CoreBot,
     slackbot: Slackbot,
-    sparkbot: SparkBot,
+    webexbot: WebexBot,
     facebookbot: Facebookbot,
     twilioipmbot: TwilioIPMbot,
     twiliosmsbot: TwilioSMSbot,

--- a/lib/Botkit.js
+++ b/lib/Botkit.js
@@ -13,6 +13,7 @@ module.exports = {
     core: CoreBot,
     slackbot: Slackbot,
     webexbot: WebexBot,
+    sparkbot: WebexBot, // [COMPAT] Webex rebrand, see https://github.com/howdyai/botkit/issues/1346
     facebookbot: Facebookbot,
     twilioipmbot: TwilioIPMbot,
     twiliosmsbot: TwilioSMSbot,

--- a/lib/WebexBot.js
+++ b/lib/WebexBot.js
@@ -8,6 +8,12 @@ function WebexBot(configuration) {
     // Create a core botkit bot
     var controller = Botkit(configuration || {});
 
+    // [COMPAT] Webex rebrand, see https://github.com/howdyai/botkit/issues/1346
+    if (controller.config.ciscospark_access_token) {
+        console.log('DEPRECATED: please switch your configuration property from "ciscospark_access_token" to "access_token"');
+        controller.config.access_token = controller.config.ciscospark_access_token;
+    }
+
     if (!controller.config.access_token) {
         throw new Error('access_token required to create controller');
     } else {
@@ -68,10 +74,19 @@ function WebexBot(configuration) {
 
         var webhook_name = controller.config.webhook_name || 'Botkit Firehose';
 
+        var webhook_path = '/webex/receive';
+        
+        // [COMPAT] Webex rebrand, see https://github.com/howdyai/botkit/issues/1346
+        if (controller.config.ciscospark_access_token) {
+            compat_path = '/ciscospark/receive';
+            console.log('COMPATIBILITY: because we detected the "ciscospark_access_token" configuration property, the "' + compat_path +  '" path is used instead of "' + webhook_path + '"');
+            webhook_path = '/ciscospark/receive';
+        }
+
         controller.log(
             '** Serving webhook endpoints for Webex Platform at: ' +
-            'http://' + controller.config.hostname + ':' + controller.config.port + '/webex/receive');
-        webserver.post('/webex/receive', function(req, res) {
+            'http://' + controller.config.hostname + ':' + controller.config.port + webhook_path);
+        webserver.post(webhook_path, function(req, res) {
             res.sendStatus(200);
             controller.handleWebhookPayload(req, res, bot);
 
@@ -87,7 +102,7 @@ function WebexBot(configuration) {
                 }
             }
 
-            var hook_url = 'https://' + controller.config.public_address + '/webex/receive';
+            var hook_url = 'https://' + controller.config.public_address + webhook_path;
 
             console.log('Webex: incoming webhook url is ', hook_url);
 

--- a/lib/WebexBot.js
+++ b/lib/WebexBot.js
@@ -3,28 +3,28 @@ var request = require('request');
 var url = require('url');
 var crypto = require('crypto');
 
-function Sparkbot(configuration) {
+function WebexBot(configuration) {
 
     // Create a core botkit bot
     var controller = Botkit(configuration || {});
 
-    if (!controller.config.ciscospark_access_token) {
-        throw new Error('ciscospark_access_token required to create controller');
+    if (!controller.config.access_token) {
+        throw new Error('access_token required to create controller');
     } else {
         controller.api = require('ciscospark').init({
             credentials: {
                 authorization: {
-                    access_token: controller.config.ciscospark_access_token
+                    access_token: controller.config.access_token
                 }
             }
         });
 
         if (!controller.api) {
-            throw new Error('Could not create Cisco Spark API');
+            throw new Error('Could not create the Webex Teams API client');
         }
 
         controller.api.people.get('me').then(function(identity) {
-            console.log('Cisco Spark: My identity is', identity);
+            console.log('Webex: My identity is', identity);
             controller.identity = identity;
         }).catch(function(err) {
             throw new Error(err);
@@ -45,7 +45,7 @@ function Sparkbot(configuration) {
     }
 
     if (!controller.config.secret) {
-        console.log('WARNING: No secret specified. Source of incoming webhooks will not be validated. https://developer.ciscospark.com/webhooks-explained.html#auth');
+        console.log('WARNING: No secret specified. Source of incoming webhooks will not be validated. https://developer.webex.com/webhooks-explained.html#auth');
         // throw new Error('secret parameter required to secure webhooks');
     }
 
@@ -69,9 +69,9 @@ function Sparkbot(configuration) {
         var webhook_name = controller.config.webhook_name || 'Botkit Firehose';
 
         controller.log(
-            '** Serving webhook endpoints for Cisco Spark Platform at: ' +
-            'http://' + controller.config.hostname + ':' + controller.config.port + '/ciscospark/receive');
-        webserver.post('/ciscospark/receive', function(req, res) {
+            '** Serving webhook endpoints for Webex Platform at: ' +
+            'http://' + controller.config.hostname + ':' + controller.config.port + '/webex/receive');
+        webserver.post('/webex/receive', function(req, res) {
             res.sendStatus(200);
             controller.handleWebhookPayload(req, res, bot);
 
@@ -87,9 +87,9 @@ function Sparkbot(configuration) {
                 }
             }
 
-            var hook_url = 'https://' + controller.config.public_address + '/ciscospark/receive';
+            var hook_url = 'https://' + controller.config.public_address + '/webex/receive';
 
-            console.log('Cisco Spark: incoming webhook url is ', hook_url);
+            console.log('Webex: incoming webhook url is ', hook_url);
 
             if (hook_id) {
                 controller.api.webhooks.update({
@@ -100,7 +100,7 @@ function Sparkbot(configuration) {
                     secret: controller.config.secret,
                     name: webhook_name,
                 }).then(function(res) {
-                    console.log('Cisco Spark: SUCCESSFULLY UPDATED CISCO SPARK WEBHOOKS');
+                    console.log('Webex: SUCCESSFULLY UPDATED WEBEX WEBHOOKS');
                     if (cb) cb();
                 }).catch(function(err) {
                     console.error('FAILED TO REGISTER WEBHOOK', err);
@@ -116,7 +116,7 @@ function Sparkbot(configuration) {
                     name: webhook_name,
                 }).then(function(res) {
 
-                    console.log('Cisco Spark: SUCCESSFULLY REGISTERED CISCO SPARK WEBHOOKS');
+                    console.log('Webex: SUCCESSFULLY REGISTERED WEBEX WEBHOOKS');
                     if (cb) cb();
                 }).catch(function(err) {
                     console.error('FAILED TO REGISTER WEBHOOK', err);
@@ -291,7 +291,7 @@ function Sparkbot(configuration) {
             platform_message[k] = message[k];
         }
 
-        // mutate the message into proper spark format
+        // mutate the message into proper Webex Teams format
         platform_message.roomId = message.channel;
         delete platform_message.channel;
 
@@ -329,7 +329,7 @@ function Sparkbot(configuration) {
     controller.defineBot(function(botkit, config) {
 
         var bot = {
-            type: 'ciscospark',
+            type: 'webex',
             botkit: botkit,
             config: config || {},
             utterances: botkit.utterances,
@@ -438,7 +438,7 @@ function Sparkbot(configuration) {
             request.head({
                 url: url,
                 headers: {
-                    'Authorization': 'Bearer ' + controller.config.ciscospark_access_token
+                    'Authorization': 'Bearer ' + controller.config.access_token
                 },
             }, function(err, response, body) {
 
@@ -460,7 +460,7 @@ function Sparkbot(configuration) {
             request({
                 url: url,
                 headers: {
-                    'Authorization': 'Bearer ' + controller.config.ciscospark_access_token
+                    'Authorization': 'Bearer ' + controller.config.access_token
                 },
                 encoding: 'binary',
             }, function(err, response, body) {
@@ -546,4 +546,4 @@ function Sparkbot(configuration) {
 }
 
 
-module.exports = Sparkbot;
+module.exports = WebexBot;


### PR DESCRIPTION
See #1346 for context.

The proposed changes here also introduce backward compatibility as described in the [Webex rebrand](https://github.com/ObjectIsAdvantag/botkit/blob/non-breaking/docs/readme-webex.md#webex-rebrand) documentation section:

> Back in April 2018, Cisco announced a rebrand from Cisco Spark to Webex. In May 2018, starting with version TODO, Botkit reflected this rebrand by updated 'Spark' mentions from the framework API.
> 
> For backward compatibility purposes, several references are now marked as deprecated, but still supported (except for Typescript code). Please migrate your code if your find references to:

> - Botkit.sparkbot() => Botkit.webexbot()
> - controller.config.ciscospark_access_token => controller.config.access_token: a warning shows up in the console if your code is still using this option.
> 
> **Breaking changes**
> - bot.type now equals 'webex' instead of 'ciscospark': there should not be any impact in your code.
> - the webhook HTTP endpoint automatically created and exposed by Botkit has been changed from '/ciscospark/receive' to '/webex/receive'. Note that this change can have an impact for the Webex Cloud platform to reach your bot if the traffic to your bot is routed by a reverse proxy. _To avoid any bot to break, the Botkit Webex connector will expose an HTTP endpoint with the deprecated '/ciscospark/receive' path if the 'ciscospark_access_token' configuration property is detected._

These modifications have been tested against the `convos@sparkbot.io` which implements various examples with the Botkit conversation object. The proposed implementation has let me take an incremental changes with no breaking changes, as detailled in the releases of the [convos bot project](https://github.com/ObjectIsAdvantag/botkit-convos/releases)