### PR TITLE
Webex guest

### DIFF
--- a/domain-validate.patch
+++ b/domain-validate.patch
@@ -1,0 +1,35 @@
+diff --git a/lib/CiscoSparkbot.js b/lib/CiscoSparkbot.js
+index 6b6b708..883a688 100644
+--- a/lib/CiscoSparkbot.js
++++ b/lib/CiscoSparkbot.js
+@@ -157,13 +157,16 @@ function Sparkbot(configuration) {
+                 domains = controller.config.limit_to_domain;
+             }
+ 
++            address = require("email-addresses")
++            var a = address.parseOneAddress(message.raw_message.data.personEmail);
++
+             var allowed = false;
+             for (var d = 0; d < domains.length; d++) {
+-                if (message.user.toLowerCase().indexOf(domains[d]) >= 0) {
++                if (a.domain.toLowerCase() == domains[d]) {
+                     allowed = true;
+                 }
+             }
+-
++            
+             if (!allowed) {
+                 console.log('WARNING: this message came from a domain that is outside of the allowed list', controller.config.limit_to_domain);
+                 // this message came from a domain that is outside of the allowed list.
+diff --git a/package.json b/package.json
+index 3b59d98..b18fe69 100644
+--- a/package.json
++++ b/package.json
+@@ -14,6 +14,7 @@
+     "clone": "2.1.1",
+     "command-line-args": "^4.0.2",
+     "debug": "^2.6.9",
++    "email-addresses": "^3.0.1",
+     "express": "^4.15.2",
+     "https-proxy-agent": "^2.0.0",
+     "jfs": "^0.2.6",

--- a/examples/webex_guest.js
+++ b/examples/webex_guest.js
@@ -1,0 +1,112 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+           ______     ______     ______   __  __     __     ______
+          /\  == \   /\  __ \   /\__  _\ /\ \/ /    /\ \   /\__  _\
+          \ \  __<   \ \ \/\ \  \/_/\ \/ \ \  _"-.  \ \ \  \/_/\ \/
+           \ \_____\  \ \_____\    \ \_\  \ \_\ \_\  \ \_\    \ \_\
+            \/_____/   \/_____/     \/_/   \/_/\/_/   \/_/     \/_/
+
+
+This is a sample Webex Teams bot built with Botkit.
+
+This bot demonstrates many of the core features of Botkit:
+
+* Connect to Cisco Webex Teams's APIs
+* Receive messages based on "spoken" patterns
+* Reply to messages
+* Use the conversation system to ask questions
+* Use the built in storage system to store and retrieve information
+  for a user.
+
+# EXTEND THE BOT:
+
+  Botkit has many features for building cool and useful bots!
+
+  Read all about it here:
+
+    -> http://botkit.ai
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+var Botkit = require('../lib/Botkit.js');
+
+async function start(){
+        var controller = await Botkit.webexguest.init({
+            debug: false,
+            log: false,
+            guest_issuer_id: process.env.guest_issuer_id,
+            guest_issuer_secret: process.env.guest_issuer_secret,
+            guest_id: process.env.guest_id,
+            guest_name: process.env.guest_name,
+            public_address: process.env.public_address,
+            studio_token: process.env.studio_token, // get one from studio.botkit.ai to enable content management, stats, message console and more
+            secret: process.env.secret, // this is an RECOMMENDED but optional setting that enables validation of incoming webhooks
+            webhook_name: 'created with Botkit, override me before going to production',
+        //    limit_to_ar domain: ['mycompany.com'],
+        //    limit_to_org: 'my_cisco_org_id',
+        });
+
+    // Refresh the JWT and Oauth tokens 30 seconds before they're due to expire
+    setInterval(async function(){
+        controller = await Botkit.webexguest.refresh(controller);
+    }, (controller.config.access_refresh-30)*1000);
+
+    var bot = controller.spawn({});
+
+    controller.setupWebserver(process.env.PORT || 3000, function(err, webserver) {
+        controller.createWebhookEndpoints(webserver, bot, function() {
+            console.log("Webex: Webhooks set up!");
+        });
+    });
+
+    controller.hears(['^markdown'], 'direct_message,direct_mention', function(bot, message) {
+
+        bot.reply(message, {text: '*this is cool*', markdown: '*this is super cool*'});
+
+    });
+
+    controller.on('user_space_join', function(bot, message) {
+        bot.reply(message, 'Welcome, ' + message.raw_message.data.personDisplayName);
+    });
+
+    controller.on('user_space_leave', function(bot, message) {
+        bot.reply(message, 'Bye, ' + message.raw_message.data.personDisplayName);
+    });
+
+
+    controller.on('bot_space_join', function(bot, message) {
+
+        bot.reply(message, 'This trusty bot is here to help.');
+
+    });
+
+
+    controller.on('direct_mention', function(bot, message) {
+        bot.reply(message, 'You mentioned me and said, "' + message.text + '"');
+    });
+
+    controller.on('direct_message', function(bot, message) {
+        bot.reply(message, 'I got your private message. You said, "' + message.text + '"');
+        if (message.raw_message.files) {
+            bot.retrieveFileInfo(message.raw_message.files[0], function(err, file) {
+                bot.reply(message,'I also got an attached file called ' + file.filename);
+            });
+        }
+    });
+
+    if (process.env.studio_token) {
+        controller.on('direct_message,direct_mention', function(bot, message) {
+            controller.studio.runTrigger(bot, message.text, message.user, message.channel).then(function(convo) {
+                if (!convo) {
+                    // console.log('NO STUDIO MATCH');
+                } else {
+                // found a conversation
+                }
+            }).catch(function(err) {
+                console.error('Error with Botkit Studio: ', err);
+            });
+        });
+    }
+
+}
+
+start();

--- a/lib/WebexGuest.js
+++ b/lib/WebexGuest.js
@@ -1,0 +1,48 @@
+var WebexBot = require(__dirname + '/WebexBot.js');
+var jwt = require('jsonwebtoken');
+var request = require('request-promise');
+
+module.exports = {
+    init: async function (configuration) {
+        var oauth = await genToken(configuration);
+        configuration.access_token = oauth.token;
+        configuration.access_refresh = oauth.expiresIn;
+        return(WebexBot(configuration));
+    },
+
+    refresh: async function (controller){
+        var oauth = await genToken(controller.config);
+        controller.api = require('ciscospark').init({
+            credentials: {
+                authorization: {
+                    access_token: oauth.token
+                }
+            }
+        });
+        controller.config.access_token = oauth.token;
+        controller.config.access_refresh = oauth.expiresIn;
+        return(controller);
+    }
+
+}
+
+async function genToken(configuration) {
+    var jwtoken = jwt.sign(
+        {
+            "sub": configuration.guest_id,
+            "name": configuration.guest_name,
+            "iss": configuration.guest_issuer_id
+        },
+    Buffer.from(configuration.guest_issuer_secret, 'base64'),
+    { expiresIn: '1h' }
+    );
+    var response = await request.post({
+            url : 'https://api.ciscospark.com/v1/jwt/login',
+            auth: {
+            'bearer': jwtoken
+            }
+        });
+    return JSON.parse(response);
+}
+
+

--- a/lib/WebexGuest.js
+++ b/lib/WebexGuest.js
@@ -27,6 +27,7 @@ module.exports = {
 }
 
 async function genToken(configuration) {
+    var expiration = configuration.guest_id || '1h';
     var jwtoken = jwt.sign(
         {
             "sub": configuration.guest_id,
@@ -34,7 +35,7 @@ async function genToken(configuration) {
             "iss": configuration.guest_issuer_id
         },
     Buffer.from(configuration.guest_issuer_secret, 'base64'),
-    { expiresIn: '1h' }
+    { expiresIn: expiration }
     );
     var response = await request.post({
             url : 'https://api.ciscospark.com/v1/jwt/login',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1427,6 +1427,18 @@
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
+        "jsonwebtoken": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
+          "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
+          "requires": {
+            "joi": "^6.10.1",
+            "jws": "^3.1.4",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -4167,7 +4179,7 @@
     },
     "isemail": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
       "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
     },
     "isexe": {
@@ -5329,7 +5341,7 @@
     },
     "joi": {
       "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
+      "resolved": "http://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
       "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
       "requires": {
         "hoek": "2.x.x",
@@ -5658,15 +5670,26 @@
       }
     },
     "jsonwebtoken": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
-      "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
+      "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
       "requires": {
-        "joi": "^6.10.1",
-        "jws": "^3.1.4",
+        "jws": "^3.1.5",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
         "lodash.once": "^4.0.0",
-        "ms": "^2.0.0",
-        "xtend": "^4.0.1"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "jsprim": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botkit",
-  "version": "0.6.16",
+  "version": "0.6.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1359,6 +1359,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bluebird": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
+    },
     "body-parser": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
@@ -1616,11 +1621,6 @@
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
       }
-    },
-    "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
     "charenc": {
       "version": "0.0.2",
@@ -2275,14 +2275,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
-    },
     "entities": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
@@ -2570,16 +2562,6 @@
             "is-plain-object": "^2.0.4"
           }
         }
-      }
-    },
-    "external-editor": {
-      "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-      "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -4138,11 +4120,6 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -4155,7 +4132,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -6101,7 +6079,8 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "min-document": {
       "version": "2.19.0",
@@ -6335,15 +6314,6 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
-      }
-    },
-    "node-fetch": {
-      "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-      "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "node-forge": {
@@ -6630,154 +6600,10 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
-    "opencollective": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
-      "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
-      "requires": {
-        "babel-polyfill": "6.23.0",
-        "chalk": "1.1.3",
-        "inquirer": "3.0.6",
-        "minimist": "1.2.0",
-        "node-fetch": "1.6.3",
-        "opn": "4.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "babel-polyfill": {
-          "version": "6.23.0",
-          "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-          "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-          "requires": {
-            "babel-runtime": "^6.22.0",
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.10.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "requires": {
-            "restore-cursor": "^2.0.0"
-          }
-        },
-        "cli-width": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-          "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "inquirer": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
-          "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
-          "requires": {
-            "ansi-escapes": "^1.1.0",
-            "chalk": "^1.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^2.0.1",
-            "figures": "^2.0.0",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rx": "^4.1.0",
-            "string-width": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "mute-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "run-async": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-          "requires": {
-            "is-promise": "^2.1.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
-        }
-      }
-    },
     "openurl": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
       "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c="
-    },
-    "opn": {
-      "version": "4.0.2",
-      "resolved": "http://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-      "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-      "requires": {
-        "object-assign": "^4.0.1",
-        "pinkie-promise": "^2.0.0"
-      }
     },
     "optimist": {
       "version": "0.6.1",
@@ -6833,7 +6659,8 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
@@ -7420,11 +7247,21 @@
         "uuid": "^3.1.0"
       }
     },
