### PR TITLE
Upgrade from Cisco Spark to Webex

### DIFF
--- a/packages/botbuilder-adapter-webex/package-lock.json
+++ b/packages/botbuilder-adapter-webex/package-lock.json
@@ -136,447 +136,811 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.13.tgz",
       "integrity": "sha512-yN/FNNW1UYsRR1wwAoyOwqvDuLDtVXnaJTZ898XIw/Q5cCaeVAlVwvsmXLX5PuiScBYwZsZU4JYSHB3TvfdwvQ=="
     },
-    "@webex/common": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.59.0.tgz",
-      "integrity": "sha512-HKL+U1Jia3Pg1XPV36NozBJe7yZIgAlaKfrnzt3i5JbQvtiLXCijvu5+o3plEuI/AFv2/04D67jql1DG8YXASw==",
+    "@webex/internal-plugin-calendar": {
+      "version": "1.72.6",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-calendar/-/internal-plugin-calendar-1.72.6.tgz",
+      "integrity": "sha512-SzoFcnNiyb54dlUtSTP3HNeqtcWv4gLmx9hORvrgmBxPDNDFnIbYUQwlb29p648K/y32C2YbfrnOC+8Tb7Lo7A==",
       "requires": {
-        "@webex/common": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "backoff": "^2.5.0",
-        "core-decorators": "^0.20.0",
+        "@webex/internal-plugin-conversation": "1.72.6",
+        "@webex/internal-plugin-encryption": "1.72.6",
+        "@webex/internal-plugin-wdm": "1.72.6",
+        "@webex/webex-core": "1.72.6",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "urlsafe-base64": "^1.0.0"
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "@webex/common": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.72.6.tgz",
+          "integrity": "sha512-yadWgygEQXUpes0+rZXObtMphJnh/fM/AnH/RqNRCTkeQXKk9ei25Y/Eelhny7binU29Y9Z/og17wWLtoesWWg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "backoff": "^2.5.0",
+            "core-decorators": "^0.20.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "urlsafe-base64": "^1.0.0"
+          }
+        },
+        "@webex/common-timers": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.72.6.tgz",
+          "integrity": "sha512-vQ3p8TGrrb6s8GQ65V9oBMr6jbD9DYaFuTvp1O56uNvdJxibSvZ8S/Il5O5PJ4ISnKcQU5Kv7vPcAk1ZgMrGpQ==",
+          "requires": {
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/helper-html": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.72.6.tgz",
+          "integrity": "sha512-Oa0pGubOAOvizitHXa7IyUbtLFnN8A5CT7/UUPXOvSz8yWY7r6/8yjCbojppn9cdoAcYAtrRl0z0TSdy2PVEbw==",
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/helper-image": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.72.6.tgz",
+          "integrity": "sha512-+aPhEPdavDK8YAWZVLyo+4XAoEkBiicmGrqd7e6D0M6MLn+j6bBtOffiYqu9FiStwJqoKfnPd4SSODIpotR/dQ==",
+          "requires": {
+            "@webex/http-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "exif": "^0.6.0",
+            "gm": "^1.23.0",
+            "lodash": "^4.17.14",
+            "mime-types": "^2.1.15"
+          }
+        },
+        "@webex/http-core": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.72.6.tgz",
+          "integrity": "sha512-oJGs1Px2Iu+7JKNNPmgiopyawEYV1hst+p/i0l2EMH9Y2YTHEmWmaJ1VjJi0FCD+8zmtisSxpXti/QlPpDu4qw==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "file-type": "^3.9.0",
+            "global": "^4.3.1",
+            "is-function": "^1.0.1",
+            "lodash": "^4.17.14",
+            "parse-headers": "^2.0.1",
+            "qs": "^6.5.1",
+            "request": "^2.81.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "@webex/internal-plugin-conversation": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.72.6.tgz",
+          "integrity": "sha512-TroqW+7WaB2Zpy37BEtJVUQL2TGSvl4b3k0t055PfXLaMPUTwOCGo8D5CvV39c7S0SLD0zpQq6ibDU8BiEfMIg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/helper-html": "1.72.6",
+            "@webex/helper-image": "1.72.6",
+            "@webex/internal-plugin-encryption": "1.72.6",
+            "@webex/internal-plugin-user": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2"
+          }
+        },
+        "@webex/internal-plugin-encryption": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.72.6.tgz",
+          "integrity": "sha512-zl+Nnk5HXvux4q1vd8TZq+3f6Dpg6ktUfz7Fr4AiNn3vYPVJzV/I96AmC7sLOFu7PKfEC/3jVM4XOiTe5tAuBw==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/internal-plugin-mercury": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "node-jose": "^0.11.0",
+            "node-kms": "^0.3.2",
+            "node-scr": "^0.2.2"
+          }
+        },
+        "@webex/internal-plugin-feature": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.72.6.tgz",
+          "integrity": "sha512-jlxrQellKLizm+i5QVmiysYnG76o7UbGVOQ6J9Q4I/TVjDspYzqjUwuh44zjEQeQ0iYrQZpjDO+0tYZMi4lrGg==",
+          "requires": {
+            "@webex/internal-plugin-mercury": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/internal-plugin-mercury": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.72.6.tgz",
+          "integrity": "sha512-gFT3hSPZSI527fXGVpc0gNoFMfrmM4kWUoFBM4xiuFmbpMaNOomPY7PI5Xd8zqRHpTXCUfYzmSvy29At0n3jdg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/internal-plugin-feature": "1.72.6",
+            "@webex/internal-plugin-metrics": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "backoff": "^2.5.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2",
+            "ws": "^4.0.0"
+          }
+        },
+        "@webex/internal-plugin-metrics": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.72.6.tgz",
+          "integrity": "sha512-EfWvAWlTU4zRHeQ+7r9XzhUSkYHiyVvsVGA/hrsUjZE+4mhMjwO8U6Im2GAu4+xRkkb8Px8okY+di1Ce0M4aNQ==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/internal-plugin-user": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.72.6.tgz",
+          "integrity": "sha512-XcHUT1X45BFWxIsmXLYFtOMA0iTC3APZWEWqXHzsBW9oZNnQS8UDrk9Kw1VODaD67YUYTw7qqoVxnJLMrkcjyw==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/internal-plugin-wdm": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-wdm/-/internal-plugin-wdm-1.72.6.tgz",
+          "integrity": "sha512-FUl5doKa7LHSqqz5ARzULlVB//usvPbi43hoMhxcrGHXokNHVEGsxsgiHo7bYwXulIphjPKDRSRrBwIPdPIVbg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "ampersand-collection": "^2.0.2",
+            "ampersand-state": "^5.0.2",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/webex-core": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.72.6.tgz",
+          "integrity": "sha512-5sRJHi6DNsieY+CRcsIijs0fjZyG6tWgfydUOJm8nh0SAcRPQkJkyfqii0Pa57YB5vxB96z7BpHVOaUIowav7Q==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "ampersand-collection": "^2.0.2",
+            "ampersand-events": "^2.0.2",
+            "ampersand-state": "^5.0.2",
+            "babel-runtime": "^6.26.0",
+            "core-decorators": "^0.20.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2"
+          }
+        }
       }
     },
