### PR TITLE
ensureMessageFormat: fix activity prop check

### DIFF
--- a/packages/botkit/src/botworker.ts
+++ b/packages/botkit/src/botworker.ts
@@ -336,7 +336,7 @@ export class BotWorker {
             // This way, any fields added by the developer to the root object
             // end up in the approved channelData location.
             for (var key in message) {
-                if (key !== 'channelData' && !activity[key]) {
+                if (key !== 'channelData' && !activity.hasOwnProperty(key)) {
                     activity.channelData[key] = message[key];
                 }
             }


### PR DESCRIPTION
Previous condition allowed copying of properties having `undefined` value and potentially properties containing other falsy values.