### PR TITLE
fix(#1633): addSelect param types

### DIFF
--- a/packages/botbuilder-adapter-slack/src/slack_dialog.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_dialog.ts
@@ -189,7 +189,7 @@ export class SlackDialog {
      * @param option_list
      * @param options
      */
-    public addSelect(label: string, name: string, value: string, option_list: string, options?: any): SlackDialog {
+    public addSelect(label: string, name: string, value: string, option_list: [{label: string, value: string}], options?: any): SlackDialog {
         var element = {
             label: label,
             name: name,


### PR DESCRIPTION
Changing option_list to an array of object.