-    "@webex/common-evented": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/common-evented/-/common-evented-1.59.0.tgz",
-      "integrity": "sha512-u7A00gJoqgz1y8s1ACWO5q1JrquAF89I8FO6e9C1w/SlXZnIYYSD4X216dzNYnX/uBDNXS2ePkklnWyH0YvBYw==",
+    "@webex/internal-plugin-lyra": {
+      "version": "1.72.6",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-lyra/-/internal-plugin-lyra-1.72.6.tgz",
+      "integrity": "sha512-0CibvFmMk6Q1BR7EJIkK0jBEJVHneJFzvRyvSX2bPXDcTITPpETprj9dOtoYRl9iIZ4e/bLjH0kM22IMFfnLkg==",
       "requires": {
-        "@webex/common": "1.59.0",
-        "babel-runtime": "^6.23.0",
+        "@webex/common": "1.72.6",
+        "@webex/internal-plugin-conversation": "1.72.6",
+        "@webex/internal-plugin-encryption": "1.72.6",
+        "@webex/internal-plugin-feature": "1.72.6",
+        "@webex/internal-plugin-mercury": "1.72.6",
+        "@webex/webex-core": "1.72.6",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
+      },
+      "dependencies": {
+        "@webex/common": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.72.6.tgz",
+          "integrity": "sha512-yadWgygEQXUpes0+rZXObtMphJnh/fM/AnH/RqNRCTkeQXKk9ei25Y/Eelhny7binU29Y9Z/og17wWLtoesWWg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "backoff": "^2.5.0",
+            "core-decorators": "^0.20.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "urlsafe-base64": "^1.0.0"
+          }
+        },
+        "@webex/common-timers": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.72.6.tgz",
+          "integrity": "sha512-vQ3p8TGrrb6s8GQ65V9oBMr6jbD9DYaFuTvp1O56uNvdJxibSvZ8S/Il5O5PJ4ISnKcQU5Kv7vPcAk1ZgMrGpQ==",
+          "requires": {
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/helper-html": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.72.6.tgz",
+          "integrity": "sha512-Oa0pGubOAOvizitHXa7IyUbtLFnN8A5CT7/UUPXOvSz8yWY7r6/8yjCbojppn9cdoAcYAtrRl0z0TSdy2PVEbw==",
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/helper-image": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.72.6.tgz",
+          "integrity": "sha512-+aPhEPdavDK8YAWZVLyo+4XAoEkBiicmGrqd7e6D0M6MLn+j6bBtOffiYqu9FiStwJqoKfnPd4SSODIpotR/dQ==",
+          "requires": {
+            "@webex/http-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "exif": "^0.6.0",
+            "gm": "^1.23.0",
+            "lodash": "^4.17.14",
+            "mime-types": "^2.1.15"
+          }
+        },
+        "@webex/http-core": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.72.6.tgz",
+          "integrity": "sha512-oJGs1Px2Iu+7JKNNPmgiopyawEYV1hst+p/i0l2EMH9Y2YTHEmWmaJ1VjJi0FCD+8zmtisSxpXti/QlPpDu4qw==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "file-type": "^3.9.0",
+            "global": "^4.3.1",
+            "is-function": "^1.0.1",
+            "lodash": "^4.17.14",
+            "parse-headers": "^2.0.1",
+            "qs": "^6.5.1",
+            "request": "^2.81.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "@webex/internal-plugin-conversation": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.72.6.tgz",
+          "integrity": "sha512-TroqW+7WaB2Zpy37BEtJVUQL2TGSvl4b3k0t055PfXLaMPUTwOCGo8D5CvV39c7S0SLD0zpQq6ibDU8BiEfMIg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/helper-html": "1.72.6",
+            "@webex/helper-image": "1.72.6",
+            "@webex/internal-plugin-encryption": "1.72.6",
+            "@webex/internal-plugin-user": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2"
+          }
+        },
+        "@webex/internal-plugin-encryption": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.72.6.tgz",
+          "integrity": "sha512-zl+Nnk5HXvux4q1vd8TZq+3f6Dpg6ktUfz7Fr4AiNn3vYPVJzV/I96AmC7sLOFu7PKfEC/3jVM4XOiTe5tAuBw==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/internal-plugin-mercury": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "node-jose": "^0.11.0",
+            "node-kms": "^0.3.2",
+            "node-scr": "^0.2.2"
+          }
+        },
+        "@webex/internal-plugin-feature": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.72.6.tgz",
+          "integrity": "sha512-jlxrQellKLizm+i5QVmiysYnG76o7UbGVOQ6J9Q4I/TVjDspYzqjUwuh44zjEQeQ0iYrQZpjDO+0tYZMi4lrGg==",
+          "requires": {
+            "@webex/internal-plugin-mercury": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/internal-plugin-mercury": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.72.6.tgz",
+          "integrity": "sha512-gFT3hSPZSI527fXGVpc0gNoFMfrmM4kWUoFBM4xiuFmbpMaNOomPY7PI5Xd8zqRHpTXCUfYzmSvy29At0n3jdg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/internal-plugin-feature": "1.72.6",
+            "@webex/internal-plugin-metrics": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "backoff": "^2.5.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2",
+            "ws": "^4.0.0"
+          }
+        },
+        "@webex/internal-plugin-metrics": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.72.6.tgz",
+          "integrity": "sha512-EfWvAWlTU4zRHeQ+7r9XzhUSkYHiyVvsVGA/hrsUjZE+4mhMjwO8U6Im2GAu4+xRkkb8Px8okY+di1Ce0M4aNQ==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/internal-plugin-user": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.72.6.tgz",
+          "integrity": "sha512-XcHUT1X45BFWxIsmXLYFtOMA0iTC3APZWEWqXHzsBW9oZNnQS8UDrk9Kw1VODaD67YUYTw7qqoVxnJLMrkcjyw==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/internal-plugin-wdm": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-wdm/-/internal-plugin-wdm-1.72.6.tgz",
+          "integrity": "sha512-FUl5doKa7LHSqqz5ARzULlVB//usvPbi43hoMhxcrGHXokNHVEGsxsgiHo7bYwXulIphjPKDRSRrBwIPdPIVbg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "ampersand-collection": "^2.0.2",
+            "ampersand-state": "^5.0.2",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/webex-core": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.72.6.tgz",
+          "integrity": "sha512-5sRJHi6DNsieY+CRcsIijs0fjZyG6tWgfydUOJm8nh0SAcRPQkJkyfqii0Pa57YB5vxB96z7BpHVOaUIowav7Q==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "ampersand-collection": "^2.0.2",
+            "ampersand-events": "^2.0.2",
+            "ampersand-state": "^5.0.2",
+            "babel-runtime": "^6.26.0",
+            "core-decorators": "^0.20.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2"
+          }
+        }
       }
     },
