### PR TITLE
Add botbuilder-core to botkit's dependencies

### DIFF
--- a/packages/botkit/package-lock.json
+++ b/packages/botkit/package-lock.json
@@ -1,105 +1,9 @@
 {
 	"name": "botkit",
-	"version": "4.6.2",
+	"version": "4.8.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@azure/ms-rest-js": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.2.6.tgz",
-			"integrity": "sha512-8cmDpxsQjVdveJwYKtNnkJorxEORLYJu9UHaUvLZA6yHExzDeISHAcSVWE0J05+VkJtqheVHF17M+2ro18Cdnw==",
-			"requires": {
-				"axios": "^0.18.0",
-				"form-data": "^2.3.2",
-				"tough-cookie": "^2.4.3",
-				"tslib": "^1.9.2",
-				"uuid": "^3.2.1",
-				"xml2js": "^0.4.19"
-			},
-			"dependencies": {
-				"axios": {
-					"version": "0.18.1",
-					"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-					"integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
-					"requires": {
-						"follow-redirects": "1.5.10",
-						"is-buffer": "^2.0.2"
-					}
-				}
-			}
-		},
-		"@microsoft/recognizers-text": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text/-/recognizers-text-1.1.4.tgz",
-			"integrity": "sha512-hlSVXcaX5i8JcjuUJpVxmy2Z/GxvFXarF0KVySCFop57wNEnrLWMHe4I4DjP866G19VyIKRw+vPA32pkGhZgTg=="
-		},
-		"@microsoft/recognizers-text-choice": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-choice/-/recognizers-text-choice-1.1.4.tgz",
-			"integrity": "sha512-4CddwFe4RVhZeJgW65ocBrEdeukBMghK8pgI0K0Qy2eA5ysPZQpeZ7BGSDz5QMQei5LPY+QaAQ3CHU+ORHoO7A==",
-			"requires": {
-				"@microsoft/recognizers-text": "~1.1.4",
-				"grapheme-splitter": "^1.0.2"
-			}
-		},
-		"@microsoft/recognizers-text-date-time": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-date-time/-/recognizers-text-date-time-1.1.4.tgz",
-			"integrity": "sha512-leMnjN+KYNwNvRD5T4G0ORUzkjlek/BBZDvQIjAujtyrd/pkViUnuouWIPkFT/dbSOxXML8et54CSk2KfHiWIA==",
-			"requires": {
-				"@microsoft/recognizers-text": "~1.1.4",
-				"@microsoft/recognizers-text-number": "~1.1.4",
-				"@microsoft/recognizers-text-number-with-unit": "~1.1.4",
-				"lodash.isequal": "^4.5.0",
-				"lodash.tonumber": "^4.0.3"
-			}
-		},
-		"@microsoft/recognizers-text-number": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number/-/recognizers-text-number-1.1.4.tgz",
-			"integrity": "sha512-6EmlR+HR+eJBIX7sQby1vs6LJB64wxLowHaGpIU9OCXFvZ5Nb0QT8qh10rC40v3Mtrz4DpScXfSXr9tWkIO5MQ==",
-			"requires": {
-				"@microsoft/recognizers-text": "~1.1.4",
-				"bignumber.js": "^7.2.1",
-				"lodash.escaperegexp": "^4.1.2",
-				"lodash.sortby": "^4.7.0",
-				"lodash.trimend": "^4.5.1"
-			}
-		},
-		"@microsoft/recognizers-text-number-with-unit": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number-with-unit/-/recognizers-text-number-with-unit-1.1.4.tgz",
-			"integrity": "sha512-zl+CfmfWK0x/x+iSgaBAevKTYO0F4+z7SYHAHztaaaGuX8FERw2jmUjSgVetm5KA3EveyCx0XYGU1mRNY8p7Eg==",
-			"requires": {
-				"@microsoft/recognizers-text": "~1.1.4",
-				"@microsoft/recognizers-text-number": "~1.1.4",
-				"lodash.escaperegexp": "^4.1.2",
-				"lodash.last": "^3.0.0",
-				"lodash.max": "^4.0.1"
-			}
-		},
-		"@microsoft/recognizers-text-sequence": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-sequence/-/recognizers-text-sequence-1.1.4.tgz",
-			"integrity": "sha512-rb5j8/aE7HSOdIxaVfCGFrj0wWPpSq0CuykFg/A/iJNPP+FnAU71bgP5HexrwQcpCsDinauisX7u0DKIChrHRA==",
-			"requires": {
-				"@microsoft/recognizers-text": "~1.1.4",
-				"grapheme-splitter": "^1.0.2"
-			}
-		},
-		"@microsoft/recognizers-text-suite": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-suite/-/recognizers-text-suite-1.1.4.tgz",
-			"integrity": "sha512-hNIaR4M2G0nNeI9WZxt9C0KYh/1vhjeKzX5Ds8XDdT0pxF7zwCSo19WNcPjrVK6aCOeZTw/ULofsAjdu9gSkcA==",
-			"requires": {
-				"@microsoft/recognizers-text": "~1.1.4",
-				"@microsoft/recognizers-text-choice": "~1.1.4",
-				"@microsoft/recognizers-text-date-time": "~1.1.4",
-				"@microsoft/recognizers-text-number": "~1.1.4",
-				"@microsoft/recognizers-text-number-with-unit": "~1.1.4",
-				"@microsoft/recognizers-text-sequence": "~1.1.4"
-			}
-		},
 		"@types/body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -146,14 +50,6 @@
 				"@types/range-parser": "*"
 			}
 		},
