### PR TITLE
Updated Teams.js with tokenReceived event

### DIFF
--- a/lib/Teams.js
+++ b/lib/Teams.js
@@ -17,7 +17,12 @@ function TeamsBot(configuration) {
         let expiryCheckDelta = 1000 * 60 * 10;
         setTimeout(controller.api.getToken, (tokenExpiresIn - expiryCheckDelta), tokenHandler);
     }
-    controller.api.getToken(tokenHandler);
+    // get API token
+    controller.api.getToken(function(err) {
+        // trigger event to signal token has been obtained
+        controller.trigger('tokenReceived', controller);
+        tokenHandler(err);
+    });
 
     controller.defineBot(function(botkit, config) {
         var bot = {


### PR DESCRIPTION
This 'tokenReceived' event will allow the caller to ensure the API token has been retrieved before spawning any new instances of the bot.

I identified this issue when attempting to spawn a bot instance `controller.spawn({ serviceUrl: ... })` directly after initializing the bot controller `Botkit.teamsbot({ clientId: 'xxx, clientSecret: 'xxx' });`.  Unfortunatly the token had not yet been obtained, which resulted in the bot instance without the API token.

A workaround was utilising setTimeout, but Ben suggested this change (Thanks again for the help).