-    "@webex/common-timers": {
-      "version": "1.58.5",
-      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.58.5.tgz",
-      "integrity": "sha512-DwP0G4Ab4jdnub2Paxm01JKCn0BDM9hzKvvVc6eWm50/alzZH0Np8wv6MgMu5/wc3UqYLsHTJ6W6JzMW9xcNZw==",
+    "@webex/internal-plugin-search": {
+      "version": "1.72.6",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-search/-/internal-plugin-search-1.72.6.tgz",
+      "integrity": "sha512-ZHAGc0lHhMQ5pyyeCzMzpm/ofMT6JaX3tVmBk2s/+oCK0jhKnhYNz48Vqqlju4q/J/3Qp+GTfp6emLixSwRlIA==",
       "requires": {
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/helper-html": {
-      "version": "1.58.5",
-      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.58.5.tgz",
-      "integrity": "sha512-3wMtZaMFc+IJ1vEdjwlflNezuEUWL7gQR6OPg7nS5+Q38Rp5UPlCpPoCXZXfZu3ECcfpl8HakBuhbUwicF1Dbw==",
-      "requires": {
-        "babel-runtime": "^6.23.0",
+        "@webex/common": "1.72.6",
+        "@webex/internal-plugin-encryption": "1.72.6",
+        "@webex/webex-core": "1.72.6",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "@webex/common": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.72.6.tgz",
+          "integrity": "sha512-yadWgygEQXUpes0+rZXObtMphJnh/fM/AnH/RqNRCTkeQXKk9ei25Y/Eelhny7binU29Y9Z/og17wWLtoesWWg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "backoff": "^2.5.0",
+            "core-decorators": "^0.20.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "urlsafe-base64": "^1.0.0"
+          }
+        },
+        "@webex/common-timers": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.72.6.tgz",
+          "integrity": "sha512-vQ3p8TGrrb6s8GQ65V9oBMr6jbD9DYaFuTvp1O56uNvdJxibSvZ8S/Il5O5PJ4ISnKcQU5Kv7vPcAk1ZgMrGpQ==",
+          "requires": {
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/http-core": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.72.6.tgz",
+          "integrity": "sha512-oJGs1Px2Iu+7JKNNPmgiopyawEYV1hst+p/i0l2EMH9Y2YTHEmWmaJ1VjJi0FCD+8zmtisSxpXti/QlPpDu4qw==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "file-type": "^3.9.0",
+            "global": "^4.3.1",
+            "is-function": "^1.0.1",
+            "lodash": "^4.17.14",
+            "parse-headers": "^2.0.1",
+            "qs": "^6.5.1",
+            "request": "^2.81.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "@webex/internal-plugin-encryption": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.72.6.tgz",
+          "integrity": "sha512-zl+Nnk5HXvux4q1vd8TZq+3f6Dpg6ktUfz7Fr4AiNn3vYPVJzV/I96AmC7sLOFu7PKfEC/3jVM4XOiTe5tAuBw==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/internal-plugin-mercury": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "node-jose": "^0.11.0",
+            "node-kms": "^0.3.2",
+            "node-scr": "^0.2.2"
+          }
+        },
+        "@webex/internal-plugin-feature": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.72.6.tgz",
+          "integrity": "sha512-jlxrQellKLizm+i5QVmiysYnG76o7UbGVOQ6J9Q4I/TVjDspYzqjUwuh44zjEQeQ0iYrQZpjDO+0tYZMi4lrGg==",
+          "requires": {
+            "@webex/internal-plugin-mercury": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/internal-plugin-mercury": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.72.6.tgz",
+          "integrity": "sha512-gFT3hSPZSI527fXGVpc0gNoFMfrmM4kWUoFBM4xiuFmbpMaNOomPY7PI5Xd8zqRHpTXCUfYzmSvy29At0n3jdg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/internal-plugin-feature": "1.72.6",
+            "@webex/internal-plugin-metrics": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "backoff": "^2.5.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2",
+            "ws": "^4.0.0"
+          }
+        },
+        "@webex/internal-plugin-metrics": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.72.6.tgz",
+          "integrity": "sha512-EfWvAWlTU4zRHeQ+7r9XzhUSkYHiyVvsVGA/hrsUjZE+4mhMjwO8U6Im2GAu4+xRkkb8Px8okY+di1Ce0M4aNQ==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/internal-plugin-wdm": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-wdm/-/internal-plugin-wdm-1.72.6.tgz",
+          "integrity": "sha512-FUl5doKa7LHSqqz5ARzULlVB//usvPbi43hoMhxcrGHXokNHVEGsxsgiHo7bYwXulIphjPKDRSRrBwIPdPIVbg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "ampersand-collection": "^2.0.2",
+            "ampersand-state": "^5.0.2",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/webex-core": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.72.6.tgz",
+          "integrity": "sha512-5sRJHi6DNsieY+CRcsIijs0fjZyG6tWgfydUOJm8nh0SAcRPQkJkyfqii0Pa57YB5vxB96z7BpHVOaUIowav7Q==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "ampersand-collection": "^2.0.2",
+            "ampersand-events": "^2.0.2",
+            "ampersand-state": "^5.0.2",
+            "babel-runtime": "^6.26.0",
+            "core-decorators": "^0.20.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2"
+          }
+        }
       }
     },
-    "@webex/helper-image": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.59.0.tgz",
-      "integrity": "sha512-AvQckU+DwIAOgyU7VyHQ0SQ17kHeRiwEopE6C0X02pG9LJG+7Z/MGDV9wnGnqL/Utf59UnMCDECYMwdczrikqw==",
+    "@webex/plugin-device-manager": {
+      "version": "1.72.6",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-device-manager/-/plugin-device-manager-1.72.6.tgz",
+      "integrity": "sha512-j9QwmxX3bnTXg3MABBla3zKc/kx8t9tl4Q627sVSq48Ub0HZmL0uoTfAs+QXu8WcBsYtzNKbrG7TOrV4VDnRIg==",
       "requires": {
-        "@webex/http-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
+        "@webex/internal-plugin-lyra": "1.72.6",
+        "@webex/internal-plugin-search": "1.72.6",
+        "@webex/internal-plugin-wdm": "1.72.6",
+        "@webex/webex-core": "1.72.6",
+        "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
-        "exif": "^0.6.0",
-        "gm": "^1.23.0",
-        "lodash": "^4.17.11",
-        "mime-types": "^2.1.15"
+        "lodash": "^4.17.14",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@webex/common": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.72.6.tgz",
+          "integrity": "sha512-yadWgygEQXUpes0+rZXObtMphJnh/fM/AnH/RqNRCTkeQXKk9ei25Y/Eelhny7binU29Y9Z/og17wWLtoesWWg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "backoff": "^2.5.0",
+            "core-decorators": "^0.20.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "urlsafe-base64": "^1.0.0"
+          }
+        },
+        "@webex/common-timers": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.72.6.tgz",
+          "integrity": "sha512-vQ3p8TGrrb6s8GQ65V9oBMr6jbD9DYaFuTvp1O56uNvdJxibSvZ8S/Il5O5PJ4ISnKcQU5Kv7vPcAk1ZgMrGpQ==",
+          "requires": {
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/http-core": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.72.6.tgz",
+          "integrity": "sha512-oJGs1Px2Iu+7JKNNPmgiopyawEYV1hst+p/i0l2EMH9Y2YTHEmWmaJ1VjJi0FCD+8zmtisSxpXti/QlPpDu4qw==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "file-type": "^3.9.0",
+            "global": "^4.3.1",
+            "is-function": "^1.0.1",
+            "lodash": "^4.17.14",
+            "parse-headers": "^2.0.1",
+            "qs": "^6.5.1",
+            "request": "^2.81.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "@webex/internal-plugin-wdm": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-wdm/-/internal-plugin-wdm-1.72.6.tgz",
+          "integrity": "sha512-FUl5doKa7LHSqqz5ARzULlVB//usvPbi43hoMhxcrGHXokNHVEGsxsgiHo7bYwXulIphjPKDRSRrBwIPdPIVbg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "ampersand-collection": "^2.0.2",
+            "ampersand-state": "^5.0.2",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/webex-core": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.72.6.tgz",
+          "integrity": "sha512-5sRJHi6DNsieY+CRcsIijs0fjZyG6tWgfydUOJm8nh0SAcRPQkJkyfqii0Pa57YB5vxB96z7BpHVOaUIowav7Q==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "ampersand-collection": "^2.0.2",
+            "ampersand-events": "^2.0.2",
+            "ampersand-state": "^5.0.2",
+            "babel-runtime": "^6.26.0",
+            "core-decorators": "^0.20.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2"
+          }
+        }
       }
     },
