### PR TITLE
(Webex) Remove `files` key with empty string value

### DIFF
--- a/packages/botbuilder-adapter-webex/src/webex_adapter.ts
+++ b/packages/botbuilder-adapter-webex/src/webex_adapter.ts
@@ -277,9 +277,9 @@ export class WebexAdapter extends BotAdapter {
                     event: 'all',
                     secret: this.options.secret,
                     name: webhook_name
-                }).then(function() {
+                }).then(function () {
                     debug('Webex: SUCCESSFULLY UPDATED WEBEX WEBHOOKS');
-                }).catch(function(err) {
+                }).catch(function (err) {
                     console.error('FAILED TO REGISTER WEBHOOK', err);
                     throw new Error(err);
                 });
@@ -290,14 +290,14 @@ export class WebexAdapter extends BotAdapter {
                     event: 'all',
                     secret: this.options.secret,
                     name: webhook_name
-                }).then(function() {
+                }).then(function () {
                     debug('Webex: SUCCESSFULLY REGISTERED WEBEX WEBHOOKS');
-                }).catch(function(err) {
+                }).catch(function (err) {
                     console.error('FAILED TO REGISTER WEBHOOK', err);
                     throw new Error(err);
                 });
             }
-        }).catch(function(err) {
+        }).catch(function (err) {
             throw new Error(err);
         });
     }
@@ -330,9 +330,9 @@ export class WebexAdapter extends BotAdapter {
                     event: 'all',
                     secret: this.options.secret,
                     name: webhook_name
-                }).then(function() {
+                }).then(function () {
                     debug('Webex: SUCCESSFULLY UPDATED WEBEX WEBHOOKS');
-                }).catch(function(err) {
+                }).catch(function (err) {
                     console.error('FAILED TO REGISTER WEBHOOK', err);
                     throw new Error(err);
                 });
@@ -343,14 +343,14 @@ export class WebexAdapter extends BotAdapter {
                     event: 'all',
                     secret: this.options.secret,
                     name: webhook_name
-                }).then(function() {
+                }).then(function () {
                     debug('Webex: SUCCESSFULLY REGISTERED WEBEX WEBHOOKS');
-                }).catch(function(err) {
+                }).catch(function (err) {
                     console.error('FAILED TO REGISTER WEBHOOK', err);
                     throw new Error(err);
                 });
             }
-        }).catch(function(err) {
+        }).catch(function (err) {
             throw new Error(err);
         });
     }
@@ -370,9 +370,10 @@ export class WebexAdapter extends BotAdapter {
 
                 // transform activity into the webex message format
                 // https://developer.webex.com/docs/api/v1/messages/create-a-message
-                const message: any = {
-                    files: activity.channelData ? activity.channelData.files : ''
-                };
+                const message: any = {};
+                if (activity.channelData && activity.channelData.files) {
+                    message.files = activity.channelData.files;
+                }
                 if (activity.text) {
                     message.text = activity.text;
                 }


### PR DESCRIPTION
This commit removes sending `files` key with empty string value when
there are no files while sending a message. `files` key with empty string is causing API to fail
with below `BadRequest: "Unable to retrieve content."`. I have validated
that by sending request to webex api from webex developer console.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>