### PR TITLE
`activityToMessage` should be protected.

### DIFF
--- a/packages/botbuilder-adapter-web/src/web_adapter.ts
+++ b/packages/botbuilder-adapter-web/src/web_adapter.ts
@@ -167,7 +167,7 @@ export class WebAdapter extends BotAdapter {
      * @param activity
      * @returns a message ready to send back to the websocket client.
      */
-    private activityToMessage(activity: Partial<Activity>): any {
+    protected activityToMessage(activity: Partial<Activity>): any {
         const message = {
             type: activity.type,
             text: activity.text


### PR DESCRIPTION
I think that activityToMessage should be something that a class that extends WebAdapter should modify for its own needs as well.

Signed-off-by: Alejandro G. Recuenco <alejandro.recuenco@ubitec.com>