### PR TITLE
enable mustache rendering of quick_replies button

### DIFF
--- a/packages/botkit/src/conversation.ts
+++ b/packages/botkit/src/conversation.ts
@@ -752,7 +752,10 @@ export class BotkitConversation<O extends object = {}> extends Dialog<O> {
         let outgoing;
 
         if (line.quick_replies) {
-            outgoing = MessageFactory.suggestedActions(line.quick_replies.map((reply) => { return { type: ActionTypes.PostBack, title: reply.title, text: reply.payload, displayText: reply.title, value: reply.payload }; }), line.text ? line.text[0] : '');
+            outgoing = MessageFactory.suggestedActions(line.quick_replies.map((reply) => {
+                Object.keys(reply).map((item) => reply[item] = mustache.render(reply[item], { vars: vars }));
+                return { type: ActionTypes.PostBack, title: reply.title, text: reply.payload, displayText: reply.title, value: reply.payload };
+            }), line.text ? line.text[0] : '');
         } else {
             outgoing = MessageFactory.text(line.text ? line.text[Math.floor(Math.random() * line.text.length)] : '');
         }


### PR DESCRIPTION
This pull request simply enable missing mustache template rendering of quick_replies button in addition to text, it can add dynamic flexibility as response to kind of issue [#1094]

Result is visually explained from Emulator as below :

Without the change :

![image](https://user-images.githubusercontent.com/6458346/61659577-689ff800-acd0-11e9-846f-15b1c702da47.png)

With the change :

![image](https://user-images.githubusercontent.com/6458346/61659191-9afd2580-accf-11e9-9d90-c93bd8a4bba2.png)
