### PR TITLE
fix: WebAdapter only sends message if websocket is OPEN

### DIFF
--- a/packages/botbuilder-adapter-web/src/web_adapter.ts
+++ b/packages/botbuilder-adapter-web/src/web_adapter.ts
@@ -200,7 +200,7 @@ export class WebAdapter extends BotAdapter {
             if (channel === 'websocket') {
                 // If this turn originated with a websocket message, respond via websocket
                 var ws = clients[activity.recipient.id];
-                if (ws) {
+                if (ws && ws.readyState === 1) {
                     try {
                         ws.send(JSON.stringify(message));
                     } catch (err) {


### PR DESCRIPTION
I did some testing over websockets and forcibly closed websocket connection without waiting for all response messages.
It produced 3 types of errors in bot's output:
```
Could not send message, no open websocket found
```
```
Error: WebSocket is not open: readyState 2 (CLOSING)
    at WebSocket.send (.../node_modules/ws/lib/websocket.js:329:19)
    at WebAdapter.<anonymous> (.../node_modules/botbuilder-adapter-web/lib/web_adapter.js:183:32)
    at Generator.next (<anonymous>)
    at .../node_modules/botbuilder-adapter-web/lib/web_adapter.js:14:71
    at new Promise (<anonymous>)
    at __awaiter (.../node_modules/botbuilder-adapter-web/lib/web_adapter.js:10:12)
    at WebAdapter.sendActivities (.../node_modules/botbuilder-adapter-web/lib/web_adapter.js:172:16)
    at emit (.../node_modules/botbuilder-core/lib/turnContext.js:172:33)
    at emitNext (.../node_modules/botbuilder-core/lib/turnContext.js:388:40)
    at Proxy.emit (.../node_modules/botbuilder-core/lib/turnContext.js:394:16)
    at Proxy.sendActivities (.../node_modules/botbuilder-core/lib/turnContext.js:171:21)
    at Proxy.sendActivity (.../node_modules/botbuilder-core/lib/turnContext.js:138:21)
    at BotWorker.<anonymous> (.../node_modules/botkit/lib/botworker.js:100:61)
    at Generator.next (<anonymous>)
    at .../node_modules/botkit/lib/botworker.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (.../node_modules/botkit/lib/botworker.js:3:12)
    at _controller.middleware.send.run (.../node_modules/botkit/lib/botworker.js:96:94)
    at next (.../node_modules/ware/lib/index.js:82:27)
    at .../node_modules/wrap-fn/index.js:121:18
```
```
Error: WebSocket is not open: readyState 3 (CLOSED)
    at WebSocket.send (.../node_modules/ws/lib/websocket.js:329:19)
    at WebAdapter.<anonymous> (.../node_modules/botbuilder-adapter-web/lib/web_adapter.js:183:32)
    at Generator.next (<anonymous>)
    at .../node_modules/botbuilder-adapter-web/lib/web_adapter.js:14:71
    at new Promise (<anonymous>)
    at __awaiter (.../node_modules/botbuilder-adapter-web/lib/web_adapter.js:10:12)
    at WebAdapter.sendActivities (.../node_modules/botbuilder-adapter-web/lib/web_adapter.js:172:16)
    at emit (.../node_modules/botbuilder-core/lib/turnContext.js:172:33)
    at emitNext (.../node_modules/botbuilder-core/lib/turnContext.js:388:40)
    at TurnContext.emit (.../node_modules/botbuilder-core/lib/turnContext.js:394:16)
    at TurnContext.sendActivities (.../node_modules/botbuilder-core/lib/turnContext.js:171:21)
    at TurnContext.sendActivity (.../node_modules/botbuilder-core/lib/turnContext.js:138:21)
    at BotWorker.<anonymous> (.../node_modules/botkit/lib/botworker.js:100:61)
    at Generator.next (<anonymous>)
    at .../node_modules/botkit/lib/botworker.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (.../node_modules/botkit/lib/botworker.js:3:12)
    at _controller.middleware.send.run (.../node_modules/botkit/lib/botworker.js:96:94)
    at next (.../node_modules/ware/lib/index.js:82:27)
    at .../node_modules/wrap-fn/index.js:121:18
```

I think that it is too much noice just because connection is being closed.
This change makes WebAdapter log error `'Could not send message, no open websocket found'` if bot tries tro send message when connection is being closed.
