### PR TITLE
Fixed misplaced ")" in facebook adapter init function...

### DIFF
--- a/packages/botbuilder-adapter-facebook/src/facebook_adapter.ts
+++ b/packages/botbuilder-adapter-facebook/src/facebook_adapter.ts
@@ -125,7 +125,7 @@ export class FacebookAdapter extends BotAdapter {
      */
     public async init(botkit): Promise<any> {
         debug('Add GET webhook endpoint for verification at: ', botkit.getConfig('webhook_uri'));
-        botkit.webserver.get(botkit.getConfig('webhook_uri', function(req, res) {
+        botkit.webserver.get(botkit.getConfig('webhook_uri'), (req, res) => {
             if (req.query['hub.mode'] === 'subscribe') {
                 if (req.query['hub.verify_token'] === this.options.verify_token) {
                     res.send(req.query['hub.challenge']);
@@ -133,7 +133,7 @@ export class FacebookAdapter extends BotAdapter {
                     res.send('OK');
                 }
             }
-        }));
+        });
     }
 
     /**


### PR DESCRIPTION
...causing the verify webhook to never get called.