### PR TITLE
Use conversations.open in place of im.open

### DIFF
--- a/packages/botbuilder-adapter-slack/src/botworker.ts
+++ b/packages/botbuilder-adapter-slack/src/botworker.ts
@@ -100,7 +100,7 @@ export class SlackBotWorker extends BotWorker {
      */
     public async startPrivateConversation(userId: string): Promise<any> {
         // create the new IM channel
-        const channel: any = await this.api.im.open({ user: userId });
+        const channel: any = await this.api.conversations.open({ users: userId });
 
         if (channel.ok === true) {
             // now, switch contexts


### PR DESCRIPTION
Resolves #1988 

See https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api and  https://api.slack.com/methods/conversations.open