-    "@webex/http-core": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.59.0.tgz",
-      "integrity": "sha512-JDtUEKkPPAWsSJNLULTOydkZsRLPFEuFmL3PWpm7Gezp/XiiBSQLHjZo1wBe2kK2LTYGb9//bEXcmpZy095u5g==",
+    "@webex/plugin-meetings": {
+      "version": "1.72.6",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-meetings/-/plugin-meetings-1.72.6.tgz",
+      "integrity": "sha512-Bx7Uu3YVBWQ5U66DjcZLFnrSytB82D2VXRAr7L5CyyRcOLOeD9gE0caIpp0Gi79mHvFXEHnm0qVzqSr0lXAxcQ==",
       "requires": {
-        "@webex/common": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "file-type": "^3.9.0",
-        "global": "^4.3.1",
-        "is-function": "^1.0.1",
-        "lodash": "^4.17.11",
-        "parse-headers": "^2.0.1",
-        "qs": "^6.5.1",
-        "request": "^2.81.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "@webex/internal-plugin-conversation": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.59.0.tgz",
-      "integrity": "sha512-uQQNpVV2E7h+G2GNxQbyFvA9wMT4aCKN2AMF8cJN4oy90DInDcvKWnsR7XrFHoGuZu4g5pGM9RFZrHyp3FhkSA==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/helper-html": "1.58.5",
-        "@webex/helper-image": "1.59.0",
-        "@webex/internal-plugin-encryption": "1.59.0",
-        "@webex/internal-plugin-user": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1"
-      }
-    },
-    "@webex/internal-plugin-encryption": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.59.0.tgz",
-      "integrity": "sha512-rafd2UgAOvz1oCaOthO/jmcjCknlcgKgdJbqBxu5juqkZpnnGiWQB4UJN8hPQtD2HgRRzgozGQiP+akAKmbAvw==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/common-timers": "1.58.5",
-        "@webex/http-core": "1.59.0",
-        "@webex/internal-plugin-mercury": "1.59.0",
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "node-jose": "^0.11.0",
-        "node-kms": "^0.3.2",
-        "node-scr": "^0.2.2"
-      }
-    },
-    "@webex/internal-plugin-feature": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.59.0.tgz",
-      "integrity": "sha512-P7UH9bEM484KtlgQgrfbPTY6JcaRAtgmc9HGRn+Mx+aautlgtSMrjIeDLfvgRdLZCFuDDHboz3q3lP7T8eaF8g==",
-      "requires": {
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      }
-    },
-    "@webex/internal-plugin-locus": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-locus/-/internal-plugin-locus-1.59.0.tgz",
-      "integrity": "sha512-b4NBq1UCsfMU86AxPN0XsXSsls87ijj3U7u+ADB0snn9T5OnZ+yF50CvP6aNDplhAdmtJf6bZ5wtb13moo14rQ==",
-      "requires": {
-        "@webex/internal-plugin-mercury": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1"
-      }
-    },
-    "@webex/internal-plugin-mercury": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.59.0.tgz",
-      "integrity": "sha512-hMf4MlE70F7dkIZZHbkQ+ie6GZ9BpeB6rvBUJPLu66ofNNKm6AVhbtgqHiEN9IEkMndzanF1VCs3vSFdhbXyDQ==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/common-timers": "1.58.5",
-        "@webex/internal-plugin-feature": "1.59.0",
-        "@webex/internal-plugin-metrics": "1.59.0",
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "backoff": "^2.5.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1",
-        "ws": "^4.0.0"
-      }
-    },
-    "@webex/internal-plugin-metrics": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.59.0.tgz",
-      "integrity": "sha512-fLwTJAIjkNSupNBXvZ8gOofbS20+htgfvoSI9DvqNm+aZxvEBFsxqfAi2fVg+EDdAK38F/mvfNOW9tVpXum4kg==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/common-timers": "1.58.5",
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/internal-plugin-user": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.59.0.tgz",
-      "integrity": "sha512-z3c0TogmGQmmBQUUFPGMN8ODmayuey3pwOUtFMbvzSOSb35U5/xTOptucW63BYROgdOx668uPeO+adDQ0opmyg==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      }
-    },
-    "@webex/internal-plugin-wdm": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-wdm/-/internal-plugin-wdm-1.59.0.tgz",
-      "integrity": "sha512-Vw1A5g/Z3bSip2otTwNmLhNYzsYUVtiSp53NhYA5NaaJis0TvGYbuQtoEoQ0Sxwks4bGoJXZbxBK87N48noIlg==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/common-timers": "1.58.5",
-        "@webex/http-core": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "ampersand-collection": "^2.0.2",
-        "ampersand-state": "^5.0.2",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      }
-    },
-    "@webex/media-engine-webrtc": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/media-engine-webrtc/-/media-engine-webrtc-1.59.0.tgz",
-      "integrity": "sha512-9TNdDq3ADTZZzVIOgp1p634dOwKRdLfUPCdJ3QO4hHoDsbC+AX8OX25s2PilyMP57FFQPFK5/A7ibvTvyo3Fgw==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/common-evented": "1.59.0",
-        "ampersand-events": "^2.0.2",
-        "babel-runtime": "^6.23.0",
+        "@webex/common": "1.72.6",
+        "@webex/common-timers": "1.72.6",
+        "@webex/internal-plugin-mercury": "1.72.6",
+        "@webex/webex-core": "1.72.6",
+        "babel-runtime": "^6.26.0",
         "bowser": "1.9.4",
-        "core-decorators": "^0.20.0",
+        "btoa": "^1.1.2",
         "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "lodash-decorators": "^4.3.4",
+        "global": "^4.3.1",
+        "javascript-state-machine": "^3.1.0",
+        "lodash": "^4.17.14",
         "sdp-transform": "^2.4.0",
