### PR TITLE
change block_actions to Message events fixes howdyai/botkit/issues/1711

### DIFF
--- a/packages/botbuilder-adapter-slack/src/slack_adapter.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_adapter.ts
@@ -521,8 +521,16 @@ export class SlackAdapter extends BotAdapter {
                     from: { id: event.bot_id ? event.bot_id : event.user.id },
                     recipient: { id: null },
                     channelData: event,
-                    type: ActivityTypes.Event
+                    type: ActivityTypes.Event,
+                    text: null
                 };
+
+                // If this is a message originating from a block_action, we'll mark it as a message
+                // so it gets processed in BotkitConversations
+                if (event.type === 'block_actions' && event.actions) {
+                    activity.type = ActivityTypes.Message;
+                    activity.text = event.actions[0].value;
+                }
 
                 // @ts-ignore this complains because of extra fields in conversation
                 activity.recipient.id = await this.getBotUserByTeam(activity as Activity);


### PR DESCRIPTION
Convert block_actions to `ActivityTypes.Message` just like user messages, so block_actions like button presses can be used to respond to BotkitConversation dialogs. Fixes howdyai/botkit/issues/1711.