-		"@types/jsonwebtoken": {
-			"version": "7.2.8",
-			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz",
-			"integrity": "sha512-XENN3YzEB8D6TiUww0O8SRznzy1v+77lH7UmuN54xq/IHIsyWjWOzZuFFTtoiRuaE782uAoRwBe/wwow+vQXZw==",
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/mime": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
@@ -163,7 +59,8 @@
 		"@types/node": {
 			"version": "10.17.17",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-			"integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+			"integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q==",
+			"dev": true
 		},
 		"@types/range-parser": {
 			"version": "1.2.3",
@@ -181,14 +78,6 @@
 				"@types/mime": "*"
 			}
 		},
-		"@types/ws": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
-			"integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"accepts": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -203,29 +92,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
 			"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
 			"dev": true
-		},
-		"adal-node": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.1.tgz",
-			"integrity": "sha512-C/oasZuTy0NIqh5wPWjG/09XaG+zS7elC8upf1ZVExt9lSRncme4Ejbx8CKYk+wsGgj609y84txtRAXQVvqApg==",
-			"requires": {
-				"@types/node": "^8.0.47",
-				"async": "^2.6.3",
-				"date-utils": "*",
-				"jws": "3.x.x",
-				"request": "^2.88.0",
-				"underscore": ">= 1.3.1",
-				"uuid": "^3.1.0",
-				"xmldom": ">= 0.1.x",
-				"xpath.js": "~1.1.0"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "8.10.59",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
-					"integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ=="
-				}
-			}
 		},
 		"ajv": {
 			"version": "6.12.0",
@@ -286,14 +152,6 @@
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
-		"async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-			"requires": {
-				"lodash": "^4.17.14"
-			}
-		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -309,24 +167,11 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
 			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
 		},
-		"axios": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-			"requires": {
-				"follow-redirects": "1.5.10"
-			}
-		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
-		},
-		"base64url": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-			"integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -335,11 +180,6 @@
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
-		},
-		"bignumber.js": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-			"integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
 		},
 		"body-parser": {
 			"version": "1.19.0",
@@ -368,75 +208,19 @@
 				}
 			}
 		},
-		"botbuilder": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.7.2.tgz",
-			"integrity": "sha512-3NzqEiiRh37CDVypk47nDBsH5zAV6pi4qW1Kv26lx89UxfgQNjoN9tF+PLAqzbQHrWYDCBWYgpmyFn1NKLsY0g==",
-			"requires": {
-				"@azure/ms-rest-js": "1.2.6",
-				"@types/node": "^10.12.18",
-				"axios": "^0.19.0",
-				"botbuilder-core": "4.7.2",
-				"botframework-connector": "4.7.2",
-				"botframework-streaming": "4.7.2",
-				"filenamify": "^4.1.0",
-				"fs-extra": "^7.0.1"
-			}
-		},
 		"botbuilder-core": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.7.2.tgz",
