### PR TITLE
fix output text is truncated

### DIFF
--- a/packages/botkit/src/conversation.ts
+++ b/packages/botkit/src/conversation.ts
@@ -278,6 +278,8 @@ export class BotkitConversation<O extends object = {}> extends Dialog<O> {
 
         if (typeof (message) === 'string') {
             message = { text: [message] };
+        } else if (typeof (message.text) === 'string') {
+            message.text = [message.text];
         }
 
         this.script[thread_name].push(message);
@@ -754,7 +756,7 @@ export class BotkitConversation<O extends object = {}> extends Dialog<O> {
         if (line.quick_replies) {
             outgoing = MessageFactory.suggestedActions(line.quick_replies.map((reply) => { return { type: ActionTypes.PostBack, title: reply.title, text: reply.payload, displayText: reply.title, value: reply.payload }; }), line.text ? line.text[0] : '');
         } else {
-            outgoing = MessageFactory.text(line.text ? line.text[Math.floor(Math.random() * line.text.length)] : '');
+            outgoing = MessageFactory.text(line.text ? line.text[0] : '');
         }
 
         if (!outgoing.channelData) {


### PR DESCRIPTION
Currently, when using the `addMessage` to define a thread, like this:
```
convo.addMessage({
    text: 'Anyways, moving on...',
    action: 'next_step',
});
```
Then when changing to this thread later, the text is truncated to some random character, as for the implementation -- 
`outgoing = MessageFactory.text(line.text ? line.text[Math.floor(Math.random() * line.text.length)] : '');`

So here, make a change for the text to always be an array to be the same with other implementation, so that can just get the first item from the array instead of some random character.