### PR TITLE
Port of Facebook to new adapter format

### DIFF
--- a/packages/botbuilder-facebook/.eslintrc.js
+++ b/packages/botbuilder-facebook/.eslintrc.js
@@ -1,0 +1,14 @@
+module.exports = {
+    "extends": "standard",
+    "rules": {
+        "semi": [2, "always"],
+        "indent": [2, 4],
+        "no-return-await": 0,
+        "space-before-function-paren": [2, {
+            "named": "never",
+            "anonymous": "never",
+            "asyncArrow": "always"
+        }],
+        "template-curly-spacing": [2, "always"]
+    }
+};

--- a/packages/botbuilder-facebook/.gitignore
+++ b/packages/botbuilder-facebook/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+lib/

--- a/packages/botbuilder-facebook/package-lock.json
+++ b/packages/botbuilder-facebook/package-lock.json
@@ -1,0 +1,961 @@
+{
+	"name": "botbuilder-facebook",
+	"version": "1.0.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"eslint": {
+			"version": "5.15.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.1.tgz",
+			"integrity": "sha512-NTcm6vQ+PTgN3UBsALw5BMhgO6i5EpIjQF/Xb5tIh3sk9QhrFafujUOczGz4J24JBlzWclSB9Vmx8d+9Z6bFCg==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"ajv": "^6.9.1",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.5",
+				"debug": "^4.0.1",
+				"doctrine": "^3.0.0",
+				"eslint-scope": "^4.0.2",
+				"eslint-utils": "^1.3.1",
+				"eslint-visitor-keys": "^1.0.0",
+				"espree": "^5.0.1",
+				"esquery": "^1.0.1",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^5.0.1",
+				"functional-red-black-tree": "^1.0.1",
+				"glob": "^7.1.2",
+				"globals": "^11.7.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.0.0",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^6.2.2",
+				"js-yaml": "^3.12.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.3.0",
+				"lodash": "^4.17.11",
+				"minimatch": "^3.0.4",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.2",
+				"path-is-inside": "^1.0.2",
+				"progress": "^2.0.0",
+				"regexpp": "^2.0.1",
+				"semver": "^5.5.1",
+				"strip-ansi": "^4.0.0",
+				"strip-json-comments": "^2.0.1",
+				"table": "^5.2.3",
+				"text-table": "^0.2.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+					"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				},
+				"acorn-jsx": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+					"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+					"dev": true
+				},
+				"ajv": {
+					"version": "6.10.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+					"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"ansi-escapes": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"dev": true,
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"astral-regex": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+					"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+					"dev": true
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"callsites": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+					"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"chardet": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+					"dev": true
+				},
+				"cli-cursor": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+					"dev": true,
+					"requires": {
+						"restore-cursor": "^2.0.0"
+					}
+				},
+				"cli-width": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+					"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+					"dev": true
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"deep-is": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+					"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+					"dev": true
+				},
+				"doctrine": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+					"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2"
+					}
+				},
+				"emoji-regex": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
+				},
+				"eslint-scope": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",
+					"integrity": "sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"eslint-utils": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+					"integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+					"dev": true
+				},
+				"eslint-visitor-keys": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+					"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+					"dev": true
+				},
+				"espree": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+					"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+					"dev": true,
+					"requires": {
+						"acorn": "^6.0.7",
+						"acorn-jsx": "^5.0.0",
+						"eslint-visitor-keys": "^1.0.0"
+					}
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
+				},
+				"esquery": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+					"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+					"dev": true,
+					"requires": {
+						"estraverse": "^4.0.0"
+					}
+				},
+				"esrecurse": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+					"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+					"dev": true,
+					"requires": {
+						"estraverse": "^4.1.0"
+					}
+				},
+				"estraverse": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+					"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+					"dev": true
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+					"dev": true
+				},
+				"external-editor": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+					"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+					"dev": true,
+					"requires": {
+						"chardet": "^0.7.0",
+						"iconv-lite": "^0.4.24",
+						"tmp": "^0.0.33"
+					}
+				},
+				"fast-deep-equal": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+					"dev": true
+				},
+				"fast-json-stable-stringify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+					"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+					"dev": true
+				},
+				"fast-levenshtein": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+					"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+					"dev": true
+				},
+				"figures": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "^1.0.5"
+					}
+				},
+				"file-entry-cache": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+					"dev": true,
+					"requires": {
+						"flat-cache": "^2.0.1"
+					}
+				},
+				"flat-cache": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+					"dev": true,
+					"requires": {
+						"flatted": "^2.0.0",
+						"rimraf": "2.6.3",
+						"write": "1.0.3"
+					}
+				},
+				"flatted": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+					"integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+					"dev": true
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+					"dev": true
+				},
+				"functional-red-black-tree": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+					"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.11.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+					"integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"iconv-lite": {
+					"version": "0.4.24",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+					"dev": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"ignore": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"dev": true
+				},
+				"import-fresh": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+					"integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+					"dev": true,
+					"requires": {
+						"parent-module": "^1.0.0",
+						"resolve-from": "^4.0.0"
+					}
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+					"dev": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"dev": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"dev": true
+				},
+				"inquirer": {
+					"version": "6.2.2",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+					"integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "^3.2.0",
+						"chalk": "^2.4.2",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^3.0.3",
+						"figures": "^2.0.0",
+						"lodash": "^4.17.11",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rxjs": "^6.4.0",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^5.0.0",
+						"through": "^2.3.6"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"dev": true
+						},
+						"strip-ansi": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
+							"integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"is-promise": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+					"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+					"dev": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+					"dev": true
+				},
+				"js-tokens": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+					"dev": true
+				},
+				"js-yaml": {
+					"version": "3.12.2",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+					"integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+					"dev": true
+				},
+				"json-stable-stringify-without-jsonify": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+					"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+					"dev": true
+				},
+				"levn": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+					"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+					"dev": true,
+					"requires": {
+						"prelude-ls": "~1.1.2",
+						"type-check": "~0.3.2"
+					}
+				},
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+					"dev": true
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"mute-stream": {
+					"version": "0.0.7",
+					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+					"dev": true
+				},
+				"natural-compare": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+					"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+					"dev": true
+				},
+				"nice-try": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+					"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+					"dev": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"dev": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"onetime": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"optionator": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+					"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+					"dev": true,
+					"requires": {
+						"deep-is": "~0.1.3",
+						"fast-levenshtein": "~2.0.4",
+						"levn": "~0.3.0",
+						"prelude-ls": "~1.1.2",
+						"type-check": "~0.3.2",
+						"wordwrap": "~1.0.0"
+					}
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+					"dev": true
+				},
+				"parent-module": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+					"integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+					"dev": true,
+					"requires": {
+						"callsites": "^3.0.0"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+					"dev": true
+				},
+				"path-is-inside": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+					"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+					"dev": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"dev": true
+				},
+				"prelude-ls": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+					"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+					"dev": true
+				},
+				"progress": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+					"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+					"dev": true
+				},
+				"punycode": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"dev": true
+				},
+				"regexpp": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+					"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+					"dev": true
+				},
+				"restore-cursor": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+					"dev": true,
+					"requires": {
+						"onetime": "^2.0.0",
+						"signal-exit": "^3.0.2"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"run-async": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+					"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+					"dev": true,
+					"requires": {
+						"is-promise": "^2.1.0"
+					}
+				},
+				"rxjs": {
+					"version": "6.4.0",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+					"integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+					"dev": true,
+					"requires": {
+						"tslib": "^1.9.0"
+					}
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+					"dev": true
+				},
+				"slice-ansi": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+					"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"astral-regex": "^1.0.0",
+						"is-fullwidth-code-point": "^2.0.0"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"table": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
+					"integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.9.1",
+						"lodash": "^4.17.11",
+						"slice-ansi": "^2.1.0",
+						"string-width": "^3.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"dev": true
+						},
+						"string-width": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
+							"integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
+				},
+				"text-table": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+					"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+					"dev": true
+				},
+				"through": {
+					"version": "2.3.8",
+					"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+					"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+					"dev": true
+				},
+				"tmp": {
+					"version": "0.0.33",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+					"dev": true,
+					"requires": {
+						"os-tmpdir": "~1.0.2"
+					}
+				},
+				"tslib": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+					"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+					"dev": true
+				},
+				"type-check": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+					"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+					"dev": true,
+					"requires": {
+						"prelude-ls": "~1.1.2"
+					}
+				},
+				"uri-js": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+					"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+					"dev": true
+				},
+				"write": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+					"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+					"dev": true,
+					"requires": {
+						"mkdirp": "^0.5.1"
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/botbuilder-facebook/package.json
+++ b/packages/botbuilder-facebook/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "botbuilder-slack",
+  "name": "botbuilder-facebook",
   "version": "1.0.0",
   "description": "",
   "main": "lib/index.js",
@@ -12,7 +12,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@slack/client": "^4.7.0",
     "botbuilder": "^4.2.0",
     "botbuilder-dialogs": "^4.2.0",
     "botframework-config": "^4.2.0",

--- a/packages/botbuilder-facebook/package.json
+++ b/packages/botbuilder-facebook/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "botbuilder-slack",
+  "version": "1.0.0",
+  "description": "",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "eslint": "./node_modules/.bin/eslint .",
+    "start": "node ./index.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@slack/client": "^4.7.0",
+    "botbuilder": "^4.2.0",
+    "botbuilder-dialogs": "^4.2.0",
+    "botframework-config": "^4.2.0",
+    "botkit": "^4.0.0",
+    "debug": "^4.1.0",
+    "dotenv": "^6.0.0",
+    "restify": "^7.2.1"
+  },
+  "devDependencies": {
+    "eslint": "^5.5.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0"
+  }
+}