-        "webrtc-adapter": "^6.1.0"
-      }
-    },
-    "@webex/plugin-authorization": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.59.0.tgz",
-      "integrity": "sha512-S8PHaiPQrp3eakEazrxPzjrhxjrupByqu51d7zRF/hYOnMrV7zeW2z//yLwY+0ctO99JUcIqVvCpGWcK39p54w==",
-      "requires": {
-        "@webex/plugin-authorization-browser": "1.59.0",
-        "@webex/plugin-authorization-node": "1.59.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/plugin-authorization-browser": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.59.0.tgz",
-      "integrity": "sha512-Vou55PXJok+WAa5TemoR4nuzWXJ9Bnphx9KakYJPxF5Oo4Vi4O43+IqCgcI4Oh7hQZr7kxn7OfG0jala3iNyfw==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1"
-      }
-    },
-    "@webex/plugin-authorization-node": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.59.0.tgz",
-      "integrity": "sha512-NLm2g64B4FP1aKZc57V53bzEydG02cxo4UZvd3YwaRY6vQ4vHx5wOEkldfJIXtMXxAwf55ew6iZp8iwthxbhCQ==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/plugin-logger": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.59.0.tgz",
-      "integrity": "sha512-AfJBs0nqzlIwiaalfyCiz23NeXx7N8D9HuflftyHGvCZNxq4vLmx7wmfP/QIe2YyaxKHr27a1xnl6cXnEIiECw==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      }
-    },
-    "@webex/plugin-memberships": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.59.0.tgz",
-      "integrity": "sha512-c28+5/hhW5ISdoEuzZ3vwYnVdaLXmenNEDV+8KwbZV65SX60k7at1TGRw5Kj1wkcFmzHEyJAYnPq7fkDmSSwdA==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/internal-plugin-conversation": "1.59.0",
-        "@webex/internal-plugin-mercury": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "debug": "^3.1.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
+        "uuid": "^3.3.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+        "@webex/common": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.72.6.tgz",
+          "integrity": "sha512-yadWgygEQXUpes0+rZXObtMphJnh/fM/AnH/RqNRCTkeQXKk9ei25Y/Eelhny7binU29Y9Z/og17wWLtoesWWg==",
           "requires": {
-            "ms": "^2.1.1"
+            "@webex/common": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "backoff": "^2.5.0",
+            "core-decorators": "^0.20.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "urlsafe-base64": "^1.0.0"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "@webex/plugin-messages": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.59.0.tgz",
-      "integrity": "sha512-FxUz0JZtPNPH4UddZ69BM7Rd8k0QEyrvLQ6PfCDpWbhYtMbtIVbf+NB6jFQZrI780CjwW7G3mKb/KTQpx9oxQQ==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/internal-plugin-conversation": "1.59.0",
-        "@webex/internal-plugin-mercury": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "debug": "^3.1.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+        "@webex/common-timers": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.72.6.tgz",
+          "integrity": "sha512-vQ3p8TGrrb6s8GQ65V9oBMr6jbD9DYaFuTvp1O56uNvdJxibSvZ8S/Il5O5PJ4ISnKcQU5Kv7vPcAk1ZgMrGpQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "envify": "^4.1.0"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
-    "@webex/plugin-people": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.59.0.tgz",
-      "integrity": "sha512-wu61+XpH32DhnmngfbexN1YCfqXOPhv1wuQsDjXjNTQaQpzNRB6kLhBxnQdUGtruDnOEPO5DS+kCYOlyLqqTCg==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/plugin-phone": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-phone/-/plugin-phone-1.59.0.tgz",
-      "integrity": "sha512-ofCyr0NxwiBXAkZHhHmLAa4Y1bIS+fmk7Vempay33itmk3L75WQdc9gCMM6mV6e60Z6whHy9Enkejc18Vvb1/Q==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/common-timers": "1.58.5",
-        "@webex/internal-plugin-locus": "1.59.0",
-        "@webex/internal-plugin-metrics": "1.59.0",
-        "@webex/media-engine-webrtc": "1.59.0",
-        "@webex/plugin-people": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "ampersand-collection": "^2.0.2",
-        "ampersand-collection-lodash-mixin": "^4.0.0",
-        "ampersand-state": "^5.0.2",
-        "babel-runtime": "^6.23.0",
-        "detectrtc": "^1.3.4",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "lodash-decorators": "^4.3.4",
-        "sdp-transform": "^2.4.0",
-        "uuid": "^3.2.1"
-      }
-    },
-    "@webex/plugin-rooms": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.59.0.tgz",
-      "integrity": "sha512-raYJ/qNXlveqTfaq2Zv6hqnTHgw1M6/fMAnWZgmOIOSr3bNBnmxpZb3wyFetGh2/NZD2SuXHC/b0Ox0euUZ8vw==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/internal-plugin-conversation": "1.59.0",
-        "@webex/internal-plugin-mercury": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "debug": "^3.1.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+        "@webex/http-core": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.72.6.tgz",
+          "integrity": "sha512-oJGs1Px2Iu+7JKNNPmgiopyawEYV1hst+p/i0l2EMH9Y2YTHEmWmaJ1VjJi0FCD+8zmtisSxpXti/QlPpDu4qw==",
           "requires": {
-            "ms": "^2.1.1"
+            "@webex/common": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "file-type": "^3.9.0",
+            "global": "^4.3.1",
+            "is-function": "^1.0.1",
+            "lodash": "^4.17.14",
+            "parse-headers": "^2.0.1",
+            "qs": "^6.5.1",
+            "request": "^2.81.0",
+            "xtend": "^4.0.1"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        "@webex/internal-plugin-feature": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.72.6.tgz",
+          "integrity": "sha512-jlxrQellKLizm+i5QVmiysYnG76o7UbGVOQ6J9Q4I/TVjDspYzqjUwuh44zjEQeQ0iYrQZpjDO+0tYZMi4lrGg==",
+          "requires": {
+            "@webex/internal-plugin-mercury": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/internal-plugin-mercury": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.72.6.tgz",
+          "integrity": "sha512-gFT3hSPZSI527fXGVpc0gNoFMfrmM4kWUoFBM4xiuFmbpMaNOomPY7PI5Xd8zqRHpTXCUfYzmSvy29At0n3jdg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/internal-plugin-feature": "1.72.6",
+            "@webex/internal-plugin-metrics": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "backoff": "^2.5.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2",
+            "ws": "^4.0.0"
+          }
+        },
+        "@webex/internal-plugin-metrics": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.72.6.tgz",
+          "integrity": "sha512-EfWvAWlTU4zRHeQ+7r9XzhUSkYHiyVvsVGA/hrsUjZE+4mhMjwO8U6Im2GAu4+xRkkb8Px8okY+di1Ce0M4aNQ==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/internal-plugin-wdm": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-wdm/-/internal-plugin-wdm-1.72.6.tgz",
+          "integrity": "sha512-FUl5doKa7LHSqqz5ARzULlVB//usvPbi43hoMhxcrGHXokNHVEGsxsgiHo7bYwXulIphjPKDRSRrBwIPdPIVbg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "ampersand-collection": "^2.0.2",
+            "ampersand-state": "^5.0.2",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/webex-core": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.72.6.tgz",
+          "integrity": "sha512-5sRJHi6DNsieY+CRcsIijs0fjZyG6tWgfydUOJm8nh0SAcRPQkJkyfqii0Pa57YB5vxB96z7BpHVOaUIowav7Q==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "ampersand-collection": "^2.0.2",
+            "ampersand-events": "^2.0.2",
+            "ampersand-state": "^5.0.2",
+            "babel-runtime": "^6.26.0",
+            "core-decorators": "^0.20.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2"
+          }
         }
-      }
-    },
-    "@webex/plugin-team-memberships": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.59.0.tgz",
-      "integrity": "sha512-UMaHAQz+qMeZrr3JGzpCy96qq2BzjolVrYxj4RnbWL7pJc12xaZZLvLjjNPirpmGsqpZKeMavusw6dp+S7Em6Q==",
-      "requires": {
-        "@webex/webex-core": "1.59.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/plugin-teams": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.59.0.tgz",
-      "integrity": "sha512-tc8wjAi+ZvukX1xHFGIJ+STFu/UtLo1n4CWi7SDk7uWC4lP9CMcjswYlT5Lohyt66I9F1q4KiWdhksbmqrRLeA==",
-      "requires": {
-        "@webex/webex-core": "1.59.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/plugin-webhooks": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.59.0.tgz",
-      "integrity": "sha512-h+tX+X00LOdsbnmVdyhxMnM7pyO27kYBoKR1IqKBdBRr+TX+zUmfSaUFtjUlDVaArYh/vQTdDGCSr5vb/O2v3A==",
-      "requires": {
-        "@webex/webex-core": "1.59.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/storage-adapter-local-storage": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.59.0.tgz",
-      "integrity": "sha512-gkAk0/IFc9n3UC0bht0R5kGQlXtTqS1w4Y93x7B61fvOuFJZLYLdaqtZb/ZNS86pTkKWg2UkS/vlx/MXyJjwJQ==",
-      "requires": {
-        "@webex/webex-core": "1.59.0",
-        "babel-runtime": "^6.23.0",
-        "envify": "^4.1.0"
-      }
-    },
-    "@webex/webex-core": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.59.0.tgz",
-      "integrity": "sha512-VHVHQ3X2UWT2Jf/ZoNGcxCg6UmuOY2OCi/+lD9fesIVLTHFptJiCt0k5NOFd9w042eSfsTfu3FjFLavwiPKvlQ==",
-      "requires": {
-        "@webex/common": "1.59.0",
-        "@webex/common-timers": "1.58.5",
-        "@webex/http-core": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "ampersand-collection": "^2.0.2",
-        "ampersand-events": "^2.0.2",
-        "ampersand-state": "^5.0.2",
-        "babel-runtime": "^6.23.0",
-        "core-decorators": "^0.20.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1"
       }
     },
     "accepts": {
@@ -628,15 +992,6 @@
         "ampersand-events": "^2.0.1",
         "ampersand-version": "^1.0.2",
         "lodash": "^4.11.1"
-      }
-    },
-    "ampersand-collection-lodash-mixin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ampersand-collection-lodash-mixin/-/ampersand-collection-lodash-mixin-4.0.0.tgz",
-      "integrity": "sha1-DtBHqOc8sHC8NrZ4pGPjgqyNtt0=",
-      "requires": {
-        "ampersand-version": "^1.0.0",
-        "lodash": "^4.6.1"
       }
     },
     "ampersand-events": {
@@ -978,6 +1333,11 @@
         "concat-map": "0.0.1"
       }
     },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -1034,29 +1394,6 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
