### PR TITLE
only require simple_storage when used

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -4,7 +4,6 @@
  *
  */
 var mustache = require('mustache');
-var simple_storage = require(__dirname + '/storage/simple_storage.js');
 var ConsoleLogger = require(__dirname + '/console_logger.js');
 var LogLevels = ConsoleLogger.LogLevels;
 var ware = require('ware');
@@ -1734,6 +1733,7 @@ function Botkit(configuration) {
         }
     } else if (configuration.json_file_store) {
         botkit.log('** Using simple storage. Saving data to ' + configuration.json_file_store);
+        var simple_storage = require(__dirname + '/storage/simple_storage.js');
         botkit.storage = simple_storage({
             path: configuration.json_file_store
         });


### PR DESCRIPTION
- this benign change reduces mem usage by about 2MB when not using simple_storage

### Test Results
```
> botkit@0.7.2 test /Users/tonym/sources/botkit
> jest

 PASS  test/Botkit.test.js
  Botkit
    ✓ Should export bot interfaces (9ms)

 PASS  test/facebook/Bot.test.js
  FacebookBot
    ✓ adds 1 + 2 to equal 3 (8ms)

 PASS  test/facebook/Handover_profile_api.test.js
  Handover_profile_api
    ✓ Should not fail (4ms)

 PASS  test/facebook/Tags_api.test.js
  Tags_api
    ✓ Should not fail (1ms)

 PASS  test/facebook/Broadcast_api.test.js
  Broadcast_api
    ✓ Should not fail (2ms)

 PASS  test/facebook/Insights_api.test.js
  Insights_api
    ✓ Should not fail (1ms)

 PASS  test/facebook/User_profile_api.test.js (6.653s)
  User_profile_api
    ✓ Should not fail (10ms)

 PASS  test/facebook/Attachment_upload_api.test.js (6.72s)
  Attachment_upload_api
    ✓ Should not fail (69ms)

 PASS  test/facebook/Personas_profile_api.test.js (6.678s)
  Personas_profile_api
    ✓ Should not fail (79ms)

 PASS  test/facebook/Messenger_profile_api.test.js (6.749s)
  Messenger_profile_api
    ✓ Should not fail (26ms)

 PASS  test/facebook/Nlp_api.test.js
  Nlp_api
    ✓ Should not fail (1ms)

Test Suites: 11 passed, 11 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        7.554s
Ran all test suites.
```
