### PR TITLE
Don't add activity and reference fields to outgoing message

### DIFF
--- a/packages/botkit/src/botworker.ts
+++ b/packages/botkit/src/botworker.ts
@@ -300,45 +300,55 @@ export class BotWorker {
      * @returns a properly formed Activity object
      */
     public ensureMessageFormat(message: Partial<BotkitMessage> | string): Partial<Activity> {
-        let activity: Partial<Activity> = {};
 
         if (typeof (message) === 'string') {
-            activity = {
+            return {
                 type: 'message',
                 text: message,
                 channelData: {}
             };
-        } else {
-            // set up a base message activity
-            activity = {
-                type: message.type || 'message',
-                text: message.text,
+        }
 
-                attachmentLayout: message.attachmentLayout,
-                attachments: message.attachments,
+        // set up a base message activity
+        const activity = {
+            type: message.type || 'message',
+            text: message.text,
 
-                suggestedActions: message.suggestedActions,
+            attachmentLayout: message.attachmentLayout,
+            attachments: message.attachments,
 
-                speak: message.speak,
-                inputHint: message.inputHint,
-                summary: message.summary,
-                textFormat: message.textFormat,
-                importance: message.importance,
-                deliveryMode: message.deliveryMode,
-                expiration: message.expiration,
-                value: message.value,
-                channelData: {
-                    ...message.channelData
-                }
-            };
+            suggestedActions: message.suggestedActions,
 
-            // Now, copy any additional fields not in the activity into channelData
-            // This way, any fields added by the developer to the root object
-            // end up in the approved channelData location.
-            for (var key in message) {
-                if (key !== 'channelData' && !activity[key]) {
-                    activity.channelData[key] = message[key];
-                }
+            speak: message.speak,
+            inputHint: message.inputHint,
+            summary: message.summary,
+            textFormat: message.textFormat,
+            importance: message.importance,
+            deliveryMode: message.deliveryMode,
+            expiration: message.expiration,
+            value: message.value,
+            channelData: {
+                ...message.channelData
+            }
+        };
+
+        const internalFields = [
+            'channelData',
+            'channelId',
+            'serviceUrl',
+            'conversation',
+            'from',
+            'recipient',
+            'replyToId'
+        ];
+
+        // Now, copy any additional fields not in the activity into channelData
+        // This way, any fields added by the developer to the root object
+        // end up in the approved channelData location.
+        for (const key in message) {
+            // Don't copy activity and reference fields
+            if (!activity.hasOwnProperty(key) && internalFields.indexOf(key) === -1) {
+                activity.channelData[key] = message[key];
             }
         }
         return activity;


### PR DESCRIPTION
I noticed that Botkit adds some garbage fields to outgoing fields, e.g. `{"type":"message","text":"Hi...","channelId":"websocket","conversation":{"id":"98f515de-b10a-4b4c-51b9-d6fa3f0e1688"},"from":{"id":"bot"},"recipient":{"id":"98f515de-b10a-4b4c-51b9-d6fa3f0e1688"}}`

So I decided to remove them.

Previous activity check was incorrect and allowed falsy values to be added to channelData.
Reference fields weren't checked at all so they were sent to client.