### PR TITLE
export facebook_api in index.ts

### DIFF
--- a/packages/botbuilder-adapter-facebook/src/index.ts
+++ b/packages/botbuilder-adapter-facebook/src/index.ts
@@ -6,6 +6,7 @@
  * Licensed under the MIT License.
  */
 
-export * from './facebook_adapter';
 export * from './botworker';
+export * from './facebook_adapter';
+export * from './facebook_api';
 export * from './facebook_event_middleware';


### PR DESCRIPTION
In botbuilder-adapter-facebook, add facebook_api in index.ts to export it.
The linked issue is https://github.com/howdyai/botkit/issues/1762

After this fix, the `const { FacebookAPI } = require('botbuilder-adapter-facebook');` will work according to the document https://botkit.ai/docs/v4/reference/facebook.html#FacebookAPI