### PR TITLE
WebAdapter: add getConnection method

### DIFF
--- a/packages/botbuilder-adapter-web/src/web_adapter.ts
+++ b/packages/botbuilder-adapter-web/src/web_adapter.ts
@@ -306,7 +306,7 @@ export class WebAdapter extends BotAdapter {
     }
 
     /**
-     * Is given user currently connected? Use this to test the websocket connection 
+     * Is given user currently connected? Use this to test the websocket connection
      * between the bot and a given user before sending messages,
      * particularly in cases where a long period of time may have passed.
      *
@@ -315,5 +315,16 @@ export class WebAdapter extends BotAdapter {
      */
     public isConnected(user: string): boolean {
         return typeof clients[user] !== 'undefined';
+    }
+
+    /**
+     * Returns websocket connection of given user
+     * @param user
+     */
+    public getConnection(user: string): WebSocket {
+        if (!this.isConnected(user)) {
+            throw new Error('User ' + user + ' is not connected');
+        }
+        return clients[user];
     }
 }

--- a/packages/botbuilder-adapter-web/src/web_adapter.ts
+++ b/packages/botbuilder-adapter-web/src/web_adapter.ts
@@ -319,6 +319,7 @@ export class WebAdapter extends BotAdapter {
 
     /**
      * Returns websocket connection of given user
+     * Example: `if (message.action === 'disconnect') bot.controller.adapter.getConnection(message.user).terminate()`
      * @param user
      */
     public getConnection(user: string): WebSocket {


### PR DESCRIPTION
Direct access to WebSocket connection can be useful, but there were no means to access connection of specific user.

What I actually wanted to do:

I got a feature request to log user's ip and user agent, but they are only available in `on connection` event handler as a second parameter, so I implemented event handler and made it assign custom properties to WebSocket objects.

```js
if (controller.adapter instanceof WebAdapter) {
    controller.ready(() => {
        const wsServer: WebSocket.Server = controller.adapter.wss;
        wsServer.on('connection', (ws, req) => {
            ws.ip = req.connection.remoteAddress;
            ws.userAgent = req.headers['user-agent'];
        });
    });
}
```
Then I can access them in my bot's code like this:
```js
if (bot.controller.adapter instanceof WebAdapter) {
	const connection = bot.controller.adapter.getConnection(message.user);
	console.log(connection.ip);
	console.log(connection.userAgent);
}
```