### PR TITLE
slack api - support of blocks

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -573,8 +573,10 @@ function Slackbot(configuration) {
         platform_message.link_names =  message.link_names || null;
         platform_message.attachments =  message.attachments ?
             JSON.stringify(message.attachments) : null;
-        platform_message.blocks =  message.blocks ?
-            JSON.stringify(message.blocks) : null;
+        if(message.blocks){
+            platform_message.blocks = JSON.stringify(message.blocks);
+        }
+        
         platform_message.unfurl_links =  typeof message.unfurl_links !== 'undefined' ? message.unfurl_links : null;
         platform_message.unfurl_media =  typeof message.unfurl_media !== 'undefined' ? message.unfurl_media : null;
         platform_message.icon_url =  message.icon_url || null;

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -573,6 +573,8 @@ function Slackbot(configuration) {
         platform_message.link_names =  message.link_names || null;
         platform_message.attachments =  message.attachments ?
             JSON.stringify(message.attachments) : null;
+        platform_message.blocks =  message.blocks ?
+            JSON.stringify(message.blocks) : null;
         platform_message.unfurl_links =  typeof message.unfurl_links !== 'undefined' ? message.unfurl_links : null;
         platform_message.unfurl_media =  typeof message.unfurl_media !== 'undefined' ? message.unfurl_media : null;
         platform_message.icon_url =  message.icon_url || null;


### PR DESCRIPTION
We tried to use new feature of  slack - `blocks` (in `chat.postMessage`) but botkit implementation does not support it. So we added `blocks`  to `format` middleware.