### PR TITLE
Support ES6 syntax for botkit features

### DIFF
--- a/packages/botkit/src/core.ts
+++ b/packages/botkit/src/core.ts
@@ -1108,7 +1108,15 @@ export class Botkit {
      */
     public loadModule(p: string): void {
         debug('Load Module:', p);
-        require(p)(this);
+        const module = require(p);
+        // Handle both CJS `module.exports` and ESM `export default` syntax.
+        if (typeof module === 'function') {
+            module(this);
+        } else if (module && typeof module.default === 'function') {
+            module.default(this);
+        } else {
+            throw new Error(`Failed to load '${p}', did you export a function?`);
+        }
     }
 
     /**


### PR DESCRIPTION
Now botkit can handle both CJS `module.exports` and ESM `export default` syntax.

Previously only this was supported:

```js
module.exports = function(controller) {
    controller.hears('sample', 'message', async (bot, message) => {
        await bot.reply(message, 'I heard a sample message.');
    });
}
```

Now you can also, optionally, use:

```js
export default (controller) => {
    // ...
}
```