-    "ciscospark": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/ciscospark/-/ciscospark-1.59.0.tgz",
-      "integrity": "sha512-uozxQp0KUFCtl/P2jE/aiSizahOAue9qxQH0fguR0wT+WZXkOaP4Aqan7sgIbQVRgP4h/S49LVLA787mfVGSpg==",
-      "requires": {
-        "@webex/internal-plugin-wdm": "1.59.0",
-        "@webex/plugin-authorization": "1.59.0",
-        "@webex/plugin-logger": "1.59.0",
-        "@webex/plugin-memberships": "1.59.0",
-        "@webex/plugin-messages": "1.59.0",
-        "@webex/plugin-people": "1.59.0",
-        "@webex/plugin-phone": "1.59.0",
-        "@webex/plugin-rooms": "1.59.0",
-        "@webex/plugin-team-memberships": "1.59.0",
-        "@webex/plugin-teams": "1.59.0",
-        "@webex/plugin-webhooks": "1.59.0",
-        "@webex/storage-adapter-local-storage": "1.59.0",
-        "@webex/webex-core": "1.59.0",
-        "babel-polyfill": "^6.23.0",
-        "envify": "^4.1.0",
-        "lodash": "^4.17.11"
-      }
-    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -1079,17 +1416,8 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
     },
     "combined-stream": {
@@ -1236,11 +1564,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "detectrtc": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/detectrtc/-/detectrtc-1.3.9.tgz",
-      "integrity": "sha512-uDmANQib8St/dRppyQGXHX36qG2wel5dKHslqz0qr2958rcpN6heOzofV2PoKi7ogtCXpQuz0JUzazWhnLBPcA=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -2214,6 +2537,11 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "javascript-state-machine": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/javascript-state-machine/-/javascript-state-machine-3.1.0.tgz",
+      "integrity": "sha512-BwhYxQ1OPenBPXC735RgfB+ZUG8H3kjsx8hrYTgWnoy6TPipEy4fiicyhT2lxRKAXq9pG7CfFT8a2HLr6Hmwxg=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2352,14 +2680,6 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-    },
-    "lodash-decorators": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash-decorators/-/lodash-decorators-4.5.0.tgz",
-      "integrity": "sha512-isfVBBSzzXu7Z6abY/Bit5hCbM+gPhQx/DluTPAmzUPF3KRtvLLRNBgVFUxw6B8vwTMGyQFRVqbvQBli9hsXZA==",
-      "requires": {
-        "tslib": "^1.7.1"
-      }
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
@@ -2639,12 +2959,12 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -3245,14 +3565,6 @@
       "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
       "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
     },
-    "rtcpeerconnection-shim": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
-      "integrity": "sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==",
-      "requires": {
-        "sdp": "^2.6.0"
-      }
-    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -3285,11 +3597,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
-    "sdp": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.9.0.tgz",
-      "integrity": "sha512-XAVZQO4qsfzVTHorF49zCpkdxiGmPNjA8ps8RcJGtGP3QJ/A8I9/SVg/QnkAFDMXIyGbHZBBFwYBw6WdnhT96w=="
     },
     "sdp-transform": {
       "version": "2.10.0",
@@ -3610,9 +3917,9 @@
       }
     },
     "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -3765,13 +4072,378 @@
         "wrap-fn": "^0.1.0"
       }
     },
