### PR TITLE
Removes enforcement of "as_user" field. Fixes #1943

### DIFF
--- a/packages/botbuilder-adapter-slack/src/slack_adapter.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_adapter.ts
@@ -340,6 +340,14 @@ export class SlackAdapter extends BotAdapter {
             message.user = activity.recipient.id;
         }
 
+        if (message.icon_url || message.icon_emoji || message.username) {
+            message.as_user = false;
+        }
+
+        // as_user flag is deprecated on v2
+        if (message.as_user === false && this.options.oauthVersion === 'v2') {
+            delete message.as_user;
+        }
 
         return message;
     }

--- a/packages/botbuilder-adapter-slack/src/slack_adapter.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_adapter.ts
@@ -340,9 +340,6 @@ export class SlackAdapter extends BotAdapter {
             message.user = activity.recipient.id;
         }
 
-        if (message.icon_url || message.icon_emoji || message.username) {
-            message.as_user = false;
-        }
 
         return message;
     }


### PR DESCRIPTION
Fixes issue #1943 

By removing this IF statement: 

**New generation bots** will be able to make use of `icon_url`, `icon_emoji` and `username` fields on the `reply` object without having Botkit forcing a deprecated field `as_user` set to false.

For **classic bots**, developers would still be able to add the `as_user` field manually as stated by the [Slack documentation](https://api.slack.com/methods/chat.postMessage#arg_as_user)

_(I'm not sure if I should make a PR to master or other branch, please advice)_
