### PR TITLE
Add receive_error event if middleware throws error

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -119,17 +119,39 @@ function Botkit(configuration) {
 
     botkit.receiveMessage = function(bot, message) {
         message._pipeline.stage = 'receive';
+        // save the bot instance and message as middlewares dont pass it along
+        // when running into an error
+        var botInstance = bot;
+        var messageInstance = message;
         botkit.middleware.receive.run(bot, message, function(err, bot, message) {
             if (err) {
+                // log the error to console, so people recognize it
                 console.error('An error occured in the receive middleware: ', err);
-                return;
+                // an error occured in the receive middleware
+                // fire the error event instead of disposing the message
+                // can be obtained by using controller.on('receive_error')[...]
+                message = messageInstance;
+                bot = botInstance;
+                botkit.trigger('receive_error', [err, bot, message]);
+                // we triggered the middleware
+                // clean up the temporary variables
+                botInstance = null;
+                messageInstance = null;
             } else {
                 botkit.debug('RECEIVED MESSAGE');
                 bot.findConversation(message, function(convo) {
                     if (convo) {
                         convo.handle(message);
+                        // we handled the convo
+                        // clean up the temporary variables
+                        botInstance = null;
+                        messageInstance = null;
                     } else {
                         botkit.trigger(message.type, [bot, message]);
+                        // we triggered the middleware
+                        // clean up the temporary variables
+                        botInstance = null;
+                        messageInstance = null;
                     }
                 });
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botkit",
-  "version": "0.6.14",
+  "version": "0.6.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Previously, if an error occurred in the receive middleware, the message would just get swallowed and not processed. The error is just logged to console. Now an actual event is fired which can be caught in a skill.

- CoreBot.js: firing receive_error event with the error message of the middleware
- Error can be caught by using `controller.on('receive_error', function(err, bot, message){[HANDLE THE ERROR...]});`