### PR TITLE
Add FB Thread owner API

### DIFF
--- a/docs/readme-facebook.md
+++ b/docs/readme-facebook.md
@@ -649,6 +649,17 @@ controller.api.handover.request_thread_control('<RECIPIENT_PSID>', 'String to pa
 });
 ```
 
+### Get Thread Owner
+
+Th Thread Owner API returns the app ID of the app the currently has thread control for a Page :
+
+- To get the app ID of the current thread owner :
+```javascript
+controller.api.handover.get_thread_owner('<RECIPIENT_PSID>', function (result) {
+   
+});
+```
+
 
 ## Messaging type
 

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -1195,6 +1195,42 @@ function Facebookbot(configuration) {
                     }
                 }
             });
+        },
+        get_thread_owner: function(recipient, cb) {
+
+            var uri = 'https://' + api_host + '/' + api_version + '/me/thread_owner';
+
+            if (facebook_botkit.config.require_appsecret_proof) {
+                uri += '&appsecret_proof=' + appsecret_proof;
+            }
+
+            request.get({
+                url: uri,
+                qs: {
+                    recipient: recipient,
+                    access_token: configuration.access_token
+                },
+                json: true
+            }, function(err, res, body) {
+                if (err) {
+                    facebook_botkit.log('Could not get thread owner');
+                    if (cb) {
+                        cb(err);
+                    }
+                } else {
+                    if (body.error) {
+                        facebook_botkit.log('ERROR while getting thread owner : ', body.error.message);
+                        if (cb) {
+                            cb(body.error);
+                        }
+                    } else {
+                        facebook_botkit.debug('Successfully getting thread owner', body);
+                        if (cb) {
+                            cb(null, body);
+                        }
+                    }
+                }
+            });
         }
     };
     var broadcast_api = {


### PR DESCRIPTION
Hello,

This PR add the Thread Owner API that allows getting the app ID of the app the currently has thread control for a Page.

[Doc here](https://developers.facebook.com/docs/messenger-platform/handover-protocol/get-thread-owner)

Enjoy 