### PR TITLE
add example response for oauth v2

### DIFF
--- a/packages/botbuilder-adapter-slack/readme.md
+++ b/packages/botbuilder-adapter-slack/readme.md
@@ -98,7 +98,7 @@ const adapter = new SlackAdapter({
     clientSigningSecret: process.env.SLACK_SECRET,
     clientId: process.env.CLIENTID, // oauth client id
     clientSecret: process.env.CLIENTSECRET, // oauth client secret
-    scopes: ['bot'], // oauth scopes requested
+    scopes: ['bot'], // oauth scopes requested, 'bot' depricated by Slack in favor of granular permissions
     redirectUri: process.env.REDIRECT_URI, // url to redirect post-login
     getTokenForTeam: async(team_id) => {
         // load the token for this team
@@ -123,9 +123,9 @@ controller.webserver.get('/install/auth', (req, res) => {
         const results = await controller.adapter.validateOauthCode(req.query.code);
 
         // Store token by team in bot state.
-        let team = results.team_id;
-        let token = results.bot.bot_access_token;
-        let userId = results.bot.bot_user_id;
+        let team = results.team_id; // results.team.id in oauth v2
+        let token = results.bot.bot_access_token; // results.access_token in oauth v2
+        let userId = results.bot.bot_user_id; // results.bot_user_id in oauth v2
 
         // Securely store the token and usedId so that they can be retrieved later by the team id.
         // ...


### PR DESCRIPTION
New slack apps will use oauth v2 by default, we can explain the discrepancy to help devs get up and running faster.