-			"integrity": "sha512-4adVtnCB6+d+R6SJQlpd9HLzvLcBmuu9i/wqcvLaTiWen2Jv6+n8mHNsSg2lR2grIIYbV0ZKqfb0FLnlvFWH4A==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.8.0.tgz",
+			"integrity": "sha512-SaLwpHoDmarRMi9KeTBefzhAhCfyu7ImB/hxdYDHxJFIz2otcyp6WqiWQRD8SpfXeo6VUl/jKD3dm+2LHrwveg==",
 			"requires": {
 				"assert": "^1.4.1",
-				"botframework-schema": "4.7.2"
-			}
-		},
-		"botbuilder-dialogs": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/botbuilder-dialogs/-/botbuilder-dialogs-4.7.2.tgz",
-			"integrity": "sha512-YQyP2msfA9x6zTtSHvoG0OXvQ34j5gz4b4sKH+wCm4UBjknaGp+s7D6ARSQ1ocQNzbzRd7z98lKgoMBf3GJ3KA==",
-			"requires": {
-				"@microsoft/recognizers-text-choice": "1.1.4",
-				"@microsoft/recognizers-text-date-time": "1.1.4",
-				"@microsoft/recognizers-text-number": "1.1.4",
-				"@microsoft/recognizers-text-suite": "1.1.4",
-				"@types/node": "^10.12.18",
-				"botbuilder-core": "4.7.2",
-				"globalize": "^1.4.2"
-			}
-		},
-		"botframework-connector": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.7.2.tgz",
-			"integrity": "sha512-Ow5/aKDm3+WUP+XOQ0axeC5fEE/zZW8ZMQKuVjQZ2BZ81He2jwKPg50+TNOe62ljZAhsnHh3KGD/aEfVv2DecA==",
-			"requires": {
-				"@azure/ms-rest-js": "1.2.6",
-				"@types/jsonwebtoken": "7.2.8",
-				"@types/node": "^10.12.18",
-				"adal-node": "0.2.1",
-				"base64url": "^3.0.0",
-				"botframework-schema": "4.7.2",
-				"form-data": "^2.3.3",
-				"jsonwebtoken": "8.0.1",
-				"node-fetch": "^2.2.1",
-				"rsa-pem-from-mod-exp": "^0.8.4"
+				"botframework-schema": "4.8.0"
 			}
 		},
 		"botframework-schema": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.7.2.tgz",
-			"integrity": "sha512-rSTywVl5dYzL4FNoK86s9kFPNkRx5iYJi7MAWEaSrhUiDV3KEHX/5VEHLa00d4nzQxC/jI9BqfbqdffpO97KIA=="
-		},
-		"botframework-streaming": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.7.2.tgz",
-			"integrity": "sha512-nkj7WTviO/8G2QCq9qyjRz9wPpx9fd5yO6YxeWLV2n81rxlF0KBosBs1kUCpbpX0xZjCwAmJC8urdqEktfcz8Q==",
-			"requires": {
-				"@types/ws": "^6.0.3",
-				"uuid": "^3.3.2",
-				"ws": "^7.1.2"
-			}
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.8.0.tgz",
+			"integrity": "sha512-0BVrnk9ktDWVUJrjNveLDUPVVDaJh1+JEaOB+buj7kKBaBY2X6Vuq/Jl7UeLZtfkrtKcW4PIADFfGB/wJqFSFQ=="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -448,11 +232,6 @@
 				"concat-map": "0.0.1"
 			}
 		},
-		"buffer-equal-constant-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
-		},
 		"bytes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -462,11 +241,6 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-		},
-		"cldrjs": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.1.tgz",
-			"integrity": "sha512-xyiP8uAm8K1IhmpDndZLraloW1yqu0L+HYdQ7O1aGPxx9Cr+BMnPANlNhSt++UKfxytL2hd2NPXgTjiy7k43Ew=="
 		},
 		"co": {
 			"version": "3.1.0",
@@ -536,11 +310,6 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
-		"date-utils": {
-			"version": "1.2.21",
-			"resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
-			"integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
-		},
 		"debug": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -599,14 +368,6 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"ecdsa-sig-formatter": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -660,11 +421,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"eslint": {
 			"version": "6.8.0",
@@ -1890,21 +1646,6 @@
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
-		"filename-reserved-regex": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
-		},
-		"filenamify": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.1.0.tgz",
-			"integrity": "sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==",
-			"requires": {
-				"filename-reserved-regex": "^2.0.0",
-				"strip-outer": "^1.0.1",
-				"trim-repeated": "^1.0.0"
-			}
-		},
 		"finalhandler": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -1938,38 +1679,10 @@
 				"locate-path": "^2.0.0"
 			}
 		},
