### PR TITLE
Fix unhandled promise rejections when a trigger errors

### DIFF
--- a/packages/botkit/src/botworker.ts
+++ b/packages/botkit/src/botworker.ts
@@ -97,16 +97,9 @@ export class BotWorker {
      * @returns Return value will contain the results of the send action, typically `{id: <id of message>}`
      */
     public async say(message: Partial<BotkitMessage> | string): Promise<any> {
-        return new Promise((resolve, reject) => {
-            const activity = this.ensureMessageFormat(message);
-
-            this._controller.middleware.send.run(this, activity, async (err, bot, activity) => {
-                if (err) {
-                    return reject(err);
-                }
-                resolve(await this.getConfig('context').sendActivity(activity));
-            });
-        });
+        const activity = this.ensureMessageFormat(message);
+        await this._controller.middleware.send.run(this, activity);
+        return this.getConfig('context').sendActivity(activity)
     };
 
     /**

--- a/packages/botkit/src/conversation.ts
+++ b/packages/botkit/src/conversation.ts
@@ -894,18 +894,10 @@ export class BotkitConversation<O extends object = {}> extends Dialog<O> {
             outgoing.suggestedActions = this.parseTemplatesRecursive(outgoing.suggestedActions, vars);
         }
 
-        return new Promise((resolve, reject) => {
-            // run the outgoing message through the Botkit send middleware
-            this._controller.spawn(dc).then((bot) => {
-                this._controller.middleware.send.run(bot, outgoing, (err, bot, outgoing) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(outgoing);
-                    }
-                });
-            }).catch(reject);
-        });
+        const bot = await this._controller.spawn(dc);
+        await this._controller.middleware.send.run(bot, outgoing);
+
+        return outgoing;
     }
 
     /**


### PR DESCRIPTION
When a trigger, such as the callback to `controller.hears(...)` errors (the async callback rejects), this promise is not handled correctly, and results in an unhandled promise rejection.

This is because the `run` function for [`ware`](https://github.com/segmentio/ware) does not support promises (the middleware themselves do, but not the callback). 

I don't really agree with the decision to use a non-promise-supporting library like `ware` in this very promise-based framework, but we can at least promisify those calls.

This ends up simplifying a lot of the code that uses the middleware, as Promise constructors no longer need to be used.

With this fix, the promises bubble up all the way to the `handleTurn` function, and can be handled at the web layer.

Maybe a `controller.on('error', () => {})` event would make sense as well. Or an `error` middleware?