### PR TITLE
adds oauth v2 support

### DIFF
--- a/packages/botbuilder-adapter-slack/src/slack_adapter.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_adapter.ts
@@ -244,7 +244,7 @@ export class SlackAdapter extends BotAdapter {
     public getInstallLink(): string {
         let redirect = ''
         if (this.options.clientId && this.options.scopes) {
-            if (this.options.oauthVersion == 'v2'|'V2'){
+            if (this.options.oauthVersion == 'v2'||'V2'){
                 redirect = 'https://slack.com/oauth/v2/authorize?client_id=' + this.options.clientId + '&scope=' + this.options.scopes.join(',');
             } 
             else {

--- a/packages/botbuilder-adapter-slack/src/slack_adapter.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_adapter.ts
@@ -292,7 +292,7 @@ export class SlackAdapter extends BotAdapter {
             redirect_uri: this.options.redirectUri
         } 
         let results = {};
-        if (this.options.oauthVersion == 'v2'|'V2'){
+        if (this.options.oauthVersion == 'v2'||'V2'){
             results = await slack.oauth.v2.access(details)
         }
         else {


### PR DESCRIPTION
Changes to this file are based on an additional Slack adapter option of "oauthVersion". This would allow for oauth v2 support with minimal changes to the adapter. Updates to this file include 2 conditional statements to use new oauth v2 if options.oauthVersion == 'v2', and updates to example oauth response in the comments.