### PR TITLE
Support updating a Slack message with blocks

### DIFF
--- a/packages/botbuilder-adapter-slack/src/slack_adapter.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_adapter.ts
@@ -322,6 +322,7 @@ export class SlackAdapter extends BotAdapter {
         const message: any = {
             ts: activity.id,
             text: activity.text,
+            blocks: activity.blocks,
             attachments: activity.attachments,
 
             channel: channelId,


### PR DESCRIPTION
Minor change to include copying the `blocks` property to allow updating a blocks based message.

I didn't include any tests with this as it's a somewhat trivial change but can if need be.