### PR TITLE
Fixed a typo

### DIFF
--- a/packages/docs/reference/core.md
+++ b/packages/docs/reference/core.md
@@ -1118,7 +1118,7 @@ convo.ask('Do you want to eat a taco?', [
      handler: async(response, convo, bot) => {
          return await convo.gotoThread('no_taco');
      }
-  },s
+  },
   {
       default: true,
       handler: async(response, convo, bot) => {


### PR DESCRIPTION
This https://github.com/howdyai/botkit/pull/1848 was already merged to master I am not sure how it got reverted.

===

Fixed a typo in the example for ask() - https://botkit.ai/docs/v4/reference/core.html#ask
```js
  {
     pattern: 'no',
     type: 'string',
     handler: async(response, convo, bot) => {
         return await convo.gotoThread('no_taco');
     }
  },s
  {
```