### PR TITLE
Change 500 to 404 when team not found

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -285,7 +285,7 @@ function Slackbot(configuration) {
                 if (!slack_botkit.config.clientId) {
                     bot = slack_botkit.spawn({});
                 } else {
-                    return res.status(500).send();
+                    return res.status(404).send();
                 }
             } else {
                 // spawn a bot
@@ -303,7 +303,7 @@ function Slackbot(configuration) {
 
                     if (!team.bot) {
                         slack_botkit.log.error('No bot identity found.');
-                        return res.status(500).send();
+                        return res.status(404).send();
                     }
 
                 }


### PR DESCRIPTION
- We recently had an Enterprise Grid customer sign up. Somehow, we're receiving webhook events from teams that are part of their grid that haven't signed up yet and thus are not in our database. This has blown up our errors and now we're getting hundreds of emails a day.
- Please note that I originally changed these from simple return statements (that would eventually timeout) to 500 status codes. So I'm just doing what I should've done in the first place :)