### PR TITLE
Allow conversation typing indicator using configuration

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -945,7 +945,12 @@ function Botkit(configuration) {
                                     that.sent.push(outbound);
                                     that.transcript.push(outbound);
 
-                                    this.task.bot.reply(this.source_message, outbound, function(err, sent_message) {
+                                    const {allow_conversation_typing} = this.task.bot.botkit.config;
+                                    const can_use_typing = this.task.bot.replyWithTyping;
+
+                                    const replyFunction = (allow_conversation_typing && can_use_typing) ? this.task.bot.replyWithTyping : this.task.bot.reply;
+
+                                    replyFunction(this.source_message, outbound, function(err, sent_message) {
                                         if (err) {
                                             botkit.log('An error occurred while sending a message: ', err);
 

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -948,9 +948,9 @@ function Botkit(configuration) {
                                     const {allow_conversation_typing} = this.task.bot.botkit.config;
                                     const can_use_typing = this.task.bot.replyWithTyping;
 
-                                    const replyFunction = (allow_conversation_typing && can_use_typing) ? this.task.bot.replyWithTyping : this.task.bot.reply;
+                                    const reply_function = (allow_conversation_typing && can_use_typing) ? this.task.bot.replyWithTyping : this.task.bot.reply;
 
-                                    replyFunction(this.source_message, outbound, function(err, sent_message) {
+                                    reply_function(this.source_message, outbound, function(err, sent_message) {
                                         if (err) {
                                             botkit.log('An error occurred while sending a message: ', err);
 


### PR DESCRIPTION
## Changes

- Allow typing indicator to be used in conversations by setting `allow_conversation_typing` to `true` in bot configuration when initialising.

## Context for raising PR

There have been previous discussions (below) as to how best to enable the typing indicator in conversations and no solutions have been agreed or merged. I'm suggesting a non-breaking configuration method which will allow people to turn it on as necessary when the bot is initialised but follows existing behaviour by default. Setting the `allow_conversation_typing` configuration to `true` will enable this. Feel free to suggest a different configuration property name. I've confirmed this works as expected when enabling a Facebook Messenger integration.

## Additional Info

I haven't added any tests as none currently exist for `CoreBot`. I'm happy to do so but wanted to confirm you were happy with this approach before starting. I also feel it might be tricky to test this functionality without a refactor of some of the existing functions. I didn't want to start refactoring in my first PR! 😄I don't think all platforms support `replyWithTyping` so I've guarded against this not existing too.

## Related issues / PRs
https://github.com/howdyai/botkit/issues/674
https://github.com/howdyai/botkit/pull/710