### PR TITLE
Add Block Kit library links to README

### DIFF
--- a/packages/botbuilder-adapter-slack/readme.md
+++ b/packages/botbuilder-adapter-slack/readme.md
@@ -239,6 +239,11 @@ Botkit will automatically construct your outgoing messages according to Slack's 
 
 The preferred way of composing interactive messages is using Slack's Block Kit.  [Read the official Slack documentation here](https://api.slack.com/messaging/composing/layouts). Slack provides a UI to help create your interactive messages. Check out [Block Kit Builder](https://api.slack.com/tools/block-kit-builder).
 
+Additionally, there are open-source libraries available that assist with building out UIs for Slack:
+
+* [**Block Builder**](https://github.com/raycharius/slack-block-builder) – Zero-dependency library, with a SwiftUI-like builder syntax.
+* [**JSX-Slack**](https://github.com/speee/jsx-slack) – JSX that transpiles to Slack API-compatible JSON.
+
 Interactive messages using blocks can be sent via any of Botkit's built in functions by passing in the appropriate "blocks" as part of the message.  Here is an example:
 
 ```javascript


### PR DESCRIPTION
As discussed in Bot Developer Hangout, adding links to two libraries that make it easier to compose Slack UIs.

Of the ones available, these were the two that are actively maintained and are documented well enough. 

There is another – [slack-block-msg-kit](https://github.com/IyiKuyoro/slack-block-msg-kit) – but just felt a bit verbose to me. Also wasn't a fan of it validating Slack business logic, without configuration available, to bypass the validation. Could create limitations and issues when Slack updates their own validation rules.