### PR TITLE
Fix typo breaking plugin middleware example code

### DIFF
--- a/packages/docs/core.md
+++ b/packages/docs/core.md
@@ -587,7 +587,7 @@ module.exports = function(botkit) {
         },
         // Any middlewares that should be automatically bound
         // Can include more than 1 of each kind.
-        middleware: {
+        middlewares: {
             ingest: [
                 (bot, message, next) => { next(); }
             ],


### PR DESCRIPTION
The example code for the form of a plugin with automatically bound middlewares was incorrect. The actual key that usePlugin()'s source code refers to is `middlewares`, not `middleware`. Without this fix in the example code, middlewares are not automatically bound. With this fix, they are bound as expected.