### PR TITLE
reduce initial memory by ~50MB -- feedback requested

### DIFF
--- a/lib/Botkit.js
+++ b/lib/Botkit.js
@@ -1,28 +1,31 @@
-var CoreBot = require(__dirname + '/CoreBot.js');
-var Slackbot = require(__dirname + '/SlackBot.js');
-var Facebookbot = require(__dirname + '/Facebook.js');
-var TwilioIPMbot = require(__dirname + '/TwilioIPMBot.js');
-var TwilioSMSbot = require(__dirname + '/TwilioSMSBot.js');
-var BotFrameworkBot = require(__dirname + '/BotFramework.js');
-var WebexBot = require(__dirname + '/WebexBot.js');
-var ConsoleBot = require(__dirname + '/ConsoleBot.js');
-var JabberBot = require(__dirname + '/JabberBot.js');
-var WebBot = require(__dirname + '/Web.js');
-var GoogleHangoutsBot = require(__dirname + '/GoogleHangoutsBot.js');
-
-module.exports = {
-    core: CoreBot,
-    slackbot: Slackbot,
-    webexbot: WebexBot,
-    sparkbot: WebexBot, // [COMPAT] Webex rebrand, see https://github.com/howdyai/botkit/issues/1346
-    facebookbot: Facebookbot,
-    twilioipmbot: TwilioIPMbot,
-    twiliosmsbot: TwilioSMSbot,
-    botframeworkbot: BotFrameworkBot,
-    teamsbot: require(__dirname + '/Teams.js'),
-    consolebot: ConsoleBot,
-    jabberbot: JabberBot,
-    socketbot: WebBot,
-    anywhere: WebBot,
-    googlehangoutsbot: GoogleHangoutsBot
+let files = {
+    core: 'CoreBot.js',
+    slackbot:  'SlackBot.js',
+    facebookbot:  'Facebook.js',
+    webexbot:     'WebexBot.js',
+    sparkbot:     'WebexBot.js', // [COMPAT] Webex rebrand, see https://github.com/howdyai/botkit/issues/1346
+    twilioipmbot: 'TwilioIPMBot.js',
+    twiliosmsbot:  'TwilioSMSBot.js',
+    botframeworkbot: 'BotFramework.js',
+    consolebot: 'ConsoleBot.js',
+    jabberbot: 'JabberBot.js',
+    socketbot: 'Web.js',
+    anywhere: 'Web.js',
+    teamsbot: 'Teams.js',
+    googlehangoutsbot: 'GoogleHangoutsBot.js'
 };
+module.exports = (options => {
+    if (typeof(options) == 'undefined') {
+        options = {};
+    }
+    let exports = {};
+    for (let k in files) {
+        if (options[k] != undefined) {
+            exports[k] = options[k];
+
+        } else {
+            exports[k] = require(__dirname + '/' + files[k]);
+        }
+    }
+    return exports;
+})(global.botkitOptions);

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -4,7 +4,6 @@
  *
  */
 var mustache = require('mustache');
-var simple_storage = require(__dirname + '/storage/simple_storage.js');
 var ConsoleLogger = require(__dirname + '/console_logger.js');
 var LogLevels = ConsoleLogger.LogLevels;
 var ware = require('ware');
@@ -1734,6 +1733,7 @@ function Botkit(configuration) {
         }
     } else if (configuration.json_file_store) {
         botkit.log('** Using simple storage. Saving data to ' + configuration.json_file_store);
+        var simple_storage = require(__dirname + '/storage/simple_storage.js');
         botkit.storage = simple_storage({
             path: configuration.json_file_store
         });


### PR DESCRIPTION
I ran into crashes on a 128MB instance, and found that a lot of memory was being used by unused modules, especially twilio and it's dependencies.   Moreover, `simple_storage.js` is now conditionally loaded to avoid the JFS code overhead.  

I've created a conditional override (clumsily as a global to preserve the `require('botkit`)` interface). 

Let me know your feedback and if you'd prefer another approach for the interface.

(Testing was done using chrome inspect-heap)

Before: **90** MB
After: **39MB** (*51MB savings!!*)


## Example of a Slack-only plugin configuration (all other plugins disabled)
```
var Botkit
  global.botkitOptions = {
    facebookbot:   {},
    twilioipmbot : {},
    twiliosmsbot:  {},
    botframeworkbot: {},
    sparkbot: {},
    consolebot: {},
    jabberbot: {},
    socketbot: {},
    anywhere:{},
    googlehangoutsbot:{},
    teamsbot: {}
  }
Botkit= require('botkit')
```