### PR TITLE
Change BotkitTestClient properties modifier to protected

### DIFF
--- a/packages/botkit/src/testClient.ts
+++ b/packages/botkit/src/testClient.ts
@@ -21,8 +21,8 @@ import { Botkit } from './core';
  * A client for testing dialogs in isolation.
  */
 export class BotkitTestClient {
-    private readonly _callback: (turnContext: TurnContext) => Promise<void>;
-    private readonly _testAdapter: TestAdapter;
+    protected _callback: (turnContext: TurnContext) => Promise<void>;
+    protected _testAdapter: TestAdapter;
     public dialogTurnResult: DialogTurnResult;
     public conversationState: ConversationState;
 

--- a/packages/botkit/tests/CustomAdapter.tests.js
+++ b/packages/botkit/tests/CustomAdapter.tests.js
@@ -22,10 +22,10 @@ class FakeAdapter extends TestAdapter {
 }
 
 class CustomTestClient extends BotkitTestClient {
-  constructor(channelId, bot, dialogToTest) {
-    super(channelId, bot, dialogToTest);
-    this._testAdapter = new FakeAdapter(this._callback, { channelId: channelId }).use(new AutoSaveStateMiddleware(this.conversationState));
-  }
+    constructor(channelId, bot, dialogToTest) {
+        super(channelId, bot, dialogToTest);
+        this._testAdapter = new FakeAdapter(this._callback, { channelId: channelId }).use(new AutoSaveStateMiddleware(this.conversationState));
+    }
 }
 
 function createDialog(controller) {
@@ -39,7 +39,7 @@ function createDialog(controller) {
     return dialog;
 }
 
-describe('Test something with custom worker', () => {
+describe('Botkit dialog with custom worker', () => {
     let botkit;
     let client;
     let testAdapter;
@@ -58,7 +58,7 @@ describe('Test something with custom worker', () => {
         let message = await client.sendActivity('');
         assert(message.text === 'How you like me now?');
         message = await client.sendActivity('nice!');
-        assert(message.text === 'You are: Roger','Custom adapter spawning invalid bot');
+        assert(message.text === 'You are: Roger', 'Custom adapter spawning invalid bot');
     });
 
     afterEach(async () => {


### PR DESCRIPTION
Related to https://github.com/howdyai/botkit/issues/1985

When creating a custom test client in a TypeScript project [as suggested here](https://github.com/howdyai/botkit/issues/1985#issuecomment-679274474), the compiler complains about the `_callback` property being not visible, and the `_testAdapter` being not visible and read-only.

```
class FakeAdapter extends TestAdapter {
  // Enables overriding the type of the BotWorker
  // (this uses a Botkit features that allows setting a worker type)
  botkit_worker = FakeBotWorker;
}

class CustomTestClient extends BotkitTestClient {
  constructor(channelId, bot, dialogToTest) {
    super(channelId, bot, dialogToTest);
    // Uh-oh, _testAdapter is private readonly and _callback is private
    this._testAdapter = new FakeAdapter(this._callback, { channelId: channelId }).use(new AutoSaveStateMiddleware(this.conversationState));
  }
}
```

This problem happens only when writing TypeScript tests.