### PR TITLE
Fix IE11 compatibility issue

### DIFF
--- a/packages/botbuilder-adapter-web/client/client.js
+++ b/packages/botbuilder-adapter-web/client/client.js
@@ -117,7 +117,7 @@ var Botkit = {
         var that = this;
 
         that.request('/api/messages', message).then(function (messages) {
-            messages.forEach((message) => {
+            messages.forEach(function (message) {
                 that.trigger(message.type, message);
             });
         }).catch(function (err) {


### PR DESCRIPTION
The "=>" syntax seems to be not supported in IE11.