### PR TITLE
Address TypeError seen in Issue 1447

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -246,20 +246,21 @@ function Slackbot(configuration) {
                 // Recent changes in Slack will break other integrations as they no longer
                 // require a bot and therefore Slack won't send the bot information.
                 if (payload.type === 'event_callback') {
-
                     if (!team.bot) {
                         slack_botkit.log.error('No bot identity found.');
                         return res.status(500).send();
                     }
 
+                    bot.identity = {
+                        id: team.bot.user_id,
+                        name: team.bot.name
+                    };
+                } else {
+                    bot.identity = {
+                        id: team.id,
+                        name: team.name
+                    };
                 }
-
-                bot.identity = {
-                    id: team.bot.user_id,
-                    name: team.bot.name
-                };
-
-
             }
 
             // include the response channel so that they can be used in


### PR DESCRIPTION
Address Issue #1447 - TypeError when Slack slash command received by bot:
* Move the former `bot.identity` assignment into the `event_callback` payload case
* Add an `else` case to catch non-`event_callback` payloads and set the `bot.identity` appropriately