+    "request-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
+      }
+    },
     "request-promise-core": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "dev": true,
       "requires": {
         "lodash": "^4.13.1"
       }
@@ -7560,11 +7397,6 @@
       "requires": {
         "once": "^1.3.0"
       }
-    },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -8094,7 +7926,8 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "simple-xmpp": {
       "version": "1.3.0",
@@ -8407,8 +8240,7 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string-length": {
       "version": "2.0.0",
@@ -8542,14 +8374,6 @@
       "requires": {
         "readable-stream": ">=1.0.33-1 <1.1.0-0",
         "xtend": ">=4.0.0 <4.1.0-0"
-      }
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "requires": {
-        "os-tmpdir": "~1.0.2"
       }
     },
     "tmpl": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "mustache": "^2.3.0",
     "promise": "^8.0.0",
     "request": "^2.81.0",
+    "request-promise": "^4.2.2",
     "requestretry": "^1.12.0",
     "simple-xmpp": "^1.3.0",
     "twilio": "^3.11.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "googleapis": "^32.0.0",
     "https-proxy-agent": "^2.2.1",
     "jfs": "^0.3.0",
+    "jsonwebtoken": "^8.3.0",
     "localtunnel": "^1.9.1",
     "md5": "^2.2.1",
     "mustache": "^2.3.0",


### PR DESCRIPTION
Webex recently introduced support for Persistent Guest Users. These are application-managed user identities, that instead of requiring a Webex Teams account to use the APIs, the application uses an existing user identity to generate a JWT and exchange it for an Oauth token. That oauth token can then be used to converse with other Teams users, both with messaging and with calls. Guests can't talk to other guests and have the same restrictions as free Teams accounts.

This PR adds guest support to Botkit. A developer can define the values that would make up their JWT, and then botkit would handle the token exchange and authenticate  to Teams. Because the oauth tokens are short-lived, the example bot also demonstrates how to refresh the token without restarting the bot.