### PR TITLE
Closes #1518: Allow Promises when on Facebook API calls

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -822,42 +822,40 @@ function Facebookbot(configuration) {
                 uri += '&appsecret_proof=' + appsecret_proof;
             }
 
-            request.post(uri,
-                { form: message },
-                function(err, res, body) {
-                    if (err) {
-                        facebook_botkit.log('Could not upload attachment');
-                        if (cb) {
-                            cb(err);
-                        }
-                    } else {
+            return new Promise(function(resolve, reject) {
+                request.post(uri,
+                    { form: message },
+                    function(err, res, body) {
+                        if (err) {
+                            facebook_botkit.log('Could not upload attachment');
+                            if (cb) cb(err);
+                            reject(err);
+                        } else {
 
-                        var results = null;
-                        try {
-                            results = JSON.parse(body);
-                        } catch (err) {
-                            facebook_botkit.log('ERROR in attachment upload API call: Could not parse JSON', err, body);
-                            if (cb) {
-                                cb(err);
+                            var results = null;
+                            try {
+                                results = JSON.parse(body);
+                            } catch (err) {
+                                facebook_botkit.log('ERROR in attachment upload API call: Could not parse JSON', err, body);
+                                if (cb) cb(err);
+                                reject(err);
                             }
-                        }
 
-                        if (results) {
-                            if (results.error) {
-                                facebook_botkit.log('ERROR in attachment upload API call: ', results.error.message);
-                                if (cb) {
-                                    cb(results.error);
-                                }
-                            } else {
-                                var attachment_id = results.attachment_id;
-                                facebook_botkit.log('Successfully got attachment id ', attachment_id);
-                                if (cb) {
-                                    cb(null, attachment_id);
+                            if (results) {
+                                if (results.error) {
+                                    facebook_botkit.log('ERROR in attachment upload API call: ', results.error.message);
+                                    if (cb) cb(results.error);
+                                    reject(results.error);
+                                } else {
+                                    var attachment_id = results.attachment_id;
+                                    facebook_botkit.log('Successfully got attachment id ', attachment_id);
+                                    if (cb) cb(null, attachment_id);
+                                    resolve(attachment_id);
                                 }
                             }
                         }
-                    }
-                });
+                    });
+            });
         }
 
     };
@@ -870,40 +868,38 @@ function Facebookbot(configuration) {
                 uri += '&appsecret_proof=' + appsecret_proof;
             }
 
-            request.get(uri,
-                function(err, res, body) {
-                    if (err) {
-                        facebook_botkit.log('Could not get tags list');
-                        if (cb) {
-                            cb(err);
-                        }
-                    } else {
+            return new Promise(function(resolve, reject) {
+                request.get(uri,
+                    function(err, res, body) {
+                        if (err) {
+                            facebook_botkit.log('Could not get tags list');
+                            if (cb) cb(err);
+                            reject(err);
+                        } else {
 
-                        var results = null;
-                        try {
-                            results = JSON.parse(body);
-                        } catch (err) {
-                            facebook_botkit.log('ERROR in page message tags call: Could not parse JSON', err, body);
-                            if (cb) {
-                                cb(err);
+                            var results = null;
+                            try {
+                                results = JSON.parse(body);
+                            } catch (err) {
+                                facebook_botkit.log('ERROR in page message tags call: Could not parse JSON', err, body);
+                                if (cb) cb(err);
+                                reject(err);
                             }
-                        }
 
-                        if (results) {
-                            if (results.error) {
-                                facebook_botkit.log('ERROR in page message tags: ', results.error.message);
-                                if (cb) {
-                                    cb(results.error);
-                                }
-                            } else {
-                                facebook_botkit.debug('Successfully call page message tags', body);
-                                if (cb) {
-                                    cb(results);
+                            if (results) {
+                                if (results.error) {
+                                    facebook_botkit.log('ERROR in page message tags: ', results.error.message);
+                                    if (cb) cb(results.error);
+                                    reject(results.error);
+                                } else {
+                                    facebook_botkit.debug('Successfully call page message tags', body);
+                                    if (cb) cb(results);
+                                    resolve(results);
                                 }
                             }
                         }
-                    }
-                });
+                    });
+            });
         }
     };
 
@@ -925,28 +921,34 @@ function Facebookbot(configuration) {
                 uri += '&appsecret_proof=' + appsecret_proof;
             }
 
-            request.post(uri, {},
-                function(err, res, body) {
-                    if (err) {
-                        facebook_botkit.log('Could not enable/disable build-in NLP');
-                    } else {
+            return new Promise(function(resolve, reject) {
+                request.post(uri, {},
+                    function(err, res, body) {
+                        if (err) {
+                            facebook_botkit.log('Could not enable/disable build-in NLP');
+                            reject(err);
+                        } else {
 
-                        var results = null;
-                        try {
-                            results = JSON.parse(body);
-                        } catch (err) {
-                            facebook_botkit.log('ERROR in build-in NLP API call: Could not parse JSON', err, body);
-                        }
+                            var results = null;
+                            try {
+                                results = JSON.parse(body);
+                            } catch (err) {
+                                facebook_botkit.log('ERROR in build-in NLP API call: Could not parse JSON', err, body);
+                                reject(err);
+                            }
 
-                        if (results) {
-                            if (results.error) {
-                                facebook_botkit.log('ERROR in build-in API call: ', results.error.message);
-                            } else {
-                                facebook_botkit.debug('Successfully enable/disable build-in NLP', body);
+                            if (results) {
+                                if (results.error) {
+                                    facebook_botkit.log('ERROR in build-in API call: ', results.error.message);
+                                    reject(results.error);
+                                } else {
+                                    facebook_botkit.debug('Successfully enable/disable build-in NLP', body);
+                                    resolve(results);
+                                }
                             }
                         }
-                    }
-                });
+                    });
+            });
         }
     };
 
@@ -1068,32 +1070,31 @@ function Facebookbot(configuration) {
                 uri += '&appsecret_proof=' + appsecret_proof;
             }
 
-            request.get({
-                url: uri,
-                qs: {
-                    fields: typeof(fields) == 'string' ? fields : fields.join(','),
-                    access_token: configuration.access_token
-                },
-                json: true
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not get secondary receivers list');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in secondary receivers list: ', body.error.message);
-                        if (cb) {
-                            cb(body.error);
-                        }
+            return new Promise(function(resolve, reject) {
+                request.get({
+                    url: uri,
+                    qs: {
+                        fields: typeof(fields) == 'string' ? fields : fields.join(','),
+                        access_token: configuration.access_token
+                    },
+                    json: true
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not get secondary receivers list');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.debug('Successfully getting secondary receivers list', body);
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in secondary receivers list: ', body.error.message);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.debug('Successfully getting secondary receivers list', body);
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         take_thread_control: function(recipient, metadata, cb) {
@@ -1109,32 +1110,32 @@ function Facebookbot(configuration) {
                 },
                 metadata: metadata
             };
-            request.post({
-                url: uri,
-                qs: {
-                    access_token: configuration.access_token
-                },
-                body: request_body,
-                json: true
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not take thread control');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in take thread control API call: ', body.error.message);
-                        if (cb) {
-                            cb(body.error);
-                        }
+
+            return new Promise(function(resolve, reject) {
+                request.post({
+                    url: uri,
+                    qs: {
+                        access_token: configuration.access_token
+                    },
+                    body: request_body,
+                    json: true
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not take thread control');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.debug('Successfully taken thread control', body);
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in take thread control API call: ', body.error.message);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.debug('Successfully taken thread control', body);
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         pass_thread_control: function(recipient, target, metadata, cb) {
@@ -1151,32 +1152,32 @@ function Facebookbot(configuration) {
                 target_app_id: target,
                 metadata: metadata
             };
-            request.post({
-                url: uri,
-                qs: {
-                    access_token: configuration.access_token
-                },
-                body: request_body,
-                json: true
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not pass thread control');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in pass thread control API call: ', body.error.message);
-                        if (cb) {
-                            cb(body.error);
-                        }
+
+            return new Promise(function(resolve, reject) {
+                request.post({
+                    url: uri,
+                    qs: {
+                        access_token: configuration.access_token
+                    },
+                    body: request_body,
+                    json: true
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not pass thread control');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.debug('Successfully passed thread control', body);
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in pass thread control API call: ', body.error.message);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.debug('Successfully passed thread control', body);
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         request_thread_control: function(recipient, metadata, cb) {
@@ -1192,32 +1193,32 @@ function Facebookbot(configuration) {
                 },
                 metadata: metadata
             };
-            request.post({
-                url: uri,
-                qs: {
-                    access_token: configuration.access_token
-                },
-                body: request_body,
-                json: true
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not request thread control');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in request thread control API call: ', body.error.message);
-                        if (cb) {
-                            cb(body.error);
-                        }
+
+            return new Promise(function(resolve, reject) {
+                request.post({
+                    url: uri,
+                    qs: {
+                        access_token: configuration.access_token
+                    },
+                    body: request_body,
+                    json: true
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not request thread control');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.debug('Successfully requested thread control', body);
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in request thread control API call: ', body.error.message);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.debug('Successfully requested thread control', body);
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         get_thread_owner: function(recipient, cb) {
@@ -1228,32 +1229,31 @@ function Facebookbot(configuration) {
                 uri += '&appsecret_proof=' + appsecret_proof;
             }
 
-            request.get({
-                url: uri,
-                qs: {
-                    recipient: recipient,
-                    access_token: configuration.access_token
-                },
-                json: true
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not get thread owner');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR while getting thread owner : ', body.error.message);
-                        if (cb) {
-                            cb(body.error);
-                        }
+            return new Promise(function(resolve, reject) {
+                request.get({
+                    url: uri,
+                    qs: {
+                        recipient: recipient,
+                        access_token: configuration.access_token
+                    },
+                    json: true
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not get thread owner');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.debug('Successfully getting thread owner', body);
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR while getting thread owner : ', body.error.message);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.debug('Successfully getting thread owner', body);
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         }
     };
@@ -1277,30 +1277,29 @@ function Facebookbot(configuration) {
                 'messages': [messageToBroadcast]
             };
 
-            request({
-                method: 'POST',
-                json: true,
-                body: body,
-                uri: uri
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not Create a broadcast message');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in creating a broadcast message call: ', body.error);
-                        if (cb) {
-                            cb(body.error);
-                        }
+            return new Promise(function(resolve, reject) {
+                request({
+                    method: 'POST',
+                    json: true,
+                    body: body,
+                    uri: uri
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not Create a broadcast message');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.debug('Successfully create a broadcast message', body);
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in creating a broadcast message call: ', body.error);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.debug('Successfully create a broadcast message', body);
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         send: function(message_creative, custom_label_id, cb) {
@@ -1323,30 +1322,29 @@ function Facebookbot(configuration) {
                 body.custom_label_id = custom_label_id;
             }
 
-            request({
-                method: 'POST',
-                json: true,
-                body: body,
-                uri: uri
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not send the broadcast message');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in sending the broadcast message call : ', body.error);
-                        if (cb) {
-                            cb(body.error);
-                        }
+            return new Promise(function(resolve, reject) {
+                request({
+                    method: 'POST',
+                    json: true,
+                    body: body,
+                    uri: uri
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not send the broadcast message');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.debug('Successfully send the broadcast message', body);
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in sending the broadcast message call : ', body.error);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.debug('Successfully send the broadcast message', body);
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         get_broadcast_metrics: function(broadcast_id, cb) {
@@ -1356,29 +1354,28 @@ function Facebookbot(configuration) {
                 uri += '&appsecret_proof=' + appsecret_proof;
             }
 
-            request({
-                method: 'GET',
-                json: true,
-                uri: uri
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not send a broadcast message');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in getting broadcast metrics call : ', body.error.message);
-                        if (cb) {
-                            cb(body.error);
-                        }
+            return new Promise(function(resolve, reject) {
+                request({
+                    method: 'GET',
+                    json: true,
+                    uri: uri
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not send a broadcast message');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.log('Successfully get broadcast metrics ');
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in getting broadcast metrics call : ', body.error.message);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.log('Successfully get broadcast metrics ');
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         create_label: function(name, cb) {
@@ -1392,30 +1389,29 @@ function Facebookbot(configuration) {
                 'name': name
             };
 
-            request({
-                method: 'POST',
-                json: true,
-                body: body,
-                uri: uri
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not create label to target broadcast messages');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in creating label to target broadcast messages call : ', body.error);
-                        if (cb) {
-                            cb(body.error);
-                        }
+            return new Promise(function(resolve, reject) {
+                request({
+                    method: 'POST',
+                    json: true,
+                    body: body,
+                    uri: uri
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not create label to target broadcast messages');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.debug('Successfully create label to target broadcast messages', body);
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in creating label to target broadcast messages call : ', body.error);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.debug('Successfully create label to target broadcast messages', body);
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         add_user_to_label: function(user, label_id, cb) {
@@ -1429,30 +1425,29 @@ function Facebookbot(configuration) {
                 'user': user
             };
 
-            request({
-                method: 'POST',
-                json: true,
-                body: body,
-                uri: uri
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not add a user to a label');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in adding a user to a label API call : ', body.error);
-                        if (cb) {
-                            cb(body.error);
-                        }
+            return new Promise(function(resolve, reject) {
+                request({
+                    method: 'POST',
+                    json: true,
+                    body: body,
+                    uri: uri
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not add a user to a label');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.debug('Successfully add a user to a label', body);
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in adding a user to a label API call : ', body.error);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.debug('Successfully add a user to a label', body);
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         remove_user_from_label: function(user, label_id, cb) {
@@ -1466,30 +1461,29 @@ function Facebookbot(configuration) {
                 'user': user
             };
 
-            request({
-                method: 'DELETE',
-                json: true,
-                body: body,
-                uri: uri
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not remove a user from a label');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in removing a user from a label API call : ', body.error);
-                        if (cb) {
-                            cb(body.error);
-                        }
+            return new Promise(function(resolve, reject) {
+                request({
+                    method: 'DELETE',
+                    json: true,
+                    body: body,
+                    uri: uri
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not remove a user from a label');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.debug('Successfully remove a user from a label', body);
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in removing a user from a label API call : ', body.error);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.debug('Successfully remove a user from a label', body);
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         get_labels_by_user: function(user, cb) {
@@ -1499,29 +1493,28 @@ function Facebookbot(configuration) {
                 uri += '&appsecret_proof=' + appsecret_proof;
             }
 
-            request({
-                method: 'GET',
-                json: true,
-                uri: uri
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not get user associated labels');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in getting user associated labels API call : ', body.error.message);
-                        if (cb) {
-                            cb(body.error);
-                        }
+            return new Promise(function(resolve, reject) {
+                request({
+                    method: 'GET',
+                    json: true,
+                    uri: uri
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not get user associated labels');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.log('Successfully get user associated labels');
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in getting user associated labels API call : ', body.error.message);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.log('Successfully get user associated labels');
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         get_label_details: function(label_id, fields, cb) {
@@ -1535,29 +1528,28 @@ function Facebookbot(configuration) {
                 uri += '&fields=' + fields.join(',');
             }
 
-            request({
-                method: 'GET',
-                json: true,
-                uri: uri
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not get label details');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in getting label details call : ', body.error.message);
-                        if (cb) {
-                            cb(body.error);
-                        }
+            return new Promise(function(resolve, reject) {
+                request({
+                    method: 'GET',
+                    json: true,
+                    uri: uri
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not get label details');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.log('Successfully get label details');
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in getting label details call : ', body.error.message);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.log('Successfully get label details');
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         get_all_labels: function(fields, cb) {
@@ -1571,29 +1563,28 @@ function Facebookbot(configuration) {
                 uri += '&fields=' + fields.join(',');
             }
 
-            request({
-                method: 'GET',
-                json: true,
-                uri: uri
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not get labels');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in getting labels call : ', body.error.message);
-                        if (cb) {
-                            cb(body.error);
-                        }
+            return new Promise(function(resolve, reject) {
+                request({
+                    method: 'GET',
+                    json: true,
+                    uri: uri
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not get labels');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.log('Successfully get labels');
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in getting labels call : ', body.error.message);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.log('Successfully get labels');
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         remove_label: function(label_id, cb) {
@@ -1603,30 +1594,29 @@ function Facebookbot(configuration) {
                 uri += '&appsecret_proof=' + appsecret_proof;
             }
 
-            request({
-                method: 'DELETE',
-                json: true,
-                body: {},
-                uri: uri
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not remove label');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in removing label API call : ', body.error);
-                        if (cb) {
-                            cb(body.error);
-                        }
+            return new Promise(function(resolve, reject) {
+                request({
+                    method: 'DELETE',
+                    json: true,
+                    body: {},
+                    uri: uri
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not remove label');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.debug('Successfully remove label', body);
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in removing label API call : ', body.error);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.debug('Successfully remove label', body);
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         cancel_scheduled_broadcast: function(broadcast_id, cb) {
@@ -1640,30 +1630,29 @@ function Facebookbot(configuration) {
                 'operation': 'cancel'
             };
 
-            request({
-                method: 'POST',
-                json: true,
-                body: body,
-                uri: uri
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not cancel scheduled broadcast');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in cancel scheduled broadcast call : ', body.error);
-                        if (cb) {
-                            cb(body.error);
-                        }
+            return new Promise(function(resolve, reject) {
+                request({
+                    method: 'POST',
+                    json: true,
+                    body: body,
+                    uri: uri
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not cancel scheduled broadcast');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.debug('Successfully cancel scheduled broadcast', body);
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in cancel scheduled broadcast call : ', body.error);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.debug('Successfully cancel scheduled broadcast', body);
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         },
         get_broadcast_status: function(broadcast_id, fields, cb) {
@@ -1677,29 +1666,28 @@ function Facebookbot(configuration) {
                 uri += '&fields=' + fields.join(',');
             }
 
-            request({
-                method: 'GET',
-                json: true,
-                uri: uri
-            }, function(err, res, body) {
-                if (err) {
-                    facebook_botkit.log('Could not get broadcast status');
-                    if (cb) {
-                        cb(err);
-                    }
-                } else {
-                    if (body.error) {
-                        facebook_botkit.log('ERROR in getting broadcast status call : ', body.error.message);
-                        if (cb) {
-                            cb(body.error);
-                        }
+            return new Promise(function(resolve, reject) {
+                request({
+                    method: 'GET',
+                    json: true,
+                    uri: uri
+                }, function(err, res, body) {
+                    if (err) {
+                        facebook_botkit.log('Could not get broadcast status');
+                        if (cb) cb(err);
+                        reject(err);
                     } else {
-                        facebook_botkit.log('Successfully get broadcast status');
-                        if (cb) {
-                            cb(null, body);
+                        if (body.error) {
+                            facebook_botkit.log('ERROR in getting broadcast status call : ', body.error.message);
+                            if (cb) cb(body.error);
+                            reject(body.error);
+                        } else {
+                            facebook_botkit.log('Successfully get broadcast status');
+                            if (cb) cb(null, body);
+                            resolve(body);
                         }
                     }
-                }
+                });
             });
         }
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botkit",
-  "version": "0.6.21",
+  "version": "0.6.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botkit",
-  "version": "0.6.19",
+  "version": "0.6.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR implements more promises into `lib/Facebook.js`, as requested in Issue #1520 