### PR TITLE
Update sample_echo to respond to direct messages

### DIFF
--- a/packages/generator-botkit/generators/app/templates/features/sample_echo.js
+++ b/packages/generator-botkit/generators/app/templates/features/sample_echo.js
@@ -5,11 +5,11 @@
 
 module.exports = function(controller) {
 
-    controller.hears('sample','message', async(bot, message) => {
+    controller.hears('sample','message,direct_message', async(bot, message) => {
         await bot.reply(message, 'I heard a sample message.');
     });
 
-    controller.on('message', async(bot, message) => {
+    controller.on('message,direct_message', async(bot, message) => {
         await bot.reply(message, `Echo: ${ message.text }`);
     });
 


### PR DESCRIPTION
After updating to 1.0.1 the samples created with the yeoman generator no longer work in a direct space.