### PR TITLE
Fix signature of spawn method

### DIFF
--- a/packages/botkit/src/core.ts
+++ b/packages/botkit/src/core.ts
@@ -1032,7 +1032,7 @@ export class Botkit {
      * for handling platform-specific events or activities.
      * @param config {any} Preferably receives a DialogContext, though can also receive a TurnContext. If excluded, must call `bot.changeContext(reference)` before calling any other method.
      */
-    public async spawn(config: any): Promise<BotWorker> {
+    public async spawn(config?: any): Promise<BotWorker> {
         if (config instanceof TurnContext) {
             config = {
                 dialogContext: await this.dialogSet.createContext(config as TurnContext),


### PR DESCRIPTION
According to documentation at https://github.com/howdyai/botkit/blob/master/packages/docs/core.md#sending-alerts-and-scheduled-messages, config parameter of spawn() is optional.

However I got an error when compiling my bot:
```
src/actions.ts:117:42 - error TS2554: Expected 1 arguments, but got 0.
117                     const newBot = await bot.controller.spawn();
                                             ~~~~~~~~~~~~~~~~~~~~~~
  node_modules/botkit/lib/core.d.ts:502:11
    502     spawn(config: any): Promise<BotWorker>;
                  ~~~~~~~~~~~
    An argument for 'config' was not provided.
```