### PR TITLE
WebAdapter: Add isConnected method

### DIFF
--- a/packages/botbuilder-adapter-web/src/web_adapter.ts
+++ b/packages/botbuilder-adapter-web/src/web_adapter.ts
@@ -305,4 +305,14 @@ export class WebAdapter extends BotAdapter {
             res.end();
         }
     }
+
+    /**
+     * Is given user currently connected?
+     *
+     * Example: `bot.controller.adapter.isConnected(message.user)`
+     * @param user
+     */
+    public isConnected(user: string): boolean {
+        return typeof clients[user] !== 'undefined';
+    }
 }


### PR DESCRIPTION
Can be used to avoid sending notifications after disconnect.

Example: 
```typescript
if (bot.controller.adapter.isConnected(message.user)) {
    const newBot = await bot.controller.spawn({});
    await newBot.changeContext(message.reference);
    await newBot.reply(message, { text: 'You were inactive for too long and your session timed out.', action: 'exit' });
}
```
