### PR TITLE
Add FB scheduled broadcast

### DIFF
--- a/docs/readme-facebook.md
+++ b/docs/readme-facebook.md
@@ -649,6 +649,15 @@ controller.api.handover.request_thread_control('<RECIPIENT_PSID>', 'String to pa
 });
 ```
 
+### Cancelling a Scheduled Broadcast
+
+- To cancel a scheduled broadcast :
+```javascript
+controller.api.handover.cancel_scheduled_broadcast('<BROADCAST_ID>', function (result) {
+   
+});
+```
+
 
 ## Messaging type
 

--- a/docs/readme-facebook.md
+++ b/docs/readme-facebook.md
@@ -649,7 +649,7 @@ controller.api.handover.request_thread_control('<RECIPIENT_PSID>', 'String to pa
 });
 ```
 
-### Cancelling a Scheduled Broadcast
+### Cancel a Scheduled Broadcast
 
 - To cancel a scheduled broadcast :
 ```javascript
@@ -658,6 +658,14 @@ controller.api.handover.cancel_scheduled_broadcast('<BROADCAST_ID>', function (r
 });
 ```
 
+### Get a Broadcast Status
+
+- To get a broadcast status :
+```javascript
+controller.api.handover.get_broadcast_status('<BROADCAST_ID>', ['scheduled_time', 'status'], function (result) {
+   
+});
+```
 
 ## Messaging type
 

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -1605,6 +1605,42 @@ function Facebookbot(configuration) {
                     }
                 }
             });
+        },
+        get_broadcast_status: function(broadcast_id, fields, cb) {
+            var uri = 'https://' + api_host + '/' + api_version + '/' + broadcast_id + '?access_token=' + configuration.access_token;
+
+            if (facebook_botkit.config.require_appsecret_proof) {
+                uri += '&appsecret_proof=' + appsecret_proof;
+            }
+
+            if (fields && fields.length > 0) {
+                uri += '&fields=' + fields.join(',');
+            }
+
+            request({
+                method: 'GET',
+                json: true,
+                uri: uri
+            }, function(err, res, body) {
+                if (err) {
+                    facebook_botkit.log('Could not get broadcast status');
+                    if (cb) {
+                        cb(err);
+                    }
+                } else {
+                    if (body.error) {
+                        facebook_botkit.log('ERROR in getting broadcast status call : ', body.error.message);
+                        if (cb) {
+                            cb(body.error);
+                        }
+                    } else {
+                        facebook_botkit.log('Successfully get broadcast status');
+                        if (cb) {
+                            cb(null, body);
+                        }
+                    }
+                }
+            });
         }
     };
 

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -1568,6 +1568,43 @@ function Facebookbot(configuration) {
                     }
                 }
             });
+        },
+        cancel_scheduled_broadcast: function(broadcast_id, cb) {
+            var uri = 'https://' + api_host + '/' + api_version + '/' + broadcast_id + '?access_token=' + configuration.access_token;
+
+            if (facebook_botkit.config.require_appsecret_proof) {
+                uri += '&appsecret_proof=' + appsecret_proof;
+            }
+
+            var body = {
+                'operation': 'cancel'
+            };
+
+            request({
+                method: 'POST',
+                json: true,
+                body: body,
+                uri: uri
+            }, function(err, res, body) {
+                if (err) {
+                    facebook_botkit.log('Could not cancel scheduled broadcast');
+                    if (cb) {
+                        cb(err);
+                    }
+                } else {
+                    if (body.error) {
+                        facebook_botkit.log('ERROR in cencel scheduled broadcast call : ', body.error);
+                        if (cb) {
+                            cb(body.error);
+                        }
+                    } else {
+                        facebook_botkit.debug('Successfully cancel scheduled broadcast', body);
+                        if (cb) {
+                            cb(null, body);
+                        }
+                    }
+                }
+            });
         }
     };
 


### PR DESCRIPTION
Hi, 

This PR adds FB scheduled broadcast management to handover API :
- ````cancel_scheduled_broadcast(...)````
- ````get_broadcast_status(...)````

[Doc here] (https://developers.facebook.com/docs/messenger-platform/send-messages/broadcast-messages/#scheduling)

Enjoy ✌️ 