-    "webrtc-adapter": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-6.4.8.tgz",
-      "integrity": "sha512-YM8yl545c/JhYcjGHgaCoA7jRK/KZuMwEDFeP2AcP0Auv5awEd+gZE0hXy9z7Ed3p9HvAXp8jdbe+4ESb1zxAw==",
+    "webex": {
+      "version": "1.72.6",
+      "resolved": "https://registry.npmjs.org/webex/-/webex-1.72.6.tgz",
+      "integrity": "sha512-Amfmpr8B+QWvThjki1KYm69YZX4dTgEA/QxROlxO3NGND4xePOwrVjpGPtZo7YoAiF5oA5qFVujvARHTYDSJbQ==",
       "requires": {
-        "rtcpeerconnection-shim": "^1.2.14",
-        "sdp": "^2.9.0"
+        "@webex/internal-plugin-calendar": "1.72.6",
+        "@webex/internal-plugin-wdm": "1.72.6",
+        "@webex/plugin-authorization": "1.72.6",
+        "@webex/plugin-device-manager": "1.72.6",
+        "@webex/plugin-logger": "1.72.6",
+        "@webex/plugin-meetings": "1.72.6",
+        "@webex/plugin-memberships": "1.72.6",
+        "@webex/plugin-messages": "1.72.6",
+        "@webex/plugin-people": "1.72.6",
+        "@webex/plugin-rooms": "1.72.6",
+        "@webex/plugin-team-memberships": "1.72.6",
+        "@webex/plugin-teams": "1.72.6",
+        "@webex/plugin-webhooks": "1.72.6",
+        "@webex/storage-adapter-local-storage": "1.72.6",
+        "@webex/webex-core": "1.72.6",
+        "babel-polyfill": "^6.26.0",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "@webex/common": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.72.6.tgz",
+          "integrity": "sha512-yadWgygEQXUpes0+rZXObtMphJnh/fM/AnH/RqNRCTkeQXKk9ei25Y/Eelhny7binU29Y9Z/og17wWLtoesWWg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "backoff": "^2.5.0",
+            "core-decorators": "^0.20.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "urlsafe-base64": "^1.0.0"
+          }
+        },
+        "@webex/common-timers": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.72.6.tgz",
+          "integrity": "sha512-vQ3p8TGrrb6s8GQ65V9oBMr6jbD9DYaFuTvp1O56uNvdJxibSvZ8S/Il5O5PJ4ISnKcQU5Kv7vPcAk1ZgMrGpQ==",
+          "requires": {
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/helper-html": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.72.6.tgz",
+          "integrity": "sha512-Oa0pGubOAOvizitHXa7IyUbtLFnN8A5CT7/UUPXOvSz8yWY7r6/8yjCbojppn9cdoAcYAtrRl0z0TSdy2PVEbw==",
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/helper-image": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.72.6.tgz",
+          "integrity": "sha512-+aPhEPdavDK8YAWZVLyo+4XAoEkBiicmGrqd7e6D0M6MLn+j6bBtOffiYqu9FiStwJqoKfnPd4SSODIpotR/dQ==",
+          "requires": {
+            "@webex/http-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "exif": "^0.6.0",
+            "gm": "^1.23.0",
+            "lodash": "^4.17.14",
+            "mime-types": "^2.1.15"
+          }
+        },
+        "@webex/http-core": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.72.6.tgz",
+          "integrity": "sha512-oJGs1Px2Iu+7JKNNPmgiopyawEYV1hst+p/i0l2EMH9Y2YTHEmWmaJ1VjJi0FCD+8zmtisSxpXti/QlPpDu4qw==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "file-type": "^3.9.0",
+            "global": "^4.3.1",
+            "is-function": "^1.0.1",
+            "lodash": "^4.17.14",
+            "parse-headers": "^2.0.1",
+            "qs": "^6.5.1",
+            "request": "^2.81.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "@webex/internal-plugin-conversation": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.72.6.tgz",
+          "integrity": "sha512-TroqW+7WaB2Zpy37BEtJVUQL2TGSvl4b3k0t055PfXLaMPUTwOCGo8D5CvV39c7S0SLD0zpQq6ibDU8BiEfMIg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/helper-html": "1.72.6",
+            "@webex/helper-image": "1.72.6",
+            "@webex/internal-plugin-encryption": "1.72.6",
+            "@webex/internal-plugin-user": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2"
+          }
+        },
+        "@webex/internal-plugin-encryption": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.72.6.tgz",
+          "integrity": "sha512-zl+Nnk5HXvux4q1vd8TZq+3f6Dpg6ktUfz7Fr4AiNn3vYPVJzV/I96AmC7sLOFu7PKfEC/3jVM4XOiTe5tAuBw==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/internal-plugin-mercury": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "node-jose": "^0.11.0",
+            "node-kms": "^0.3.2",
+            "node-scr": "^0.2.2"
+          }
+        },
+        "@webex/internal-plugin-feature": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.72.6.tgz",
+          "integrity": "sha512-jlxrQellKLizm+i5QVmiysYnG76o7UbGVOQ6J9Q4I/TVjDspYzqjUwuh44zjEQeQ0iYrQZpjDO+0tYZMi4lrGg==",
+          "requires": {
+            "@webex/internal-plugin-mercury": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/internal-plugin-mercury": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.72.6.tgz",
+          "integrity": "sha512-gFT3hSPZSI527fXGVpc0gNoFMfrmM4kWUoFBM4xiuFmbpMaNOomPY7PI5Xd8zqRHpTXCUfYzmSvy29At0n3jdg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/internal-plugin-feature": "1.72.6",
+            "@webex/internal-plugin-metrics": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "backoff": "^2.5.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2",
+            "ws": "^4.0.0"
+          }
+        },
+        "@webex/internal-plugin-metrics": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.72.6.tgz",
+          "integrity": "sha512-EfWvAWlTU4zRHeQ+7r9XzhUSkYHiyVvsVGA/hrsUjZE+4mhMjwO8U6Im2GAu4+xRkkb8Px8okY+di1Ce0M4aNQ==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/internal-plugin-user": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.72.6.tgz",
+          "integrity": "sha512-XcHUT1X45BFWxIsmXLYFtOMA0iTC3APZWEWqXHzsBW9oZNnQS8UDrk9Kw1VODaD67YUYTw7qqoVxnJLMrkcjyw==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/internal-plugin-wdm": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/internal-plugin-wdm/-/internal-plugin-wdm-1.72.6.tgz",
+          "integrity": "sha512-FUl5doKa7LHSqqz5ARzULlVB//usvPbi43hoMhxcrGHXokNHVEGsxsgiHo7bYwXulIphjPKDRSRrBwIPdPIVbg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "ampersand-collection": "^2.0.2",
+            "ampersand-state": "^5.0.2",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/plugin-authorization": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.72.6.tgz",
+          "integrity": "sha512-c/JV5Typ8vsmqATfhXjydeWAE8VFHsJXiqdQWOqjG2tB6KvE1rJfwY8XE+HHVD2eEauxELEBjeHQhWEwMTL1pw==",
+          "requires": {
+            "@webex/plugin-authorization-browser": "1.72.6",
+            "@webex/plugin-authorization-node": "1.72.6",
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/plugin-authorization-browser": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.72.6.tgz",
+          "integrity": "sha512-WZpEhb1GplQL/Lc0NXqifLGj0G4IHBvrXhW7oBHyJdbYLEQrtzXAXmElpVxXzKgO5yDWjxSU9N7QKWGAyJn9KA==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2"
+          }
+        },
+        "@webex/plugin-authorization-node": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.72.6.tgz",
+          "integrity": "sha512-CVgycOGM9hn3xCLucjLftpd7/B2kTuvo4bJ3gJX2W6VJfcdpblLL4f+Rc3R6JUSTtRlavgvPKSzy5tOLOVaUMA==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/internal-plugin-wdm": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/plugin-logger": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.72.6.tgz",
+          "integrity": "sha512-PLo1qXbl1uYuS4gZOmr3Bb+AKkSs1DR/++5Q5Pt0knugu3XxG86L2LuRn2EZvKuMIh/7zb+5clwtVMdM3fI3fQ==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/plugin-memberships": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.72.6.tgz",
+          "integrity": "sha512-Ft2dpZgsW94OfO7QfPv93+rHKrmJhIYn38cY08GUTBC+xJmpGzpuLS0CQ5DNXdw+DXZkyUbVe2Ar1iLC0WFspg==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/internal-plugin-conversation": "1.72.6",
+            "@webex/internal-plugin-mercury": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "debug": "^3.1.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/plugin-messages": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.72.6.tgz",
+          "integrity": "sha512-ZAcUwDcjVOOShn/7or0VqWkt7kS5rq44L5pbNWHR2JxNTLT6HTG8QvCBhYs8V89z5bWaG5GZo/JfaOYzVqgfqA==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/internal-plugin-conversation": "1.72.6",
+            "@webex/internal-plugin-mercury": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "debug": "^3.1.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/plugin-people": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.72.6.tgz",
+          "integrity": "sha512-GrICsldvI8GmGCoF4fU54+1iVmQhUG4Yf+jyzqWXn8Hqp19yO8MWft19+UNwDBBZRUgCe7QIoK4/UAP/YiG1zA==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/plugin-rooms": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.72.6.tgz",
+          "integrity": "sha512-VsrP6cRtW6VfKoDrjg0kPqd/7ZoUtGq2i89xqg2nnjfDLYAb8ZxgPberocAm7DkhsVdWfoW1r1R4Xz9nifMImw==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/internal-plugin-conversation": "1.72.6",
+            "@webex/internal-plugin-mercury": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "debug": "^3.1.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@webex/plugin-team-memberships": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.72.6.tgz",
+          "integrity": "sha512-Fnw7yK58x1hI7UdibB+4pDpVfGiZkyWhS5MblZYBXD3P+WIFiMpQCl92Y0LagooVgEIcnyvtd/RULJgOacPeJA==",
+          "requires": {
+            "@webex/webex-core": "1.72.6",
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/plugin-teams": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.72.6.tgz",
+          "integrity": "sha512-qhUnh5Yyqt7bUvAw7YNdvIPQndcCHsoJxDS7/oHi4XS2Rqk0d4qxGZyT1/yZm9Zy+/Iarwah6bKak9YFHiwbBw==",
+          "requires": {
+            "@webex/webex-core": "1.72.6",
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/plugin-webhooks": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.72.6.tgz",
+          "integrity": "sha512-XiOiIAPflf22rmin5QSlusYecv70BGkq9dI+R8EEEDeIQiqV5ll8/JsSHkUe43uGHx7WNagzj4dRif5desXeKA==",
+          "requires": {
+            "@webex/webex-core": "1.72.6",
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/storage-adapter-local-storage": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.72.6.tgz",
+          "integrity": "sha512-dWzyxLIpSJ2dG9LXZ/0cBbVzkUyzOT2qifoFXP39ftbOtltX0We0m/GmCn+bJ0TVVwJQe0zqrCsSGOLiysJrfQ==",
+          "requires": {
+            "@webex/webex-core": "1.72.6",
+            "babel-runtime": "^6.26.0",
+            "envify": "^4.1.0"
+          }
+        },
+        "@webex/webex-core": {
+          "version": "1.72.6",
+          "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.72.6.tgz",
+          "integrity": "sha512-5sRJHi6DNsieY+CRcsIijs0fjZyG6tWgfydUOJm8nh0SAcRPQkJkyfqii0Pa57YB5vxB96z7BpHVOaUIowav7Q==",
+          "requires": {
+            "@webex/common": "1.72.6",
+            "@webex/common-timers": "1.72.6",
+            "@webex/http-core": "1.72.6",
+            "@webex/webex-core": "1.72.6",
+            "ampersand-collection": "^2.0.2",
+            "ampersand-events": "^2.0.2",
+            "ampersand-state": "^5.0.2",
+            "babel-runtime": "^6.26.0",
+            "core-decorators": "^0.20.0",
+            "envify": "^4.1.0",
+            "lodash": "^4.17.14",
+            "uuid": "^3.3.2"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "which": {

--- a/packages/botbuilder-adapter-webex/package.json
+++ b/packages/botbuilder-adapter-webex/package.json
@@ -32,12 +32,12 @@
     "type": "git",
     "url": "https://github.com/howdyai/botkit.git"
   },
-    "dependencies": {
-    "botkit": "^4.5.0",
+  "dependencies": {
     "botbuilder": "^4.5.2",
-    "ciscospark": "^1.32.23",
+    "botkit": "^4.5.0",
     "debug": "^4.1.0",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "webex": "^1.72.3"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/packages/botbuilder-adapter-webex/readme.md
+++ b/packages/botbuilder-adapter-webex/readme.md
@@ -88,7 +88,7 @@ All events [listed here](https://developer.webex.com/webhooks-explained.html#res
 
 ## Calling Webex APIs
 
-This package exposes a pre-configured [Webex API client](https://www.npmjs.com/package/ciscospark) for developers who want to use one of the many available API endpoints.
+This package exposes a pre-configured [Webex API client](https://www.npmjs.com/package/webex) for developers who want to use one of the many available API endpoints.
 
 In Botkit handlers, the `bot` worker object passed into all handlers will contain a `bot.api` field that contains the client, preconfigured and ready to use.
 

--- a/packages/botbuilder-adapter-webex/src/botworker.ts
+++ b/packages/botbuilder-adapter-webex/src/botworker.ts
@@ -7,7 +7,7 @@
  */
 
 import { BotWorker, BotkitMessage } from 'botkit';
-import * as Ciscospark from 'ciscospark';
+import * as Webex from 'webex';
 
 /**
  * This is a specialized version of [Botkit's core BotWorker class](core.md#BotWorker) that includes additional methods for interacting with Webex Teams.
@@ -17,9 +17,9 @@ import * as Ciscospark from 'ciscospark';
  */
 export class WebexBotWorker extends BotWorker {
     /**
-     * An instance of the [webex api client](https://www.npmjs.com/package/ciscospark)
+     * An instance of the [webex api client](https://www.npmjs.com/package/webex)
      */
-    public api: Ciscospark;
+    public api: Webex;
 
     /**
      * Change the context of the _next_ message

--- a/packages/botbuilder-adapter-webex/src/webex_adapter.ts
+++ b/packages/botbuilder-adapter-webex/src/webex_adapter.ts
@@ -8,7 +8,7 @@
 
 import { Activity, ActivityTypes, BotAdapter, ResourceResponse, ConversationReference, TurnContext } from 'botbuilder';
 import { WebexBotWorker } from './botworker';
-import * as Ciscospark from 'ciscospark';
+import * as Webex from 'webex';
 import * as url from 'url';
 import * as crypto from 'crypto';
 import * as Debug from 'debug';
@@ -45,7 +45,7 @@ export interface WebexAdapterOptions {
 export class WebexAdapter extends BotAdapter {
     private options: WebexAdapterOptions;
 
-    private _api: Ciscospark;
+    private _api: Webex;
     private _identity: any;
 
     /**
@@ -122,7 +122,7 @@ export class WebexAdapter extends BotAdapter {
                 console.error(err);
             }
         } else {
-            this._api = Ciscospark.init({
+            this._api = Webex.init({
                 credentials: {
                     authorization: {
                         access_token: this.options.access_token

--- a/packages/docs/index.json
+++ b/packages/docs/index.json
@@ -15038,7 +15038,7 @@
                 "isExternal": true
               },
               "comment": {
-                "shortText": "An instance of the [webex api client](https://www.npmjs.com/package/ciscospark)"
+                "shortText": "An instance of the [webex api client](https://www.npmjs.com/package/webex)"
               },
               "sources": [
                 {
@@ -15049,7 +15049,7 @@
               ],
               "type": {
                 "type": "reference",
-                "name": "Ciscospark"
+                "name": "Webex"
               }
             },
             {
@@ -15286,7 +15286,7 @@
                 "isExternal": true
               },
               "comment": {
-                "shortText": "An instance of the [webex api client](https://www.npmjs.com/package/ciscospark)"
+                "shortText": "An instance of the [webex api client](https://www.npmjs.com/package/webex)"
               },
               "sources": [
                 {
@@ -15297,7 +15297,7 @@
               ],
               "type": {
                 "type": "reference",
-                "name": "Ciscospark"
+                "name": "Webex"
               }
             }
           ],

--- a/packages/docs/platforms/webex.md
+++ b/packages/docs/platforms/webex.md
@@ -90,7 +90,7 @@ All events [listed here](https://developer.webex.com/webhooks-explained.html#res
 
 ## Calling Webex APIs
 
-This package exposes a pre-configured [Webex API client](https://www.npmjs.com/package/ciscospark) for developers who want to use one of the many available API endpoints.
+This package exposes a pre-configured [Webex API client](https://www.npmjs.com/package/webex) for developers who want to use one of the many available API endpoints.
 
 In Botkit handlers, the `bot` worker object passed into all handlers will contain a `bot.api` field that contains the client, preconfigured and ready to use.
 

--- a/packages/docs/reference/webex.md
+++ b/packages/docs/reference/webex.md
@@ -220,7 +220,7 @@ This class includes the following methods:
 
 | Name | Type | Description
 |--- |--- |---
-| api | Ciscospark | An instance of the [webex api client](https://www.npmjs.com/package/ciscospark)
+| api | Webex | An instance of the [webex api client](https://www.npmjs.com/package/webex)
 
 ## WebexBotWorker Class Methods
 <a name="deleteMessage"></a>


### PR DESCRIPTION
Cisco Spark is rebranded to Webex, so that [ciscospark package is deprecated](https://www.npmjs.com/package/ciscospark), and following the [official guide](https://github.com/webex/webex-js-sdk/blob/master/UPGRADING.md) to upgrade to Webex.