### PR TITLE
[adapter-slack] Fix typo in 'src.channnel' in 'replyInteractive'

### DIFF
--- a/packages/botbuilder-adapter-slack/src/botworker.ts
+++ b/packages/botbuilder-adapter-slack/src/botworker.ts
@@ -241,7 +241,7 @@ export class SlackBotWorker extends BotWorker {
             let msg = this.ensureMessageFormat(resp);
             // @ts-ignore
             msg.conversation = {
-                id: src.channnel
+                id: src.channel
             };
             msg.channelData.to = src.user;
 


### PR DESCRIPTION
- Replace `src.channnel` with `src.channel`  in [packages/botbuilder-adapter-slack/src/botworker.ts](https://github.com/howdyai/botkit/blob/master/packages/botbuilder-adapter-slack/src/botworker.ts#L244)