### PR TITLE
Add FB payment settings API

### DIFF
--- a/docs/readme-facebook.md
+++ b/docs/readme-facebook.md
@@ -441,6 +441,21 @@ Remove the home_url setting
 
 Get the home_url
 
+### controller.api.messenger_profile.payment_settings()
+| Argument | Description
+|---  |---
+| payload | A JSON object with the properties `privacy_url`, `public_key`, `testers`
+
+View [the facebook documentation](https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/payment-settings) for more details.
+
+### controller.api.messenger_profile.delete_payment_settings()
+
+Remove the payment_settings setting
+
+### controller.api.messenger_profile.get_payment_settings()
+
+Get the payment_settings property of your bot's Messenger Profile
+
 #### Using the The Messenger Profile API
 
 ```js

--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -614,6 +614,18 @@ function Facebookbot(configuration) {
         get_home_url: function(cb) {
             return facebook_botkit.api.messenger_profile.getAPI('home_url', cb);
         },
+        payment_settings: function(payload) {
+            var message = {
+                payment_settings: payload
+            };
+            return facebook_botkit.api.messenger_profile.postAPI(message);
+        },
+        delete_payment_settings: function() {
+            return facebook_botkit.api.messenger_profile.deleteAPI('payment_settings');
+        },
+        get_payment_settings: function(cb) {
+            return facebook_botkit.api.messenger_profile.getAPI('payment_settings', cb);
+        },
         postAPI: function(message) {
             return new Promise(function(resolve, reject) {
                 var uri = 'https://' + api_host + '/' + api_version + '/me/messenger_profile?access_token=' + configuration.access_token;


### PR DESCRIPTION
Hello 👋 

This PR adds Facebook payment settings to messenger profile API.

[Docs here](https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/payment-settings)

Enjoy