### PR TITLE
Fix type error of attachments field

### DIFF
--- a/packages/botkit/src/conversation.ts
+++ b/packages/botkit/src/conversation.ts
@@ -33,7 +33,7 @@ interface BotkitMessageTemplate {
     text: string[];
     action?: string;
     quick_replies?: [any];
-    attachments?: [];
+    attachments?: any[];
     channelData?: any;
     collect: {
         key: string;


### PR DESCRIPTION
Fixes `error TS1122: A tuple type element list cannot be empty.`