### PR TITLE
Bump to web-api 5.6.0

### DIFF
--- a/packages/botbuilder-adapter-slack/package.json
+++ b/packages/botbuilder-adapter-slack/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/howdyai/botkit.git"
   },
   "dependencies": {
-    "@slack/web-api": "^5.5.0",
+    "@slack/web-api": "^5.6.0",
     "botbuilder": "^4.6.0",
     "botkit": "^4.6.0",
     "debug": "^4.1.0"


### PR DESCRIPTION
Exposes oauth.v2.access for new granular scoping.

I know this is tricky because the granular scoping still has a BETA tag on the Slack side, but bot installation fails because `getInstallLink()` and `validateOauthCode()` call against oauth.access, which throws `oauth_authorization_url_mismatch` when granular scoping is enabled on the Slack side.