### PR TITLE
Improve studio_token argument for cli

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -177,7 +177,10 @@ async function getBotPlatform(options) {
 }
 
 async function getBotToken(options) {
-    if (options.studio_token) {
+    if (options.studio_token !== undefined) {
+        if (options.studio_token == null) {
+            options.studio_token = "";
+        }
         return options.studio_token;
     } else {
         const response = await prompts([{


### PR DESCRIPTION
studio_token argument is optional. But it will be prompted to enter.
It is inconvenient to build botkit environment with Docker and I'd like to improve it.