### PR TITLE
Fix dynamic text field type definition

### DIFF
--- a/packages/botkit/src/conversation.ts
+++ b/packages/botkit/src/conversation.ts
@@ -36,7 +36,7 @@ interface BotkitConvoTrigger {
  * Template for definiting a BotkitConversation template
  */
 interface BotkitMessageTemplate {
-    text: ((template: any, vars: any) => string[]) | string[];
+    text: ((template: any, vars: any) => string) | string[];
     action?: string;
     execute?: {
         script: string;


### PR DESCRIPTION
See [BotkitConversation.makeOutgoing](https://github.com/howdyai/botkit/blob/master/packages/botkit/src/conversation.ts#L795-L802) method. 

The `text` variable must be a string, as it is fed into the mustache renderer [here](https://github.com/howdyai/botkit/blob/master/packages/botkit/src/conversation.ts#L867). So the template function must always return a string, or the function will crash later on.

Therefore, the type definition must reflect that. I am getting TypeScript error when returning a string, if I can it to an array, botkit breaks. 😞