### PR TITLE
End invalid Slack signature response.

### DIFF
--- a/packages/botbuilder-adapter-slack/src/slack_adapter.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_adapter.ts
@@ -475,6 +475,7 @@ export class SlackAdapter extends BotAdapter {
             if (!validSignature()) {
                 debug('Signature verification failed, Ignoring message');
                 res.status(401);
+                res.end();
                 return false;
             }
         }


### PR DESCRIPTION
When the Slack adapter receives an invalid signature header, it sets the status
code of the response to 401 but does not end the response.

This causes requests to hang that do not have a valid signature. This commit
therefore fixes the issue