### PR TITLE
Move message delay functionality from tick function to message creation

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -520,6 +520,10 @@ function Botkit(configuration) {
             } else {
                 message.channel = this.source_message.channel;
             }
+            if (message.hasOwnProperty(delay)) {
+                //Todo: add timestamp and delay here
+                message.timestamp = now.getTime() + message.delay;
+            }
 
             if (!this.threads[thread]) {
                 this.threads[thread] = [];
@@ -885,9 +889,9 @@ function Botkit(configuration) {
                             this.messages[0].timestamp <= now.getTime()) {
                             var message = this.messages.shift();
                             // make sure next message is delayed appropriately
-                            if (this.messages.length && this.messages[0].delay) {
-                                this.messages[0].timestamp = now.getTime() + parseInt(this.messages[0].delay);
-                            }
+                            //if (this.messages.length && this.messages[0].delay) {
+                            //    this.messages[0].timestamp = now.getTime() + parseInt(this.messages[0].delay);
+                            //}
 
                             if (message.conditional) {
                                 this.evaluateCondition(message.conditional);


### PR DESCRIPTION
The 'delay' property is not considered until the 'tick' function is called, I moved the timestamp assignment to the message creation to add delay functionality. 