### PR TITLE
Add attachments to webex teams adapter to support adaptive cards fixes #1759

### DIFF
--- a/packages/botbuilder-adapter-webex/src/webex_adapter.ts
+++ b/packages/botbuilder-adapter-webex/src/webex_adapter.ts
@@ -333,7 +333,10 @@ export class WebexAdapter extends BotAdapter {
                 } else if (activity.channelData && activity.channelData.toPersonEmail) {
                     message.toPersonEmail = activity.channelData.toPersonEmail;
                 }
-
+                if (activity.attachments) {
+                    message.attachments = activity.attachments;
+                }
+                
                 let response = await this._api.messages.create(message);
 
                 responses.push(response);


### PR DESCRIPTION
Fixes the issue in #1759 so that the attachments field is added to the message sent to webex teams in order to enable the sending of adaptive cards.