### PR TITLE
Make redirectUri optional in type definition

### DIFF
--- a/packages/botbuilder-adapter-slack/src/slack_adapter.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_adapter.ts
@@ -729,7 +729,7 @@ export interface SlackAdapterOptions {
     /**
      * The URL users will be redirected to after an oauth flow. In most cases, should be `https://<mydomain.com>/install/auth`
      */
-    redirectUri: string;
+    redirectUri?: string;
 
     /**
      * A method that receives a Slack team id and returns the bot token associated with that team. Required for multi-team apps.


### PR DESCRIPTION
The `redirectUri` property of `SlackAdapterOptions` is only relevant for apps that uses OAuth. It is treated as optional by the code and the type definitions should reflect that.