### PR TITLE
added quick_reply to facebook_event_middleware

### DIFF
--- a/packages/botbuilder-adapter-facebook/src/facebook_event_middleware.ts
+++ b/packages/botbuilder-adapter-facebook/src/facebook_event_middleware.ts
@@ -53,6 +53,8 @@ export class FacebookEventTypeMiddleware extends MiddlewareSet {
                 type = 'facebook_postback';
             } else if (context.activity.channelData.referral) {
                 type = 'facebook_referral';
+            } else if (context.activity.channelData.quick_reply) {
+                type = 'facebook_quick_reply';
             } else if (context.activity.channelData.optin) {
                 type = 'facebook_optin';
             } else if (context.activity.channelData.delivery) {


### PR DESCRIPTION
Very small changes for handling facebook quick_reply. I tested and it works with new version of botkit.