### PR TITLE
Add null check for channelData

### DIFF
--- a/packages/botbuilder-adapter-webex/src/webex_adapter.ts
+++ b/packages/botbuilder-adapter-webex/src/webex_adapter.ts
@@ -398,7 +398,7 @@ export class WebexAdapter extends BotAdapter {
                 if (activity.conversation && activity.conversation.parentId) {
                     // @ts-ignore ignore this webex specific field
                     message.parentId = activity.conversation.parentId;
-                } else if (activity.channelData.parentId) {
+                } else if (activity.channelData && activity.channelData.parentId) {
                     message.parentId = activity.channelData.parentId;
                 }
                 


### PR DESCRIPTION
No null check for channelData looks like breaking changes as sometime it
will not be present when we try to use context.sendActivity.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>