--- a/packages/botbuilder-facebook/src/botworker.ts
+++ b/packages/botbuilder-facebook/src/botworker.ts
@@ -1,6 +1,6 @@
 import { BotWorker, BotkitMessage } from 'botkit';
 
-export class FacebookWorker extends BotWorker {
+export class FacebookBotWorker extends BotWorker {
 
     constructor(botkit, config) {
         super(botkit, config);

--- a/packages/botbuilder-facebook/src/botworker.ts
+++ b/packages/botbuilder-facebook/src/botworker.ts
@@ -1,0 +1,9 @@
+import { BotWorker, BotkitMessage } from 'botkit';
+
+export class FacebookWorker extends BotWorker {
+
+    constructor(botkit, config) {
+        super(botkit, config);
+    }
+
+}

--- a/packages/botbuilder-facebook/src/facebook_adapter.ts
+++ b/packages/botbuilder-facebook/src/facebook_adapter.ts
@@ -1,0 +1,219 @@
+import { Activity, ActivityTypes, BotAdapter, TurnContext, ConversationReference } from 'botbuilder';
+import * as Debug from 'debug';
+import { FacebookBotWorker } from './botworker';
+const debug = Debug('botkit:facebook');
+
+
+export interface FacebookAdapterOptions {
+    api_host: string;
+}
+
+export class FacebookAdapter extends BotAdapter {
+    // Botkit Plugin fields
+    public name: string;
+    public middlewares;
+    public web;
+    public menu;
+    private options: FacebookAdapterOptions;
+    private api; // google api
+
+    // tell botkit to use this type of worker
+    public botkit_worker = FacebookBotWorker;
+
+    private api_version: string = 'v2.11';
+    private api_host: string = 'graph.facebook.com';
+
+    // TODO: Define options
+    constructor(options: FacebookAdapterOptions) {
+        super();
+
+        this.options = options;
+
+        if (this.options.api_host) {
+            this.api_host = this.options.api_host;
+        }
+
+        this.name = 'Facebook Adapter';
+
+        this.middlewares = {
+            spawn: [
+                async (bot, next) => {
+
+                    bot.api = this.api;
+                    next();
+
+                }
+            ]
+        };
+
+        this.web = [];
+
+        this.menu = [];
+    }
+
+    private activityToFacebook(activity: any): any {
+
+        const message = {
+            parent: activity.conversation.id,
+            threadKey: activity.conversation.threadKey || null,
+            requestBody: { 
+                text: activity.text,
+                thread: activity.conversation.thread ? { name: activity.conversation.thread } : null
+            },
+        };
+
+        // if channelData is specified, overwrite any fields in message object
+        if (activity.channelData) {
+            Object.keys(activity.channelData).forEach(function(key) {
+                message.requestBody[key] = activity.channelData[key];
+            });
+        }
+
+        debug('OUT TO FACEBOOK > ', message);
+
+        return message;
+    }
+
+    public async sendActivities(context: TurnContext, activities: Activity[]) {
+        const responses = [];
+        for (var a = 0; a < activities.length; a++) {
+            const activity = activities[a];
+            if (activity.type === ActivityTypes.Message) {
+                const message = this.activityToFacebook(activity);
+                try {
+                    // const res = await this.api.spaces.messages.create(message);
+                    // responses.push({ id: res.data.name });
+                } catch (err) {
+                    console.error('Error sending activity to Slack:', err);
+                }
+            } else {
+                // TODO: Handle sending of other types of message?
+            }
+        }
+
+        return responses;
+    }
+
+    async updateActivity(context: TurnContext, activity: Activity) {
+        if (activity.id) {
+            try {
+                // const results = await this.api.spaces.messages.update({
+                //     name: activity.id,
+                //     updateMask: 'text,cards',
+                //     resource: {
+                //         text: activity.text,
+                //         // @ts-ignore allow cards field
+                //         cards: activity.cards ? activity.cards : (activity.channelData ? activity.channelData.cards : null),
+                //     }
+                // });
+
+                // TODO: evaluate success
+
+            } catch (err) {
+                console.error('Error updating activity on Hangouts:', err);
+            }
+        } else {
+            throw new Error('Cannot update activity: activity is missing id');
+        }
+    }
+
+    async deleteActivity(context: TurnContext, reference: ConversationReference) {
+        if (reference.activityId) {
+            try {
+
+                // const results = await this.api.spaces.messages.delete({
+                //     name: reference.activityId,
+                // });
+
+                // TODO: evaluate success
+            } catch (err) {
+                console.error('Error deleting activity', err);
+                throw err;
+            }
+        } else {
+            throw new Error('Cannot delete activity: reference is missing activityId');
+        }
+    }
+
+    async continueConversation(reference: ConversationReference, logic: (t: TurnContext) => Promise<any>) {
+        const request = TurnContext.applyConversationReference(
+            { type: 'event', name: 'continueConversation' },
+            reference,
+            true
+        );
+        const context = new TurnContext(this, request);
+
+        return this.runMiddleware(context, logic);
+    }
+
+    async processActivity(req, res, logic) {
+        let event = req.body;
+
+        debug('IN FROM HANGOUTS >', event);
+
+        if (this.options.token && this.options.token !== event.token) {
+            res.status(401);
+            debug('Token verification failed, Ignoring message');
+        } else {
+            const activity = {
+                id: event.message ? event.message.name : event.eventTime,
+                timestamp: new Date(),
+                channelId: 'googlehangouts',
+                conversation: {
+                    id: event.space.name,
+                    thread: (event.message && !event.threadKey) ? event.message.thread.name : null,
+                    threadKey: event.threadKey ||  null
+                },
+                from: {
+                    id: event.user.name
+                }, 
+                channelData: event,
+                text: event.message ? (event.message.argumentText ? event.message.argumentText.trim() : '') : '',
+                type: event.message ? ActivityTypes.Message : ActivityTypes.Event
+            };
+
+            // change type of message event for private messages
+            if (event.space.type === 'DM') {
+                activity.channelData.botkitEventType = 'direct_message';
+            }
+
+            if ('ADDED_TO_SPACE' === event.type) {
+                activity.channelData.botkitEventType = 'ROOM' === event.space.type ? 'bot_room_join' : 'bot_dm_join';
+            }
+    
+            if ('REMOVED_FROM_SPACE' === event.type) {
+                activity.channelData.botkitEventType = 'ROOM' === event.space.type ? 'bot_room_leave' : 'bot_dm_leave';
+            }
+    
+            if ('CARD_CLICKED' === event.type) {
+                activity.channelData.botkitEventType = event.type.toLowerCase();
+            }
+
+            // create a conversation reference
+            // @ts-ignore
+            const context = new TurnContext(this, activity as Activity);
+
+            if (event.type !== 'CARD_CLICKED') {
+                // send 200 status immediately, otherwise 
+                // hangouts does not mark the incoming message as received
+                res.status(200);
+                res.end();
+            } else {
+                context.turnState.set('httpStatus', 200);
+            }
+
+            await this.runMiddleware(context, logic)
+                .catch((err) => { throw err; });
+
+            if (event.type === 'CARD_CLICKED') {
+                // send http response back
+                res.status(context.turnState.get('httpStatus'));
+                if (context.turnState.get('httpBody')) {
+                    res.send(context.turnState.get('httpBody'));
+                } else {
+                    res.end();
+                }
+            }
+        }
+    }
+}

--- a/packages/botbuilder-facebook/src/facebook_api.ts
+++ b/packages/botbuilder-facebook/src/facebook_api.ts
@@ -1,0 +1,33 @@
+import * as request from 'request';
+
+export class FacebookAPI {
+
+    private token: string;
+    private api_host: string;
+    private api_version: string;
+
+    constructor(token: string, api_host:string = 'graph.facebook.com', api_version: string = 'v2.11') {
+        this.token = token;
+        this.api_host = api_host;
+        this.api_version = api_version;
+    }
+
+    public async callAPI(uri: string, method:string='POST', payload): Promise<any> {
+        return new Promise((resolve, reject) => {
+            request({
+                method: method,
+                json: true,
+                body: payload,
+                uri: 'https://' + this.api_host + '/' + this.api_version + uri
+            }, (err, res, body) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(body);
+                }
+            });
+        });
+    }
+
+
+}

--- a/packages/botbuilder-facebook/src/facebook_event_middleware.ts
+++ b/packages/botbuilder-facebook/src/facebook_event_middleware.ts
@@ -1,0 +1,40 @@
+import { ActivityTypes, MiddlewareSet } from 'botbuilder';
+
+export class FacebookEventTypeMiddleware extends MiddlewareSet {
+    async onTurn(context, next) {
+        if (context.activity && context.activity.channelData) {
+            let type = null;
+            if (context.activity.channelData.postback) {
+                type = 'facebook_postback';
+            } else if (context.activity.channelData.referral) {
+                type = 'facebook_referral';
+            } else if (context.activity.channelData.optin) {
+                type = 'facebook_option';
+            } else if (context.activity.channelData.delivery) {
+                type = 'message_delivered';
+            } else if (context.activity.channelData.read) {
+                type = 'message_read';
+            } else if (context.activity.channelData.account_linking) {
+                type = 'facebook_account_linking';
+            } else if (context.activity.channelData.message && context.activity.channelData.message.is_echo) {
+                type = 'message_echo';
+            } else if (context.activity.channelData.app_roles) {
+                type = 'facebook_app_roles';
+            } else if (context.activity.channelData.standby) {
+                type = 'standby';
+            } else if (context.activity.channelData.pass_thread_control) {
+                type = 'facebook_receive_thread_control';
+            } else if (context.activity.channelData.take_thread_control) {
+                type = 'facebook_lose_thread_control';
+            } else if (context.activity.channelData.request_thread_control) {
+                type = 'facebook_request_thread_control';
+            } else if (context.activity.channelData.app_roles) {
+                type = 'facebook_app_roles';
+            }
+
+            context.activity.channelData.botkitEventType = type;
+        }
+
+        await next();
+    }
+}

--- a/packages/botbuilder-facebook/src/index.ts
+++ b/packages/botbuilder-facebook/src/index.ts
@@ -1,0 +1,3 @@
+export * from './facebook_adapter';
+export * from './botworker';
+export * from './facebook_event_middleware';

--- a/packages/botbuilder-facebook/tsconfig.json
+++ b/packages/botbuilder-facebook/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "commonjs",
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "types" : ["node"],
+    "lib": [
+      "es5",
+      "es2015",
+      "es2016.array.include",
+      "esnext.asynciterable"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/botkit/src/botworker.ts
+++ b/packages/botkit/src/botworker.ts
@@ -105,6 +105,9 @@ export class BotWorker {
             };
         }
 
+        // TODO: This should copy any fields outside the normal activity schema into the channelData field
+        // that way botkit users can just do message.foo and it will map to the right place in the adapter level, which can then map as necessary
+
         return msg;
     }
 

