### PR TITLE
Add missing Block Actions to Botkit Conversations

### DIFF
--- a/packages/botbuilder-adapter-slack/src/slack_adapter.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_adapter.ts
@@ -530,26 +530,26 @@ export class SlackAdapter extends BotAdapter {
                 if ((event.type === 'block_actions' || event.type == 'interactive_message') && event.actions) {
                     activity.type = ActivityTypes.Message;
                     switch (event.actions[0].type) {
-                        case 'button': { 
+                        case 'button':  
                             activity.text = event.actions[0].value;
-                        } break
+                        break
                         case 'static_select':
                         case 'external_select':
-                        case 'overflow': {
+                        case 'overflow': 
                             activity.text = event.actions[0].selected_option.value;
-                        } break
-                        case 'users_select': {
+                            break
+                        case 'users_select':
                             activity.text = event.actions[0].selected_user;
-                        } break
-                        case 'conversations_select': {
+                            break
+                        case 'conversations_select':
                             activity.text = event.actions[0].selected_conversation;
-                        } break
-                        case 'channels_select': {
+                            break
+                        case 'channels_select':
                             activity.text = event.actions[0].selected_channel;
-                        } break
-                        case 'datepicker': {
+                            break
+                        case 'datepicker':
                             activity.text = event.action[0].selected_date;
-                        } break
+                            break
                         default: activity.text = event.actions[0].type;
                     }
                 }

--- a/packages/botbuilder-adapter-slack/src/slack_adapter.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_adapter.ts
@@ -524,12 +524,34 @@ export class SlackAdapter extends BotAdapter {
                     type: ActivityTypes.Event,
                     text: null
                 };
-
+                
                 // If this is a message originating from a block_action or button click, we'll mark it as a message
                 // so it gets processed in BotkitConversations
                 if ((event.type === 'block_actions' || event.type == 'interactive_message') && event.actions) {
                     activity.type = ActivityTypes.Message;
-                    activity.text = event.actions[0].value;
+                    switch (event.actions[0].type) {
+                        case 'button': { 
+                            activity.text = event.actions[0].value;
+                        } break
+                        case 'static_select':
+                        case 'external_select':
+                        case 'overflow': {
+                            activity.text = event.actions[0].selected_option.value;
+                        } break
+                        case 'users_select': {
+                            activity.text = event.actions[0].selected_user;
+                        } break
+                        case 'conversations_select': {
+                            activity.text = event.actions[0].selected_conversation;
+                        } break
+                        case 'channels_select': {
+                            activity.text = event.actions[0].selected_channel;
+                        } break
+                        case 'datepicker': {
+                            activity.text = event.action[0].selected_date;
+                        } break
+                        default: activity.text = event.actions[0].type;
+                    }
                 }
                   
                 // @ts-ignore this complains because of extra fields in conversation


### PR DESCRIPTION
This change extends the existing 'Slack button event as Message' pattern to all Block Action events. This change includes 'select' events from static, external, overflow, user, conversation, and channel selections, as well as date picker selections.

This update is required to use Slack select and date picker Block elements in Botkit Conversations.