### PR TITLE
Add support for Slack's new modals APIs and events

### DIFF
--- a/packages/botbuilder-adapter-slack/package.json
+++ b/packages/botbuilder-adapter-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botbuilder-adapter-slack",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Connect Botkit or BotBuilder to Slack",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
@@ -33,7 +33,7 @@
     "url": "https://github.com/howdyai/botkit.git"
   },
   "dependencies": {
-    "@slack/client": "^4.7.0",
+    "@slack/web-api": "^5.2.0",
     "botbuilder": "^4.5.2",
     "botkit": "^4.5.0",
     "debug": "^4.1.0"

--- a/packages/botbuilder-adapter-slack/src/botworker.ts
+++ b/packages/botbuilder-adapter-slack/src/botworker.ts
@@ -3,7 +3,7 @@
  */
 
 import { Botkit, BotkitMessage, BotWorker } from 'botkit';
-import { WebClient, Dialog } from '@slack/client';
+import { WebClient, Dialog } from '@slack/web-api';
 import * as request from 'request';
 
 /**

--- a/packages/botbuilder-adapter-slack/src/messagetype_middleware.ts
+++ b/packages/botbuilder-adapter-slack/src/messagetype_middleware.ts
@@ -46,7 +46,11 @@ export class SlackMessageTypeMiddleware extends MiddlewareSet {
             var direct_mention = new RegExp('^' + mentionSyntax, 'i');
 
             // is this a DM, a mention, or just ambient messages passing through?
-            if (context.activity.channelData.channel_type && context.activity.channelData.channel_type === 'im') {
+            if (context.activity.channelData.type == 'block_actions') { 
+                context.activity.channelData.botkitEventType = 'block_actions';
+            } else if (context.activity.channelData.type == 'interactive_message') { 
+                context.activity.channelData.botkitEventType = 'interactive_message';
+            } else if (context.activity.channelData.channel_type && context.activity.channelData.channel_type === 'im') {
                 context.activity.channelData.botkitEventType = 'direct_message';
 
                 // strip any potential leading @mention

--- a/packages/botbuilder-adapter-slack/src/slack_adapter.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_adapter.ts
@@ -7,7 +7,7 @@
  */
 
 import { Activity, ActivityTypes, BotAdapter, TurnContext, ConversationReference, ResourceResponse } from 'botbuilder';
-import { WebClient, WebAPICallResult } from '@slack/client';
+import { WebClient, WebAPICallResult } from '@slack/web-api';
 import { SlackBotWorker } from './botworker';
 import * as crypto from 'crypto';
 import * as Debug from 'debug';
@@ -514,7 +514,7 @@ export class SlackAdapter extends BotAdapter {
                     timestamp: new Date(),
                     channelId: 'slack',
                     conversation: {
-                        id: event.channel.id,
+                        id: event.channel ? event.channel.id : event.team.id, // use team id for channel id, required because modal block actions and submissions don't include channel.
                         thread_ts: event.thread_ts,
                         team: event.team.id
                     },

--- a/packages/testbot/features/slack_modals.js
+++ b/packages/testbot/features/slack_modals.js
@@ -1,0 +1,133 @@
+module.exports = function(controller) {
+
+    if (controller.adapter.name === 'Slack Adapter') {
+
+        controller.hears('modal','direct_message,direct_mention,mention', async(bot, message) => {
+
+            const responseCard = {
+              attachments: [
+                {
+                  text: 'Click the button to launch a modal.',
+                  actions: [
+                    {
+                      name: 'modal',
+                      type: 'button',
+                      text: 'Open Modal',
+                      value: 'modal',
+                    }
+                  ],
+                  callback_id: 'modal',
+                }
+              ]
+            };
+
+            await bot.reply(message, responseCard);
+
+        });
+
+        controller.on('interactive_message', async(bot, message) => {
+          if (message.actions[0].name === 'modal') {
+              const trigger_id = message.trigger_id;
+              const response = await bot.api.views.open({
+                trigger_id: trigger_id,
+                view: {
+                  "type": "modal",
+                  "callback_id": "modal-identifier",
+                  "title": {
+                    "type": "plain_text",
+                    "text": "Just a modal"
+                  },
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "block_id": "section-identifier",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "This is a sample modal"
+                      },
+                      "accessory": {
+                        "type": "button",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "Update this modal",
+                        },
+                        "value": "update_modal",
+                        "action_id": "button-identifier",
+                      }
+                    },
+                  ]
+                }
+              });
+          }
+        });
+
+        controller.hears('update_modal','block_actions', async(bot, message) => {
+
+          const response = await bot.api.views.update({
+            view_id: message.container.view_id,
+            view: {
+              "type": "modal",
+              "callback_id": "modal-identifier",
+              "title": {
+                "type": "plain_text",
+                "text": "Just a modal"
+              },
+              "blocks": [
+                {
+                  "type": "section",
+                  "block_id": "section-identifier",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "This is a sample modal"
+                  }
+                },
+                {
+                  "type": "input",
+                  "block_id": "ticket-title",
+                  "label": {
+                    "type": "plain_text",
+                    "text": "Ticket title"
+                  },
+                  "element": {
+                    "type": "plain_text_input",
+                    "action_id": "ticket-title-value"
+                  }
+                },
+                {
+                  "type": "input",
+                  "block_id": "ticket-desc",
+                  "label": {
+                    "type": "plain_text",
+                    "text": "Ticket description"
+                  },
+                  "element": {
+                    "type": "plain_text_input",
+                    "multiline": true,
+                    "action_id": "ticket-desc-value"
+                  }
+                }
+              ],
+              "submit": {
+                "type": "plain_text",
+                "text": "Submit"
+              }
+            }
+          });
+
+        });
+
+
+        controller.on('view_submission', async(bot, message) => {
+          console.log('VIEW SUBMISSION', message.view.state.values);
+          bot.httpBody({
+            response_action: 'errors',
+            errors: {
+              "ticket-desc": 'I will never accept a value, you are doomed!'
+            }
+          })
+
+        })
+
+    }
+}
+


### PR DESCRIPTION
This PR adds support for [Slack's new modal APIS and events described here](https://api.slack.com/block-kit/surfaces/modals)

Changes include:

* Update dependency to latest version of @slack/web-api
* Add some new sample code to the testbot
* allow events without channels -- because new modal events do not include channel data. (This means bot.reply will not work with these events, amongst other caveats)

In addition, this will fix the behavior that caused all "block_actions" and "interactive_message" events to become "message" events.  These events will retain their native event type, but will still be passed into active dialogs (so a button click can be passed to a convo.ask)
