### PR TITLE
[Slack] Add redirectUri in getInstallLink()

### DIFF
--- a/packages/botbuilder-adapter-slack/src/slack_adapter.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_adapter.ts
@@ -224,7 +224,7 @@ export class SlackAdapter extends BotAdapter {
      */
     public getInstallLink(): string {
         if (this.options.clientId && this.options.scopes) {
-            const redirect = 'https://slack.com/oauth/authorize?client_id=' + this.options.clientId + '&scope=' + this.options.scopes.join(',');
+            const redirect = 'https://slack.com/oauth/authorize?client_id=' + this.options.clientId + '&scope=' + this.options.scopes.join(',') + '&redirect_uri=' + this.options.redirectUri;
             return redirect;
         } else {
             throw new Error('getInstallLink() cannot be called without clientId and scopes in adapter options');

--- a/packages/botbuilder-adapter-slack/src/slack_adapter.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_adapter.ts
@@ -224,7 +224,12 @@ export class SlackAdapter extends BotAdapter {
      */
     public getInstallLink(): string {
         if (this.options.clientId && this.options.scopes) {
-            const redirect = 'https://slack.com/oauth/authorize?client_id=' + this.options.clientId + '&scope=' + this.options.scopes.join(',') + '&redirect_uri=' + this.options.redirectUri;
+            let redirect = 'https://slack.com/oauth/authorize?client_id=' + this.options.clientId + '&scope=' + this.options.scopes.join(',');
+
+            if (this.options.redirectUri) {
+                redirect += '&redirect_uri=' + encodeURIComponent(this.options.redirectUri);
+            }
+
             return redirect;
         } else {
             throw new Error('getInstallLink() cannot be called without clientId and scopes in adapter options');


### PR DESCRIPTION
On Slack adapter, `redirectUri` is not send to Slack via `getInstallLink()`. Therefore Slack is redirecting to a wrong url during installation, hitting the wrong endpoint and breaking installation.

If you use the Slack adapter with a `redirectUri` param before this fix, you cannot trigger OAuth with Botkit `getInstallLink()`.