### PR TITLE
set useQuerystring to true in Slack API

### DIFF
--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -251,6 +251,7 @@ module.exports = function(bot, config) {
         bot.debug('** API CALL: ' + url);
         var params = {
             url: url,
+            useQuerystring: true,
             headers: {
                 'User-Agent': bot.userAgent(),
             }


### PR DESCRIPTION
PHP-style array argument is never valid in Slack API

fixes #1522 