### PR TITLE
Add Slack chat.command web api method

### DIFF
--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -13,11 +13,12 @@ function noop() {}
  * @returns {Object} A callback-based Slack API interface.
  */
 module.exports = function(bot, config) {
-
-    var api_root = bot.config.api_root ? bot.config.api_root : 'https://slack.com';
+    var api_root = bot.config.api_root
+        ? bot.config.api_root
+        : 'https://slack.com';
 
     var slack_api = {
-        api_url: api_root + '/api/'
+        api_url: api_root + '/api/',
     };
 
     // Slack API methods: https://api.slack.com/methods
@@ -44,6 +45,7 @@ module.exports = function(bot, config) {
         'chat.postEphemeral',
         'chat.update',
         'chat.unfurl',
+        'chat.command',
         'conversations.archive',
         'conversations.close',
         'conversations.create',
@@ -145,7 +147,7 @@ module.exports = function(bot, config) {
         'users.lookupByEmail',
         'users.setPhoto',
         'users.profile.get',
-        'users.profile.set'
+        'users.profile.set',
     ];
 
     /**
@@ -176,7 +178,6 @@ module.exports = function(bot, config) {
         postForm(slack_api.api_url + command, data, cb);
     };
 
-
     // generate all API methods
     slackApiMethods.forEach(function(slackMethod) {
         /*
@@ -198,7 +199,6 @@ module.exports = function(bot, config) {
         currentGroup[method] = function(options, cb) {
             slack_api.callAPI(slackMethod, options, cb);
         };
-
     });
 
     // overwrite default behavior
@@ -217,13 +217,18 @@ module.exports = function(bot, config) {
         slack_api.callAPI('chat.update', options, cb);
     };
 
+    slack_api.chat.command = function(options, cb) {
+        sanitizeOptions(options);
+        slack_api.callAPI('chat.command', options, cb);
+    };
+
     // specify that files get uploaded using multipart
     slack_api.files.upload = function(options, cb) {
         slack_api.callAPI('files.upload', options, cb, !!options.file);
     };
 
     function sanitizeOptions(options) {
-        if (options.attachments && typeof(options.attachments) != 'string') {
+        if (options.attachments && typeof options.attachments != 'string') {
             try {
                 options.attachments = JSON.stringify(options.attachments);
             } catch (err) {
@@ -233,9 +238,7 @@ module.exports = function(bot, config) {
         }
     }
 
-
     return slack_api;
-
 
     /**
      * Makes a POST request as a form to the given url with the options as data
@@ -252,7 +255,7 @@ module.exports = function(bot, config) {
             url: url,
             headers: {
                 'User-Agent': bot.userAgent(),
-            }
+            },
         };
 
         if (multipart === true) {
@@ -276,7 +279,7 @@ module.exports = function(bot, config) {
                     return cb(parseError);
                 }
 
-                return cb((json.ok ? null : json.error), json);
+                return cb(json.ok ? null : json.error, json);
             } else if (response.statusCode == 429) {
                 return cb(new Error('Rate limit exceeded'));
             } else {

--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -217,11 +217,6 @@ module.exports = function(bot, config) {
         slack_api.callAPI('chat.update', options, cb);
     };
 
-    slack_api.chat.command = function(options, cb) {
-        sanitizeOptions(options);
-        slack_api.callAPI('chat.command', options, cb);
-    };
-
     // specify that files get uploaded using multipart
     slack_api.files.upload = function(options, cb) {
         slack_api.callAPI('files.upload', options, cb, !!options.file);

--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -13,12 +13,10 @@ function noop() {}
  * @returns {Object} A callback-based Slack API interface.
  */
 module.exports = function(bot, config) {
-    var api_root = bot.config.api_root
-        ? bot.config.api_root
-        : 'https://slack.com';
+    var api_root = bot.config.api_root ? bot.config.api_root : 'https://slack.com';
 
     var slack_api = {
-        api_url: api_root + '/api/',
+        api_url: api_root + '/api/'
     };
 
     // Slack API methods: https://api.slack.com/methods
@@ -147,7 +145,7 @@ module.exports = function(bot, config) {
         'users.lookupByEmail',
         'users.setPhoto',
         'users.profile.get',
-        'users.profile.set',
+        'users.profile.set'
     ];
 
     /**
@@ -178,6 +176,7 @@ module.exports = function(bot, config) {
         postForm(slack_api.api_url + command, data, cb);
     };
 
+
     // generate all API methods
     slackApiMethods.forEach(function(slackMethod) {
         /*
@@ -199,6 +198,7 @@ module.exports = function(bot, config) {
         currentGroup[method] = function(options, cb) {
             slack_api.callAPI(slackMethod, options, cb);
         };
+
     });
 
     // overwrite default behavior
@@ -228,7 +228,7 @@ module.exports = function(bot, config) {
     };
 
     function sanitizeOptions(options) {
-        if (options.attachments && typeof options.attachments != 'string') {
+        if (options.attachments && typeof(options.attachments) != 'string') {
             try {
                 options.attachments = JSON.stringify(options.attachments);
             } catch (err) {
@@ -238,7 +238,9 @@ module.exports = function(bot, config) {
         }
     }
 
+
     return slack_api;
+
 
     /**
      * Makes a POST request as a form to the given url with the options as data
@@ -255,7 +257,7 @@ module.exports = function(bot, config) {
             url: url,
             headers: {
                 'User-Agent': bot.userAgent(),
-            },
+            }
         };
 
         if (multipart === true) {
@@ -279,7 +281,7 @@ module.exports = function(bot, config) {
                     return cb(parseError);
                 }
 
-                return cb(json.ok ? null : json.error, json);
+                return cb((json.ok ? null : json.error), json);
             } else if (response.statusCode == 429) {
                 return cb(new Error('Rate limit exceeded'));
             } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botkit",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Add Slack Web API method: `chat.command`.

This method executes a slash command in a public channel.

`chat.command`  is not currently documented in [offical Slack Web API methods](https://api.slack.com/methods), please refer to this [Documentation of undocumented Slack API methods](https://github.com/ErikKalkoken/slackApiDoc/blob/master/chat.command.md)

From my personal view, this can be useful if included in `lib/Slack_web_api.js`, but since it's not included in Slack offical API doc, I understand if the pull request failed to be approved.

