### PR TITLE
Include http server in botkit.webserver

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -1585,7 +1585,7 @@ function Botkit(configuration) {
         }));
         botkit.webserver.use(express.static(static_dir));
 
-        botkit.webserver.httpserver = botkit.webserver.listen(
+        botkit.httpserver = botkit.webserver.listen(
             botkit.config.port,
             botkit.config.hostname,
             function() {

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -1585,7 +1585,7 @@ function Botkit(configuration) {
         }));
         botkit.webserver.use(express.static(static_dir));
 
-        botkit.webserver.listen(
+        botkit.webserver.server = botkit.webserver.listen(
             botkit.config.port,
             botkit.config.hostname,
             function() {

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -1585,7 +1585,7 @@ function Botkit(configuration) {
         }));
         botkit.webserver.use(express.static(static_dir));
 
-        botkit.webserver.server = botkit.webserver.listen(
+        botkit.webserver.httpserver = botkit.webserver.listen(
             botkit.config.port,
             botkit.config.hostname,
             function() {


### PR DESCRIPTION
We need the ability to call `server.close()` to stop our server (in our integration test suite) and the http server is not currently exposed. This fixes that!