### PR TITLE
Fix location of adapter in bot worker

### DIFF
--- a/packages/botbuilder-adapter-slack/package.json
+++ b/packages/botbuilder-adapter-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botbuilder-adapter-slack",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Connect Botkit or BotBuilder to Slack",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/botbuilder-adapter-slack/src/botworker.ts
+++ b/packages/botbuilder-adapter-slack/src/botworker.ts
@@ -268,7 +268,7 @@ export class SlackBotWorker extends BotWorker {
                 msg.conversation.thread_ts = src.incoming_message.channelData.thread_ts;
             }
 
-            msg = this.getConfig('context').adapter.activityToSlack(msg);
+            msg = this.getConfig('adapter').activityToSlack(msg);
 
             const requestOptions = {
                 uri: src.incoming_message.channelData.response_url,
@@ -336,7 +336,7 @@ export class SlackBotWorker extends BotWorker {
      * @param update An object in the form `{id: <id of message to update>, conversation: { id: <channel> }, text: <new text>, card: <array of card objects>}`
      */
     public async updateMessage(update: Partial<BotkitMessage>): Promise<any> {
-        return this.getConfig('context').adapter.updateActivity(
+        return this.getConfig('adapter').updateActivity(
             this.getConfig('context'),
             update
         );
@@ -356,7 +356,7 @@ export class SlackBotWorker extends BotWorker {
      * @param update An object in the form of `{id: <id of message to delete>, conversation: { id: <channel of message> }}`
      */
     public async deleteMessage(update: Partial<BotkitMessage>): Promise<any> {
-        return this.getConfig('context').adapter.deleteActivity(
+        return this.getConfig('adapter').deleteActivity(
             this.getConfig('context'),
             {
                 activityId: update.id,

--- a/packages/botkit/package.json
+++ b/packages/botkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botkit",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "Building Blocks for Building Bots",
   "main": "lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/botkit/src/botworker.ts
+++ b/packages/botkit/src/botworker.ts
@@ -259,7 +259,7 @@ export class BotWorker {
         );
 
         // create a turn context
-        const turnContext = new TurnContext(this.getConfig('context').adapter, activity as Activity);
+        const turnContext = new TurnContext(this.getConfig('adapter'), activity as Activity);
 
         // create a new dialogContext so beginDialog works.
         const dialogContext = await this._controller.dialogSet.createContext(turnContext);
@@ -278,7 +278,7 @@ export class BotWorker {
 
         // Create conversation
         const parameters: ConversationParameters = { bot: reference.bot, members: [reference.user], isGroup: false, activity: null, channelData: null };
-        const client = this.getConfig('context').adapter.createConnectorClient(reference.serviceUrl);
+        const client = this.getConfig('adapter').createConnectorClient(reference.serviceUrl);
 
         // Mix in the tenant ID if specified. This is required for MS Teams.
         if (reference.conversation && reference.conversation.tenantId) {
@@ -312,7 +312,7 @@ export class BotWorker {
         if (response.serviceUrl) { request.serviceUrl = response.serviceUrl; }
 
         // Create context and run middleware
-        const turnContext: TurnContext = this.getConfig('context').adapter.createContext(request);
+        const turnContext: TurnContext = this.getConfig('adapter').createContext(request);
 
         // create a new dialogContext so beginDialog works.
         const dialogContext = await this._controller.dialogSet.createContext(turnContext);

--- a/packages/botkit/src/core.ts
+++ b/packages/botkit/src/core.ts
@@ -1077,13 +1077,17 @@ export class Botkit {
         }
 
         let worker: BotWorker = null;
-        const adapter = custom_adapter || config.context.adapter || this.adapter;
+        const adapter = custom_adapter || (config.context && config.context.adapter) ? config.context.adapter : this.adapter;
+
         if (adapter.botkit_worker) {
             const CustomBotWorker = adapter.botkit_worker;
             worker = new CustomBotWorker(this, config);
         } else {
             worker = new BotWorker(this, config);
         }
+
+        // make sure the adapter is available in a standard location.
+        worker.getConfig().adapter = adapter;
 
         return new Promise((resolve, reject) => {
             this.middleware.spawn.run(worker, (err, worker) => {


### PR DESCRIPTION
Fixes #1937 

This is a fix to the change to how the adapter is referenced inside the botworker introduced in 4.8.
This change introduced a bug pertaining to spawning proactive slack bots.