### PR TITLE
Add warning log for empty socket messages

### DIFF
--- a/lib/Slackbot_worker.js
+++ b/lib/Slackbot_worker.js
@@ -197,7 +197,11 @@ module.exports = function(botkit, config) {
 
                 botkit.trigger('rtm_open', [bot]);
                 bot.rtm.on('message', function(data) {
-
+                    // Distinguish between empty data and malformed JSON
+                    if (!data || data.trim() === '') {
+                        console.warn('** RECEIVED EMPTY DATA FROM SLACK:', data);
+                        return;
+                    }
                     var message = null;
                     try {
                         message = JSON.parse(data);


### PR DESCRIPTION
We've been seeing errors over time stemming from slack sending an empty websocket frame when connecting to a workspace for the first time. When reaching out to slack, they were unable to confirm why this was happening and that we should just ignore empty frames when parsing JSON.

We'd still like to understand how often this happens, so we're leaving the empty frame case as a warning log, while only logging in error in the event of malformed JSON.

