### PR TITLE
Fix Facebook typing indicator

### DIFF
--- a/packages/botbuilder-adapter-facebook/CHANGELOG.md
+++ b/packages/botbuilder-adapter-facebook/CHANGELOG.md
@@ -1,5 +1,9 @@
 # botbuilder-adapter-facebook changelog
 
+# 1.0.7
+
+* Fix for Facebook typing indicators. To send a typing indicator, use `await bot.say({sender_action: 'typing_on'});`
+
 # 1.0.6
 
 * Query parameters for GET apis can now be passed in using an object parameter (like POST): [Thanks to @adantoscano](https://github.com/howdyai/botkit/pull/1768)

--- a/packages/botbuilder-adapter-facebook/package.json
+++ b/packages/botbuilder-adapter-facebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botbuilder-adapter-facebook",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Connect Botkit or BotBuilder to Facebook Messenger",
   "main": "lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/botbuilder-adapter-facebook/src/facebook_adapter.ts
+++ b/packages/botbuilder-adapter-facebook/src/facebook_adapter.ts
@@ -241,6 +241,11 @@ export class FacebookAdapter extends BotAdapter {
 
             if (activity.channelData.sender_action) {
                 message.sender_action = activity.channelData.sender_action;
+
+                // from docs: https://developers.facebook.com/docs/messenger-platform/reference/send-api/
+                // Cannot be sent with message. Must be sent as a separate request.
+                // When using sender_action, recipient should be the only other property set in the request.
+                delete(message.message);
             }
 
             // make sure the quick reply has a type

--- a/packages/testbot/features/facebook_features.js
+++ b/packages/testbot/features/facebook_features.js
@@ -33,6 +33,16 @@ module.exports = function(controller) {
         await bot.reply(message,`I heard you posting back a post_back about ${ message.text }`);
     });
 
+    controller.hears('typing', 'message', async(bot, message)=> {
+
+      await bot.reply(message,{sender_action: 'typing_on'});
+      setTimeout(async function() {
+        await bot.changeContext(message.reference);
+        await bot.reply(message,'typing done');
+
+      }, 3000);
+
+    });
 
     controller.ready(async () => {
         // example of proactive message

--- a/packages/testbot/features/facebook_features.js
+++ b/packages/testbot/features/facebook_features.js
@@ -1,3 +1,6 @@
+const { BotkitConversation } = require('botkit');
+
+
 module.exports = function(controller) {
 
     if (controller.adapter.name === 'Facebook Adapter') {
@@ -33,16 +36,44 @@ module.exports = function(controller) {
         await bot.reply(message,`I heard you posting back a post_back about ${ message.text }`);
     });
 
-    controller.hears('typing', 'message', async(bot, message)=> {
+
+
+    let typing = new BotkitConversation('typing', controller);
+
+    typing.say('I am going to type for a while now...');
+    typing.addAction('typing');
+
+    // start the typing indicator
+    typing.addMessage({channelData: {sender_action: 'typing_on'}}, 'typing');
+    // trigger a gotoThread, which gives us an opportunity to delay the next message
+    typing.addAction('next_thread','typing');
+
+    typing.addMessage('typed!','next_thread');
+
+   // use the before handler to delay the next message 
+    typing.before('next_thread',  async() => {
+        return new Promise((resolve, reject) => {
+            // simulate some long running process
+            setTimeout(resolve, 3000);
+        });
+    });
+
+    controller.addDialog(typing);
+
+    controller.hears('typing dialog', 'message', async(bot, message) => {
+        await bot.beginDialog('typing');
+    });
+
+    controller.hears('typing reply', 'message', async(bot, message) => {
 
       await bot.reply(message,{sender_action: 'typing_on'});
       setTimeout(async function() {
         await bot.changeContext(message.reference);
         await bot.reply(message,'typing done');
-
       }, 3000);
 
     });
+
 
     controller.ready(async () => {
         // example of proactive message
@@ -50,7 +81,6 @@ module.exports = function(controller) {
         bot.startConversationWithUser(process.env.FACEBOOK_ADMIN_USER).then(async () => {
             let res = await bot.say('Hello human');
             console.log('results of proactive message', res);
-
         }); 
 
         let res = await bot.api.callAPI('/me/messenger_profile', 'delete', {fields: ['persistent_menu']});


### PR DESCRIPTION
This pull request corrects the Facebook adapter's treatment of `sender_action` messages.

The change removes the `message` field from the outgoing payload when sender_action is present, as this causes Facebook to reject the message.