### PR TITLE
hangouts chat: allow to consume auth data from env var instead of file

### DIFF
--- a/lib/GoogleHangoutsBot.js
+++ b/lib/GoogleHangoutsBot.js
@@ -159,23 +159,43 @@ function GoogleHangoutsBot(configuration) {
     });
 
     google_hangouts_botkit.middleware.spawn.use(function(worker, next) {
+        if(process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+            /*
+             * if the env variable containing a json file path is present then do classic
+             * auth
+             */
+            let params = {
+                scopes: 'https://www.googleapis.com/auth/chat.bot'
+            };
 
-        let params = {
-            scopes: 'https://www.googleapis.com/auth/chat.bot'
-        };
-
-        google
-            .auth
-            .getClient(params)
-            .then(client => {
-                worker.authClient = client;
-                worker.api = google.chat({version: api_version, auth: worker.authClient});
-                next();
-            })
-            .catch(err => {
-                console.error('Could not get google auth client !');
-                throw new Error(err);
+            google
+                .auth
+                .getClient(params)
+                .then(client => {
+                    worker.authClient = client;
+                    worker.api = google.chat({version: api_version, auth: worker.authClient});
+                    next();
+                })
+                .catch(err => {
+                    console.error('Could not get google auth client !');
+                    throw new Error(err);
+                });
+        }
+        else if(process.env.GOOGLE_APPLICATION_CREDENTIALS_DATA) {
+            // else we use the env containing the actual data
+            let keys = JSON.parse(process.env.GOOGLE_APPLICATION_CREDENTIALS_DATA);
+            let client = google.auth.fromJSON(keys);
+            client.scopes = ['https://www.googleapis.com/auth/chat.bot'];
+            worker.authClient = client;
+            worker.api = google.chat({
+                version: api_version,
+                auth: worker.authClient
             });
+            next();
+        }
+        else {
+            throw new Error('Can\'t find GOOGLE_APPLICATION_CREDENTIALS or GOOGLE_APPLICATION_CREDENTIALS_DATA, auth failed');
+        }
     });
 
     google_hangouts_botkit.middleware.normalize.use(function handlePostback(bot, message, next) {

--- a/lib/GoogleHangoutsBot.js
+++ b/lib/GoogleHangoutsBot.js
@@ -159,54 +159,34 @@ function GoogleHangoutsBot(configuration) {
     });
 
     google_hangouts_botkit.middleware.spawn.use(function(worker, next) {
-        if(process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-            /*
-             * if the env variable containing a json file path is present then do classic
-             * auth
-             */
-            let params = {
-                scopes: 'https://www.googleapis.com/auth/chat.bot'
-            };
+        let params = {
+            scopes: 'https://www.googleapis.com/auth/chat.bot',
+              ...configuration.google_auth_params
+        };
 
-            google
-                .auth
-                .getClient(params)
-                .then(client => {
-                    worker.authClient = client;
-                    worker.api = google.chat({version: api_version, auth: worker.authClient});
-                    next();
-                })
-                .catch(err => {
-                    console.error('Could not get google auth client !');
-                    throw new Error(err);
-                });
-        }
-        else if(process.env.GOOGLE_APPLICATION_CREDENTIALS_DATA) {
-            // else we use the env containing the actual data
-            let keys = JSON.parse(process.env.GOOGLE_APPLICATION_CREDENTIALS_DATA);
-            let client = google.auth.fromJSON(keys);
-            client.scopes = ['https://www.googleapis.com/auth/chat.bot'];
-            worker.authClient = client;
-            worker.api = google.chat({
-                version: api_version,
-                auth: worker.authClient
+        google
+            .auth
+            .getClient(params)
+            .then(client => {
+                worker.authClient = client;
+                worker.api = google.chat({version: api_version, auth: worker.authClient});
+                next();
+            })
+            .catch(err => {
+                console.error('Could not get google auth client !');
+                throw new Error(err);
             });
-            next();
-        }
-        else {
-            throw new Error('Can\'t find GOOGLE_APPLICATION_CREDENTIALS or GOOGLE_APPLICATION_CREDENTIALS_DATA, auth failed');
-        }
-    });
+      });
 
-    google_hangouts_botkit.middleware.normalize.use(function handlePostback(bot, message, next) {
-        message.user = message.user.name;
-        if (message.message) {
-            message.channel = message.message.thread.name;
-            message.text = message.message.argumentText ? message.message.argumentText.trim() : '';
-        } else {
-            message.channel = message.space.name;
-        }
-        next();
+      google_hangouts_botkit.middleware.normalize.use(function handlePostback(bot, message, next) {
+          message.user = message.user.name;
+          if (message.message) {
+              message.channel = message.message.thread.name;
+              message.text = message.message.argumentText ? message.message.argumentText.trim() : '';
+          } else {
+              message.channel = message.space.name;
+          }
+          next();
     });
 
     google_hangouts_botkit.middleware.categorize.use(function(bot, message, next) {

--- a/lib/GoogleHangoutsBot.js
+++ b/lib/GoogleHangoutsBot.js
@@ -159,9 +159,10 @@ function GoogleHangoutsBot(configuration) {
     });
 
     google_hangouts_botkit.middleware.spawn.use(function(worker, next) {
+
         let params = {
             scopes: 'https://www.googleapis.com/auth/chat.bot',
-              ...configuration.google_auth_params
+            ...configuration.google_auth_params
         };
 
         google
@@ -176,17 +177,17 @@ function GoogleHangoutsBot(configuration) {
                 console.error('Could not get google auth client !');
                 throw new Error(err);
             });
-      });
+    });
 
-      google_hangouts_botkit.middleware.normalize.use(function handlePostback(bot, message, next) {
-          message.user = message.user.name;
-          if (message.message) {
-              message.channel = message.message.thread.name;
-              message.text = message.message.argumentText ? message.message.argumentText.trim() : '';
-          } else {
-              message.channel = message.space.name;
-          }
-          next();
+    google_hangouts_botkit.middleware.normalize.use(function handlePostback(bot, message, next) {
+        message.user = message.user.name;
+        if (message.message) {
+            message.channel = message.message.thread.name;
+            message.text = message.message.argumentText ? message.message.argumentText.trim() : '';
+        } else {
+            message.channel = message.space.name;
+        }
+        next();
     });
 
     google_hangouts_botkit.middleware.categorize.use(function(bot, message, next) {


### PR DESCRIPTION
Instead of setting `GOOGLE_APPLICATION_CREDENTIALS` with the path of the json google auth file, this PR allow to use `GOOGLE_APPLICATION_CREDENTIALS_DATA` that contains the actual json data. This idea come from [here](https://github.com/googleapis/google-auth-library-nodejs/blob/master/README.md#loading-credentials-from-environment-variables).

It will allow to use botkit as a hangout chat bot on Heroku like systems.

You need to start botkit like that:

```
$ GOOGLE_APPLICATION_CREDENTIALS_DATA='{
  "type": "service_account",
  "project_id": "your-project-id",
  "private_key_id": "your-private-key-id",
  "private_key": "your-private-key",
  "client_email": "your-client-email",
  "client_id": "your-client-id",
  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
  "token_uri": "https://accounts.google.com/o/oauth2/token",
  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
  "client_x509_cert_url": "your-cert-url"
}' npm start
```

See issue #1533 
