### PR TITLE
Set correct Facebook profile default fields

### DIFF
--- a/lib/Facebook.js
+++ b/lib/Facebook.js
@@ -960,7 +960,7 @@ function Facebookbot(configuration) {
 
     var user_profile = function(uid, fields, cb) {
         if (!fields) {
-            fields = 'first_name,last_name,timezone,gender,locale,email,picture';
+            fields = 'name,first_name,last_name,profile_pic';
         }
         return new Promise(function(resolve, reject) {
             var uri = 'https://' + api_host + '/' + api_version + '/' + uid + '?fields=' + fields + '&access_token=' + configuration.access_token;


### PR DESCRIPTION
## Context

As of the release of Graph API v3.1 on July 26, 2018, the default permissions allowed for retrieval of user profile data are:

```
name,first_name,last_name,profile_pic
```

[Documentation is here.](https://developers.facebook.com/docs/messenger-platform/identity/user-profile/#fields)

To retrieve additional fields such as `locale`, `timezone`, and `gender` requires additional page permissions.

## Changes

- Change o only retrieve the default fields from user profile

## Related issue

https://github.com/howdyai/botkit/issues/1589