### PR TITLE
slack api - extend error object with response details if rate limit is hit

### DIFF
--- a/lib/Slack_web_api.js
+++ b/lib/Slack_web_api.js
@@ -280,7 +280,9 @@ module.exports = function(bot, config) {
 
                 return cb((json.ok ? null : json.error), json);
             } else if (response.statusCode == 429) {
-                return cb(new Error('Rate limit exceeded'));
+                var rateLimitError = new Error('Rate limit exceeded');
+                rateLimitError.response = response;
+                return cb(rateLimitError);
             } else {
                 return cb(new Error('Invalid response'));
             }


### PR DESCRIPTION
We recently got rate a limit error. An error message provides no information about  [`Retry-After`](https://api.slack.com/docs/rate-limits) time. This PR includes more response details when the rate limit error is hit.