### PR TITLE
fix error when initiating handover protocol

### DIFF
--- a/packages/botbuilder-adapter-facebook/src/facebook_adapter.ts
+++ b/packages/botbuilder-adapter-facebook/src/facebook_adapter.ts
@@ -352,7 +352,7 @@ export class FacebookAdapter extends BotAdapter {
 
                     // handle standby messages (this bot is not the active receiver)
                     if (entry.standby) {
-                        payload = entry.standyby;
+                        payload = entry.standby;
 
                         for (let m = 0; m < payload.length; m++) {
                             let message = payload[m];


### PR DESCRIPTION
Fix a typo that causes an error during handover of thread from bot to messenger inbox. 

This fixes https://github.com/howdyai/botkit/issues/1694