### PR TITLE
Result is not necessarily defined here

### DIFF
--- a/packages/botkit/src/conversation.ts
+++ b/packages/botkit/src/conversation.ts
@@ -962,7 +962,7 @@ export class BotkitConversation<O extends object = {}> extends Dialog<O> {
             const index = step.index;
             const thread_name = step.thread;
             const result = step.result;
-            const response = result.text || (typeof (result) === 'string' ? result : null);
+            const response = result == null ? null : (result.text || (typeof (result) === 'string' ? result : null));
 
             // spawn a bot instance so devs can use API or other stuff as necessary
             const bot = await this._controller.spawn(dc);


### PR DESCRIPTION
You can get an undefined result at this point, since `runStep` can be called with an empty result. I don't believe it is assumed that an action handler is called always after the previous step generated a result

Until this is fixed, what would be an alternative?