-		"follow-redirects": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-			"requires": {
-				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-		},
-		"form-data": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-			"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
-			}
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -1980,16 +1693,6 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-		},
-		"fs-extra": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -2005,23 +1708,11 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
-		"globalize": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/globalize/-/globalize-1.4.2.tgz",
-			"integrity": "sha512-IfKeYI5mAITBmT5EnH8kSQB5uGson4Fkj2XtTpyEbIS7IHNfLHoeTyLJ6tfjiKC6cJXng3IhVurDk5C7ORqFhQ==",
-			"requires": {
-				"cldrjs": "^0.5.0"
-			}
-		},
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
-		},
-		"grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+			"dev": true
 		},
 		"har-schema": {
 			"version": "2.0.0",
@@ -2110,11 +1801,6 @@
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
 			"dev": true
 		},
-		"is-buffer": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-			"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-		},
 		"is-callable": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
@@ -2187,31 +1873,6 @@
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
-		"jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"requires": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"jsonwebtoken": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
-			"integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
-			"requires": {
-				"jws": "^3.1.4",
-				"lodash.includes": "^4.3.0",
-				"lodash.isboolean": "^3.0.3",
-				"lodash.isinteger": "^4.0.4",
-				"lodash.isnumber": "^3.0.3",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.once": "^4.0.0",
-				"ms": "^2.0.0",
-				"xtend": "^4.0.1"
-			}
-		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -2221,25 +1882,6 @@
 				"extsprintf": "1.3.0",
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
-			}
-		},
-		"jwa": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-			"requires": {
-				"buffer-equal-constant-time": "1.0.1",
-				"ecdsa-sig-formatter": "1.0.11",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"jws": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-			"requires": {
-				"jwa": "^1.4.1",
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"load-json-file": {
@@ -2263,81 +1905,6 @@
 				"p-locate": "^2.0.0",
 				"path-exists": "^3.0.0"
 			}
-		},
-		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-		},
-		"lodash.escaperegexp": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-			"integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
-		},
-		"lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-		},
-		"lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-		},
-		"lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-		},
-		"lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-		},
-		"lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-		},
-		"lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-		},
-		"lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-		},
-		"lodash.last": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
-			"integrity": "sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw="
-		},
-		"lodash.max": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
-			"integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
-		},
-		"lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
-		},
-		"lodash.sortby": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-		},
-		"lodash.tonumber": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
-			"integrity": "sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="
-		},
-		"lodash.trimend": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
-			"integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
 		},
 		"media-typer": {
 			"version": "0.3.0",
@@ -2386,20 +1953,10 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
-		"mustache": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
-			"integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA=="
-		},
 		"negotiator": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
 			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
-		},
-		"node-fetch": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -2685,11 +2242,6 @@
 				"path-parse": "^1.0.6"
 			}
 		},
-		"rsa-pem-from-mod-exp": {
-			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
-			"integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
-		},
 		"safe-buffer": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
@@ -2699,11 +2251,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"sax": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"semver": {
 			"version": "5.7.1",
@@ -2848,14 +2395,6 @@
 			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
 			"dev": true
 		},
-		"strip-outer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-			"requires": {
-				"escape-string-regexp": "^1.0.2"
-			}
-		},
 		"toidentifier": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -2869,19 +2408,6 @@
 				"psl": "^1.1.28",
 				"punycode": "^2.1.1"
 			}
-		},
-		"trim-repeated": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
-			"requires": {
-				"escape-string-regexp": "^1.0.2"
-			}
-		},
-		"tslib": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -2904,16 +2430,6 @@
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.24"
 			}
-		},
-		"underscore": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-			"integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
-		},
-		"universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -2993,40 +2509,6 @@
 			"requires": {
 				"co": "3.1.0"
 			}
-		},
-		"ws": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
-		},
-		"xml2js": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-			"requires": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "~11.0.0"
-			}
-		},
-		"xmlbuilder": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-		},
-		"xmldom": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-			"integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g=="
-		},
-		"xpath.js": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-			"integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
-		},
-		"xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 		}
 	}
 }

--- a/packages/botkit/package.json
+++ b/packages/botkit/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "botbuilder": "^4.8.0",
+    "botbuilder-core": "^4.8.0",
     "botbuilder-dialogs": "^4.8.0",
     "botframework-connector": "^4.8.0",
     "debug": "^4.1.0",
@@ -42,7 +43,7 @@
     "request": "^2.88.0",
     "ware": "^1.3.0"
   },
-  "devDependencies": { 
+  "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/express": "^4.17.2",
     "@types/node": "^10.17.5",


### PR DESCRIPTION
Fixes #1939. `botbuilder-core` was being used in [`testClient.ts`](https://github.com/howdyai/botkit/blob/77e309b9522f1c654dcc68332c11d80fae3d2a53/packages/botkit/src/testClient.ts#L16), but wasn’t declared in the package.json.