--- a/packages/botkit/src/botworker.ts
+++ b/packages/botkit/src/botworker.ts
@@ -107,6 +107,7 @@ export class BotWorker {
 
         // TODO: This should copy any fields outside the normal activity schema into the channelData field
         // that way botkit users can just do message.foo and it will map to the right place in the adapter level, which can then map as necessary
+        // Could be a small issue with attachments, as slack and botframework both use that field? maybe not?
 
         return msg;
     }

--- a/packages/botkit/src/conversation.ts
+++ b/packages/botkit/src/conversation.ts
@@ -373,6 +373,40 @@ export class BotkitConversation<O extends object = {}> extends Dialog<O> {
             };
         }
 
+        // TODO: have to handle all the weird mappings
+
+        console.log('PROCESSING FOR OUTGOING', line);
+
+        // handle facebook attachments
+        if (line.fb_attachment) {
+
+            let attachment = line.fb_attachment;
+            if (attachment.template_type) {
+                if (attachment.template_type == 'button') {
+                    attachment.text = outgoing.text;
+                }
+                outgoing.channelData.attachment = {
+                    type: 'template',
+                    payload: attachment
+                };
+            } else if (attachment.type) {
+                outgoing.channelData.attachment = attachment;
+            }
+
+            // blank text, not allowed with attachment
+            outgoing.text = null;
+
+            // remove blank button array if specified
+            if (outgoing.channelData.attachment.payload.elements) {
+                for (var e = 0; e < outgoing.channelData.attachment.payload.elements.length; e++) {
+                    if (!outgoing.channelData.attachment.payload.elements[e].buttons || !outgoing.channelData.attachment.payload.elements[e].buttons.length) {
+                        delete(outgoing.channelData.attachment.payload.elements[e].buttons);
+                    }
+                }
+            }
+
+        }
+
         // handle teams attachments
         if (line.platforms && line.platforms.teams) {
             if (line.platforms.teams.attachments) {

--- a/packages/botkit/src/conversation.ts
+++ b/packages/botkit/src/conversation.ts
@@ -366,11 +366,11 @@ export class BotkitConversation<O extends object = {}> extends Dialog<O> {
             outgoing = MessageFactory.text(line.text[Math.floor(Math.random()*line.text.length)]);
         }
 
+        outgoing.channelData = {};
+
         // handle slack attachments
         if (line.attachments) {
-            outgoing.channelData = {
-                attachments: line.attachments,
-            };
+            outgoing.channelData.attachments = line.attachments;
         }
 
         // TODO: have to handle all the weird mappings

--- a/packages/testbot/bot.js
+++ b/packages/testbot/bot.js
@@ -3,6 +3,7 @@ const { SlackAdapter, SlackMessageTypeMiddleware, SlackIdentifyBotsMiddleware, S
 const { WebexAdapter } = require('botbuilder-webex');
 const { ShowTypingMiddleware } = require('botbuilder');
 const { WebsocketAdapter } = require('botbuilder-websocket');
+const { FacebookAdapter, FacebookEventTypeMiddleware } = require('botbuilder-facebook');
 const { MongoDbStorage } = require('botbuilder-storage-mongodb');
 
 const basicAuth = require('express-basic-auth');
@@ -43,17 +44,17 @@ if (process.env.MONGO_URI) {
  * Configure the Slack adapter
  * ----------------------------------------------------------------------
  */
-const adapter = new SlackAdapter({
-   verificationToken: process.env.verificationToken,
-    clientSigningSecret: process.env.clientSigningSecret,  
-    botToken: process.env.botToken,
-    clientId: process.env.clientId,
-    clientSecret: process.env.clientSecret,
-    scopes: ['bot'],
-    redirectUri: process.env.redirectUri,
-    getTokenForTeam: getTokenForTeam,
-    getBotUserByTeam: getBotUserByTeam,
-});
+// const adapter = new SlackAdapter({
+//    verificationToken: process.env.verificationToken,
+//     clientSigningSecret: process.env.clientSigningSecret,  
+//     botToken: process.env.botToken,
+//     clientId: process.env.clientId,
+//     clientSecret: process.env.clientSecret,
+//     scopes: ['bot'],
+//     redirectUri: process.env.redirectUri,
+//     getTokenForTeam: getTokenForTeam,
+//     getBotUserByTeam: getBotUserByTeam,
+// });
 
 let tokenCache = {};
 let userCache = {};
@@ -93,10 +94,10 @@ async function getBotUserByTeam(teamId) {
 
 // Use SlackEventMiddleware to emit events that match their original Slack event types.
 // this may BREAK waterfall dailogs which only accept ActivityTypes.Message
-adapter.use(new SlackEventMiddleware());
+// adapter.use(new SlackEventMiddleware());
 
 // Use SlackMessageType middleware to further classify messages as direct_message, direct_mention, or mention
-adapter.use(new SlackMessageTypeMiddleware());
+// adapter.use(new SlackMessageTypeMiddleware());
 
 // adapter.use(new SlackIdentifyBotsMiddleware());
 
@@ -111,6 +112,15 @@ adapter.use(new SlackMessageTypeMiddleware());
  * ----------------------------------------------------------------------
  */
 // const adapter = new WebsocketAdapter({});
+
+const adapter = new FacebookAdapter({
+    verify_token: process.env.FACEBOOK_VERIFY_TOKEN,
+    access_token: process.env.FACEBOOK_ACCESS_TOKEN,
+    app_secret: process.env.FACEBOOK_APP_SECRET,
+})
+
+// emit events based on the type of facebook event being received
+adapter.use(new FacebookEventTypeMiddleware());
 
 const controller = new Botkit({
     debug: true,

--- a/packages/testbot/features/convo.js
+++ b/packages/testbot/features/convo.js
@@ -66,10 +66,10 @@ module.exports = function(controller) {
         await bot.beginDialog('tacos');
     });
 
-    controller.cms.after('tacos', async(results, bot) => {
-        console.log('AFTER TACOS!!!!!!');
-        await bot.beginDialog('menu'); 
-    });
+    // controller.cms.after('tacos', async(results, bot) => {
+    //     console.log('AFTER TACOS!!!!!!');
+    //     await bot.beginDialog('menu'); 
+    // });
 
     controller.dialogSet.add(welcome);
     controller.hears(['welcome'],'message', async (bot, message) => {

--- a/packages/testbot/features/facebook_features.js
+++ b/packages/testbot/features/facebook_features.js
@@ -7,5 +7,9 @@ module.exports = function(controller) {
         await bot.reply(message,'Cool sticker.');
     });
 
+    controller.on('facebook_postback', async(bot, message) => {
+        await bot.reply(message,`I heard you posting back a post_back about ${ message.text }`);
+    });
+
 
 }

--- a/packages/testbot/features/facebook_features.js
+++ b/packages/testbot/features/facebook_features.js
@@ -1,0 +1,11 @@
+module.exports = function(controller) {
+
+    /**
+     * Detect when a message has a sticker attached
+     */
+    controller.hears(async(message) => message.sticker_id, 'message', async(bot, message) => {
+        await bot.reply(message,'Cool sticker.');
+    });
+
+
+}

--- a/packages/testbot/features/hear_patterns.js
+++ b/packages/testbot/features/hear_patterns.js
@@ -1,7 +1,7 @@
 module.exports = function(controller) {
 
     // use a function to match a condition in the message
-    controller.hears(async(message) => message.text.toLowerCase() === 'foo', ['message'], async (bot, message) => {
+    controller.hears(async(message) => message.text && message.text.toLowerCase() === 'foo', ['message'], async (bot, message) => {
         await bot.reply(message, 'I heard foo via a function test');
     });
 

--- a/packages/testbot/features/z_fallback.js
+++ b/packages/testbot/features/z_fallback.js
@@ -1,5 +1,7 @@
 module.exports = function(controller) {
     controller.on('message', async (bot, message) => {
         await bot.reply(message,{ text: 'Echo: ' + message.text});
+
+        console.log(JSON.stringify(message, null, 2));
     });
 }

--- a/packages/testbot/package.json
+++ b/packages/testbot/package.json
@@ -17,6 +17,7 @@
     "botbuilder-storage-mongodb": "^0.9.5",
     "botbuilder-webex": "1.0.0",
     "botbuilder-websocket": "1.0.0",
+    "botbuilder-facebook": "1.0.0",
     "botkit": "^4.0.0",
     "dotenv": "^6.2.0",
     "express-basic-auth": "^1.1.6"


### PR DESCRIPTION
Fixes #1576 

To use, create an adapter like this and pass it into your Botkit constructor:

```
const adapter = new FacebookAdapter({
    verify_token: process.env.FACEBOOK_VERIFY_TOKEN,
    access_token: process.env.FACEBOOK_ACCESS_TOKEN,
    app_secret: process.env.FACEBOOK_APP_SECRET,
})

// emit events based on the type of facebook event being received
adapter.use(new FacebookEventTypeMiddleware());
```

Still to do:

- [ ] multi-tenancy
- [ ] Flesh out facebook API client (or find one that already has the features we want)
- [ ] Readme file
- [ ] tests