### PR TITLE
Update HangoutsAdapter Google Credentials Verifier 

### DIFF
--- a/packages/botbuilder-adapter-hangouts/package-lock.json
+++ b/packages/botbuilder-adapter-hangouts/package-lock.json
@@ -1,31 +1,78 @@
 {
 	"name": "botbuilder-adapter-hangouts",
-	"version": "1.0.5",
+	"version": "1.0.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@azure/ms-rest-js": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.2.6.tgz",
-			"integrity": "sha512-8cmDpxsQjVdveJwYKtNnkJorxEORLYJu9UHaUvLZA6yHExzDeISHAcSVWE0J05+VkJtqheVHF17M+2ro18Cdnw==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.9.1.tgz",
+			"integrity": "sha512-F1crHKhmsvFLM9fsnDyCGFd2E2KR9GEZm5oBVV5D5k2EBQ7u7idtSJlSF6RDLDIrGWtc4NnFdYwsoiW8NLlBQg==",
 			"requires": {
-				"axios": "^0.18.0",
+				"@types/tunnel": "0.0.0",
+				"axios": "^0.21.1",
 				"form-data": "^2.3.2",
 				"tough-cookie": "^2.4.3",
 				"tslib": "^1.9.2",
+				"tunnel": "0.0.6",
 				"uuid": "^3.2.1",
 				"xml2js": "^0.4.19"
+			}
+		},
+		"@babel/code-frame": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+			"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.10.4"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+			"dev": true
+		},
+		"@babel/highlight": {
+			"version": "7.13.10",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+			"integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.12.11",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
 			},
 			"dependencies": {
-				"axios": {
-					"version": "0.18.1",
-					"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-					"integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
-						"follow-redirects": "1.5.10",
-						"is-buffer": "^2.0.2"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				}
+			}
+		},
+		"@eslint/eslintrc": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+			"integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.12.4",
+				"debug": "^4.1.1",
+				"espree": "^7.3.0",
+				"globals": "^12.1.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^3.13.1",
+				"minimatch": "^3.0.4",
+				"strip-json-comments": "^3.1.1"
 			}
 		},
 		"@microsoft/recognizers-text": {
@@ -109,9 +156,17 @@
 			}
 		},
 		"@types/node": {
-			"version": "10.17.17",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-			"integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+			"version": "14.14.33",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.33.tgz",
+			"integrity": "sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g=="
+		},
+		"@types/tunnel": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.0.tgz",
+			"integrity": "sha512-FGDp0iBRiBdPjOgjJmn1NH0KDLN+Z8fRmo+9J7XGBhubq1DPrGrbmG4UTlGzrpbCpesMqD0sWkzi27EYkOMHyg==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/ws": {
 			"version": "6.0.4",
@@ -139,9 +194,15 @@
 			}
 		},
 		"acorn": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-			"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"dev": true
+		},
+		"acorn-jsx": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
 			"dev": true
 		},
 		"adal-node": {
@@ -161,9 +222,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "8.10.59",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
-					"integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ=="
+					"version": "8.10.66",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+					"integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
 				}
 			}
 		},
@@ -176,14 +237,44 @@
 			}
 		},
 		"ajv": {
-			"version": "6.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-			"integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
+			}
+		},
+		"ansi-colors": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"array-flatten": {
@@ -234,6 +325,12 @@
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
+		"astral-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+			"dev": true
+		},
 		"async": {
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
@@ -253,16 +350,23 @@
 			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
 		},
 		"axios": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+			"version": "0.21.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+			"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
 			"requires": {
-				"follow-redirects": "1.5.10"
+				"follow-redirects": "^1.10.0"
+			},
+			"dependencies": {
+				"follow-redirects": {
+					"version": "1.13.3",
+					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+					"integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+				}
 			}
 		},
 		"balanced-match": {
@@ -322,89 +426,158 @@
 			}
 		},
 		"botbuilder": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.7.2.tgz",
-			"integrity": "sha512-3NzqEiiRh37CDVypk47nDBsH5zAV6pi4qW1Kv26lx89UxfgQNjoN9tF+PLAqzbQHrWYDCBWYgpmyFn1NKLsY0g==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.12.0.tgz",
+			"integrity": "sha512-OE5Lo4tBzbbiejG4l+LV2MiX0rfcB13zwMMjLwYsh6kNfa+oMo4vTHMqsxcUtqgyKKXYzLVqMQK8xqHWdrghvg==",
 			"requires": {
-				"@azure/ms-rest-js": "1.2.6",
-				"@types/node": "^10.12.18",
-				"axios": "^0.19.0",
-				"botbuilder-core": "4.7.2",
-				"botframework-connector": "4.7.2",
-				"botframework-streaming": "4.7.2",
+				"@azure/ms-rest-js": "1.9.1",
+				"axios": "^0.21.1",
+				"botbuilder-core": "4.12.0",
+				"botframework-connector": "4.12.0",
+				"botframework-streaming": "4.12.0",
+				"dayjs": "^1.10.3",
 				"filenamify": "^4.1.0",
-				"fs-extra": "^7.0.1"
+				"fs-extra": "^7.0.1",
+				"uuid": "^8.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+				}
 			}
 		},
 		"botbuilder-core": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.7.2.tgz",
-			"integrity": "sha512-4adVtnCB6+d+R6SJQlpd9HLzvLcBmuu9i/wqcvLaTiWen2Jv6+n8mHNsSg2lR2grIIYbV0ZKqfb0FLnlvFWH4A==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.12.0.tgz",
+			"integrity": "sha512-PURNeGbYMxQ+NqbrRDanVpCmVOqbG0kzZ2QasWUweakYCKiysvM7Xp4qkh32De/5EAxBKO7AKeK0RKqTp7jHsg==",
 			"requires": {
 				"assert": "^1.4.1",
-				"botframework-schema": "4.7.2"
+				"botbuilder-stdlib": "4.12.0-internal",
+				"botframework-connector": "4.12.0",
+				"botframework-schema": "4.12.0",
+				"uuid": "^8.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+				}
 			}
 		},
 		"botbuilder-dialogs": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/botbuilder-dialogs/-/botbuilder-dialogs-4.7.2.tgz",
-			"integrity": "sha512-YQyP2msfA9x6zTtSHvoG0OXvQ34j5gz4b4sKH+wCm4UBjknaGp+s7D6ARSQ1ocQNzbzRd7z98lKgoMBf3GJ3KA==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/botbuilder-dialogs/-/botbuilder-dialogs-4.12.0.tgz",
+			"integrity": "sha512-cjUlTATfQxFlDUPzFiE4XGxOvidVj5UlI4nnt7bOP6/wFVhgUh0U3C6G9JNpGRKBa5G5LBI2KsA+knRo1SUbIg==",
 			"requires": {
 				"@microsoft/recognizers-text-choice": "1.1.4",
 				"@microsoft/recognizers-text-date-time": "1.1.4",
 				"@microsoft/recognizers-text-number": "1.1.4",
 				"@microsoft/recognizers-text-suite": "1.1.4",
-				"@types/node": "^10.12.18",
-				"botbuilder-core": "4.7.2",
-				"globalize": "^1.4.2"
+				"botbuilder-core": "4.12.0",
+				"globalize": "^1.4.2",
+				"uuid": "^8.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+				}
 			}
 		},
+		"botbuilder-stdlib": {
+			"version": "4.12.0-internal",
+			"resolved": "https://registry.npmjs.org/botbuilder-stdlib/-/botbuilder-stdlib-4.12.0-internal.tgz",
+			"integrity": "sha512-AwtWOZlgTaQte+uBeDOAy83veksMOzKHR62k3UYgUeqgsUamtqi6+OGV633hLi49ZmF/Gs8dP4iid2jCLDEQBg=="
+		},
 		"botframework-connector": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.7.2.tgz",
-			"integrity": "sha512-Ow5/aKDm3+WUP+XOQ0axeC5fEE/zZW8ZMQKuVjQZ2BZ81He2jwKPg50+TNOe62ljZAhsnHh3KGD/aEfVv2DecA==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.12.0.tgz",
+			"integrity": "sha512-H4UOqBswIkiRF9Z1/6HpqLVE660SJS2+xHjEHtQJ2vvvutpOAiSWl7FSQpazAMpCVIhYpekofNPhaayRxJitvw==",
 			"requires": {
-				"@azure/ms-rest-js": "1.2.6",
+				"@azure/ms-rest-js": "1.9.1",
 				"@types/jsonwebtoken": "7.2.8",
-				"@types/node": "^10.12.18",
+				"@types/node": "^10.17.27",
 				"adal-node": "0.2.1",
 				"base64url": "^3.0.0",
-				"botframework-schema": "4.7.2",
-				"form-data": "^2.3.3",
+				"botframework-schema": "4.12.0",
+				"cross-fetch": "^3.0.5",
 				"jsonwebtoken": "8.0.1",
-				"node-fetch": "^2.2.1",
 				"rsa-pem-from-mod-exp": "^0.8.4"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "10.17.55",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.55.tgz",
+					"integrity": "sha512-koZJ89uLZufDvToeWO5BrC4CR4OUfHnUz2qoPs/daQH6qq3IN62QFxCTZ+bKaCE0xaoCAJYE4AXre8AbghCrhg=="
+				},
+				"jsonwebtoken": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
+					"integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
+					"requires": {
+						"jws": "^3.1.4",
+						"lodash.includes": "^4.3.0",
+						"lodash.isboolean": "^3.0.3",
+						"lodash.isinteger": "^4.0.4",
+						"lodash.isnumber": "^3.0.3",
+						"lodash.isplainobject": "^4.0.6",
+						"lodash.isstring": "^4.0.1",
+						"lodash.once": "^4.0.0",
+						"ms": "^2.0.0",
+						"xtend": "^4.0.1"
+					}
+				}
 			}
 		},
 		"botframework-schema": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.7.2.tgz",
-			"integrity": "sha512-rSTywVl5dYzL4FNoK86s9kFPNkRx5iYJi7MAWEaSrhUiDV3KEHX/5VEHLa00d4nzQxC/jI9BqfbqdffpO97KIA=="
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.12.0.tgz",
+			"integrity": "sha512-W0/0xvrxafRrusWfGsGiwK2X4FOoIL7obvitkS+3XZfwhr6XeDKLClkQMbaU0GCawVF6DtbiPKErHpPUhd2Oig==",
+			"requires": {
+				"botbuilder-stdlib": "4.12.0-internal"
+			}
 		},
 		"botframework-streaming": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.7.2.tgz",
-			"integrity": "sha512-nkj7WTviO/8G2QCq9qyjRz9wPpx9fd5yO6YxeWLV2n81rxlF0KBosBs1kUCpbpX0xZjCwAmJC8urdqEktfcz8Q==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.12.0.tgz",
+			"integrity": "sha512-RB7uUq66Qs5PbwINXX7muHN8Q6EEKuwkjIax4h9iaI/5KtLyW3VlIsPlpOx569qjVKpLd14zR1eWCdKmJlApuA==",
 			"requires": {
+				"@types/node": "^10.17.27",
 				"@types/ws": "^6.0.3",
-				"uuid": "^3.3.2",
+				"uuid": "^8.3.2",
 				"ws": "^7.1.2"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "10.17.55",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.55.tgz",
+					"integrity": "sha512-koZJ89uLZufDvToeWO5BrC4CR4OUfHnUz2qoPs/daQH6qq3IN62QFxCTZ+bKaCE0xaoCAJYE4AXre8AbghCrhg=="
+				},
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+				}
 			}
 		},
 		"botkit": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/botkit/-/botkit-4.6.2.tgz",
-			"integrity": "sha512-tWasAdmN9BCNl91aGPip/IVHekdVwoMm2z4BvZmfIVyS89/g4fwfu1JCAWo79FK7sfvDUz2ZyNUc21Uh2E+T7w==",
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/botkit/-/botkit-4.10.0.tgz",
+			"integrity": "sha512-0++POhvSAy1KwjKLF6euxZ3sTXRk53/M1JBcLHwNRJ195EK97MvKdwocOoSe8MpXW2rFhcv3GZObEBBncNZq/Q==",
 			"requires": {
-				"body-parser": "^1.18.3",
-				"botbuilder": "^4.7.1",
-				"botbuilder-dialogs": "^4.7.1",
-				"botframework-connector": "^4.7.1",
+				"body-parser": "^1.19.0",
+				"botbuilder": "^4.10.1",
+				"botbuilder-core": "^4.10.1",
+				"botbuilder-dialogs": "^4.10.1",
+				"botframework-connector": "^4.10.1",
 				"debug": "^4.1.0",
-				"express": "^4.16.4",
-				"mustache": "^3.0.1",
+				"express": "^4.17.1",
+				"mustache": "^4.0.1",
 				"path": "^0.12.7",
-				"request": "^2.88.0",
 				"ware": "^1.3.0"
 			}
 		},
@@ -428,20 +601,92 @@
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
 			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
 		},
+		"callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true
+		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
+		"chalk": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"cldrjs": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.1.tgz",
-			"integrity": "sha512-xyiP8uAm8K1IhmpDndZLraloW1yqu0L+HYdQ7O1aGPxx9Cr+BMnPANlNhSt++UKfxytL2hd2NPXgTjiy7k43Ew=="
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.5.tgz",
+			"integrity": "sha512-KDwzwbmLIPfCgd8JERVDpQKrUUM1U4KpFJJg2IROv89rF172lLufoJnqJ/Wea6fXL5bO6WjuLMzY8V52UWPvkA=="
 		},
 		"co": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
 			"integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -498,6 +743,32 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
+		"cross-fetch": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+			"integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+			"requires": {
+				"node-fetch": "2.6.1"
+			},
+			"dependencies": {
+				"node-fetch": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+					"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+				}
+			}
+		},
+		"cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"requires": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			}
+		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -510,6 +781,11 @@
 			"version": "1.2.21",
 			"resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
 			"integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
+		},
+		"dayjs": {
+			"version": "1.10.4",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+			"integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
 		},
 		"debug": {
 			"version": "4.1.1",
@@ -525,6 +801,12 @@
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
 			}
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.3",
@@ -582,10 +864,25 @@
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
+		"emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
 			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+		},
+		"enquirer": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "^4.1.1"
+			}
 		},
 		"error-ex": {
 			"version": "1.3.2",
@@ -650,238 +947,50 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"eslint": {
-			"version": "6.8.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-			"integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
+			"integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
+				"@babel/code-frame": "7.12.11",
+				"@eslint/eslintrc": "^0.4.0",
 				"ajv": "^6.10.0",
-				"chalk": "^2.1.0",
-				"cross-spawn": "^6.0.5",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.2",
 				"debug": "^4.0.1",
 				"doctrine": "^3.0.0",
-				"eslint-scope": "^5.0.0",
-				"eslint-utils": "^1.4.3",
-				"eslint-visitor-keys": "^1.1.0",
-				"espree": "^6.1.2",
-				"esquery": "^1.0.1",
+				"enquirer": "^2.3.5",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^2.1.0",
+				"eslint-visitor-keys": "^2.0.0",
+				"espree": "^7.3.1",
+				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
-				"file-entry-cache": "^5.0.1",
+				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
 				"glob-parent": "^5.0.0",
 				"globals": "^12.1.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
-				"inquirer": "^7.0.0",
 				"is-glob": "^4.0.0",
 				"js-yaml": "^3.13.1",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.3.0",
-				"lodash": "^4.17.14",
+				"levn": "^0.4.1",
+				"lodash": "^4.17.20",
 				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.3",
+				"optionator": "^0.9.1",
 				"progress": "^2.0.0",
-				"regexpp": "^2.0.1",
-				"semver": "^6.1.2",
-				"strip-ansi": "^5.2.0",
-				"strip-json-comments": "^3.0.1",
-				"table": "^5.2.3",
+				"regexpp": "^3.1.0",
+				"semver": "^7.2.1",
+				"strip-ansi": "^6.0.0",
+				"strip-json-comments": "^3.1.0",
+				"table": "^6.0.4",
 				"text-table": "^0.2.0",
 				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.8.3"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.8.3",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^4.0.0"
-					}
-				},
-				"acorn-jsx": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-					"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
-					"dev": true
-				},
-				"ajv": {
-					"version": "6.11.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
-					"integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^3.1.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"ansi-escapes": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-					"integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				},
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"argparse": {
-					"version": "1.0.10",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-					"dev": true,
-					"requires": {
-						"sprintf-js": "~1.0.2"
-					}
-				},
-				"astral-regex": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-					"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-					"dev": true
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"dev": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"dev": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"callsites": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-					"dev": true
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"chardet": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-					"dev": true
-				},
-				"cli-cursor": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-					"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-					"dev": true,
-					"requires": {
-						"restore-cursor": "^3.1.0"
-					}
-				},
-				"cli-width": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-					"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-					"dev": true
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true
-				},
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "5.7.1",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-							"dev": true
-						}
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"deep-is": {
-					"version": "0.1.3",
-					"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-					"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-					"dev": true
-				},
 				"doctrine": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -891,771 +1000,36 @@
 						"esutils": "^2.0.2"
 					}
 				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-					"dev": true
-				},
-				"eslint-scope": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-					"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 					"dev": true,
 					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
+						"yallist": "^4.0.0"
 					}
-				},
-				"eslint-utils": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-					"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
-					"dev": true,
-					"requires": {
-						"eslint-visitor-keys": "^1.1.0"
-					}
-				},
-				"eslint-visitor-keys": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-					"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-					"dev": true
-				},
-				"espree": {
-					"version": "6.1.2",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
-					"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
-					"dev": true,
-					"requires": {
-						"acorn": "^7.1.0",
-						"acorn-jsx": "^5.1.0",
-						"eslint-visitor-keys": "^1.1.0"
-					}
-				},
-				"esprima": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-					"dev": true
-				},
-				"esquery": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-					"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
-					"dev": true,
-					"requires": {
-						"estraverse": "^4.0.0"
-					}
-				},
-				"esrecurse": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-					"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-					"dev": true,
-					"requires": {
-						"estraverse": "^4.1.0"
-					}
-				},
-				"estraverse": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-					"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-					"dev": true
-				},
-				"esutils": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-					"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-					"dev": true
-				},
-				"external-editor": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-					"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-					"dev": true,
-					"requires": {
-						"chardet": "^0.7.0",
-						"iconv-lite": "^0.4.24",
-						"tmp": "^0.0.33"
-					}
-				},
-				"fast-deep-equal": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-					"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
-					"dev": true
-				},
-				"fast-json-stable-stringify": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-					"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-					"dev": true
-				},
-				"fast-levenshtein": {
-					"version": "2.0.6",
-					"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-					"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-					"dev": true
-				},
-				"figures": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-					"integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
-					"dev": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.5"
-					}
-				},
-				"file-entry-cache": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-					"dev": true,
-					"requires": {
-						"flat-cache": "^2.0.1"
-					}
-				},
-				"flat-cache": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-					"dev": true,
-					"requires": {
-						"flatted": "^2.0.0",
-						"rimraf": "2.6.3",
-						"write": "1.0.3"
-					}
-				},
-				"flatted": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-					"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
-					"dev": true
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-					"dev": true
-				},
-				"functional-red-black-tree": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-					"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-					"dev": true
-				},
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"glob-parent": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-					"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-					"dev": true,
-					"requires": {
-						"is-glob": "^4.0.1"
-					}
-				},
-				"globals": {
-					"version": "12.3.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-					"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"ignore": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-					"dev": true
-				},
-				"import-fresh": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
-					"dev": true,
-					"requires": {
-						"parent-module": "^1.0.0",
-						"resolve-from": "^4.0.0"
-					}
-				},
-				"imurmurhash": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-					"dev": true
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"dev": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-					"dev": true
-				},
-				"inquirer": {
-					"version": "7.0.4",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
-					"integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
-					"dev": true,
-					"requires": {
-						"ansi-escapes": "^4.2.1",
-						"chalk": "^2.4.2",
-						"cli-cursor": "^3.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^3.0.3",
-						"figures": "^3.0.0",
-						"lodash": "^4.17.15",
-						"mute-stream": "0.0.8",
-						"run-async": "^2.2.0",
-						"rxjs": "^6.5.3",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^5.1.0",
-						"through": "^2.3.6"
-					}
-				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-promise": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-					"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-					"dev": true
-				},
-				"isexe": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-					"dev": true
-				},
-				"js-tokens": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-					"dev": true
-				},
-				"js-yaml": {
-					"version": "3.13.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-					"dev": true,
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
-				"json-schema-traverse": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-					"dev": true
-				},
-				"json-stable-stringify-without-jsonify": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-					"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-					"dev": true
-				},
-				"levn": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-					"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-					"dev": true,
-					"requires": {
-						"prelude-ls": "~1.1.2",
-						"type-check": "~0.3.2"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				},
-				"mimic-fn": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-					"dev": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-					"dev": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
-				"mute-stream": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-					"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-					"dev": true
-				},
-				"natural-compare": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-					"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-					"dev": true
-				},
-				"nice-try": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-					"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-					"dev": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"dev": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"onetime": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-					"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
-					}
-				},
-				"optionator": {
-					"version": "0.8.3",
-					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-					"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-					"dev": true,
-					"requires": {
-						"deep-is": "~0.1.3",
-						"fast-levenshtein": "~2.0.6",
-						"levn": "~0.3.0",
-						"prelude-ls": "~1.1.2",
-						"type-check": "~0.3.2",
-						"word-wrap": "~1.2.3"
-					}
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-					"dev": true
-				},
-				"parent-module": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-					"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-					"dev": true,
-					"requires": {
-						"callsites": "^3.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-					"dev": true
-				},
-				"path-key": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-					"dev": true
-				},
-				"prelude-ls": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-					"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-					"dev": true
-				},
-				"progress": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-					"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-					"dev": true
-				},
-				"punycode": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-					"dev": true
-				},
-				"regexpp": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-					"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
-					"dev": true
-				},
-				"resolve-from": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-					"dev": true
-				},
-				"restore-cursor": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-					"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-					"dev": true,
-					"requires": {
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"run-async": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-					"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-					"dev": true,
-					"requires": {
-						"is-promise": "^2.1.0"
-					}
-				},
-				"rxjs": {
-					"version": "6.5.4",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
-					"integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.9.0"
-					}
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-					"dev": true
 				},
 				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"shebang-command": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
 					"dev": true,
 					"requires": {
-						"shebang-regex": "^1.0.0"
+						"lru-cache": "^6.0.0"
 					}
 				},
-				"shebang-regex": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-					"dev": true
-				},
-				"slice-ansi": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-					"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"astral-regex": "^1.0.0",
-						"is-fullwidth-code-point": "^2.0.0"
-					},
-					"dependencies": {
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-							"dev": true
-						}
-					}
-				},
-				"sprintf-js": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					},
-					"dependencies": {
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						}
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-							"dev": true
-						}
-					}
-				},
-				"strip-json-comments": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"table": {
-					"version": "5.4.6",
-					"resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-					"integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
-					"dev": true,
-					"requires": {
-						"ajv": "^6.10.2",
-						"lodash": "^4.17.14",
-						"slice-ansi": "^2.1.0",
-						"string-width": "^3.0.0"
-					},
-					"dependencies": {
-						"emoji-regex": {
-							"version": "7.0.3",
-							"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-							"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-							"dev": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-							"dev": true
-						},
-						"string-width": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-							"dev": true,
-							"requires": {
-								"emoji-regex": "^7.0.1",
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^5.1.0"
-							}
-						}
-					}
-				},
-				"text-table": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-					"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-					"dev": true
-				},
-				"through": {
-					"version": "2.3.8",
-					"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-					"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-					"dev": true
-				},
-				"tmp": {
-					"version": "0.0.33",
-					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-					"dev": true,
-					"requires": {
-						"os-tmpdir": "~1.0.2"
-					}
-				},
-				"tslib": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-					"dev": true
-				},
-				"type-check": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-					"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-					"dev": true,
-					"requires": {
-						"prelude-ls": "~1.1.2"
-					}
-				},
-				"type-fest": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-					"dev": true
-				},
-				"uri-js": {
-					"version": "4.2.2",
-					"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-					"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-					"dev": true,
-					"requires": {
-						"punycode": "^2.1.0"
-					}
-				},
-				"v8-compile-cache": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-					"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
-					"dev": true
-				},
-				"which": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				},
-				"word-wrap": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-					"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-					"dev": true
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true
-				},
-				"write": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-					"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-					"dev": true,
-					"requires": {
-						"mkdirp": "^0.5.1"
-					}
 				}
 			}
 		},
 		"eslint-config-standard": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
-			"integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
+			"integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
 			"dev": true
 		},
 		"eslint-import-resolver-node": {
@@ -1701,9 +1075,9 @@
 			}
 		},
 		"eslint-plugin-es": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz",
-			"integrity": "sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+			"integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
 			"dev": true,
 			"requires": {
 				"eslint-utils": "^2.0.0",
@@ -1742,9 +1116,9 @@
 			}
 		},
 		"eslint-plugin-node": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.0.0.tgz",
-			"integrity": "sha512-chUs/NVID+sknFiJzxoN9lM7uKSOEta8GC8365hw1nDfwIPIjjpRSwwPvQanWv8dt/pDe9EV4anmVSwdiSndNg==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+			"integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
 			"dev": true,
 			"requires": {
 				"eslint-plugin-es": "^3.0.0",
@@ -1755,6 +1129,12 @@
 				"semver": "^6.1.0"
 			},
 			"dependencies": {
+				"ignore": {
+					"version": "5.1.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+					"dev": true
+				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1775,19 +1155,102 @@
 			"integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
 			"dev": true
 		},
+		"eslint-scope": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"dev": true,
+			"requires": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^4.1.1"
+			}
+		},
 		"eslint-utils": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-			"integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+			"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
 			"dev": true,
 			"requires": {
 				"eslint-visitor-keys": "^1.1.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+					"dev": true
+				}
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+			"integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+			"dev": true
+		},
+		"espree": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+			"integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+			"dev": true,
+			"requires": {
+				"acorn": "^7.4.0",
+				"acorn-jsx": "^5.3.1",
+				"eslint-visitor-keys": "^1.3.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+					"dev": true
+				}
+			}
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
+		},
+		"esquery": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"dev": true,
+			"requires": {
+				"estraverse": "^5.1.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				}
+			}
+		},
+		"esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
+			"requires": {
+				"estraverse": "^5.2.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+					"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+					"dev": true
+				}
+			}
+		},
+		"estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true
 		},
 		"esutils": {
@@ -1874,14 +1337,29 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"file-entry-cache": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+			"dev": true,
+			"requires": {
+				"flat-cache": "^3.0.4"
+			}
 		},
 		"filename-reserved-regex": {
 			"version": "2.0.0",
@@ -1889,9 +1367,9 @@
 			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
 		},
 		"filenamify": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.1.0.tgz",
-			"integrity": "sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.2.0.tgz",
+			"integrity": "sha512-pkgE+4p7N1n7QieOopmn3TqJaefjdWXwEkj2XLZJLKfOgcQKkn11ahvGNgTD8mLggexLiDFQxeTs14xVU22XPA==",
 			"requires": {
 				"filename-reserved-regex": "^2.0.0",
 				"strip-outer": "^1.0.1",
@@ -1930,6 +1408,22 @@
 			"requires": {
 				"locate-path": "^2.0.0"
 			}
+		},
+		"flat-cache": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+			"dev": true,
+			"requires": {
+				"flatted": "^3.1.0",
+				"rimraf": "^3.0.2"
+			}
+		},
+		"flatted": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+			"integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+			"dev": true
 		},
 		"follow-redirects": {
 			"version": "1.5.10",
@@ -1984,10 +1478,22 @@
 				"universalify": "^0.1.0"
 			}
 		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
 		"gaxios": {
@@ -2030,12 +1536,44 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
-		"globalize": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/globalize/-/globalize-1.4.2.tgz",
-			"integrity": "sha512-IfKeYI5mAITBmT5EnH8kSQB5uGson4Fkj2XtTpyEbIS7IHNfLHoeTyLJ6tfjiKC6cJXng3IhVurDk5C7ORqFhQ==",
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
 			"requires": {
-				"cldrjs": "^0.5.0"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"requires": {
+				"is-glob": "^4.0.1"
+			}
+		},
+		"globalize": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/globalize/-/globalize-1.6.0.tgz",
+			"integrity": "sha512-MTuAU3Tnbtga8PvxbpSPdQNIs6K5UdATWIuarWJK2Z3e1DghXpxb/GmShSVagzHqCOYgZr7N/Hi7D1mrHG30jQ==",
+			"requires": {
+				"cldrjs": "^0.5.4"
+			}
+		},
+		"globals": {
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+			"dev": true,
+			"requires": {
+				"type-fest": "^0.8.1"
 			}
 		},
 		"google-auth-library": {
@@ -2145,11 +1683,11 @@
 			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 			"requires": {
-				"ajv": "^6.5.5",
+				"ajv": "^6.12.3",
 				"har-schema": "^2.0.0"
 			}
 		},
@@ -2161,6 +1699,12 @@
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"has-symbols": {
 			"version": "1.0.1",
@@ -2236,10 +1780,36 @@
 			}
 		},
 		"ignore": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-			"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
 			"dev": true
+		},
+		"import-fresh": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+			"dev": true,
+			"requires": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
 		},
 		"inherits": {
 			"version": "2.0.1",
@@ -2273,6 +1843,27 @@
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
 			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
 			"dev": true
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true
+		},
+		"is-glob": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+			"dev": true,
+			"requires": {
+				"is-extglob": "^2.1.1"
+			}
 		},
 		"is-regex": {
 			"version": "1.0.5",
@@ -2309,10 +1900,32 @@
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 			"dev": true
 		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
 		},
 		"jsbn": {
 			"version": "0.1.1",
@@ -2329,6 +1942,12 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
+		"json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
+		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -2343,11 +1962,11 @@
 			}
 		},
 		"jsonwebtoken": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
-			"integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+			"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
 			"requires": {
-				"jws": "^3.1.4",
+				"jws": "^3.2.2",
 				"lodash.includes": "^4.3.0",
 				"lodash.isboolean": "^3.0.3",
 				"lodash.isinteger": "^4.0.4",
@@ -2355,8 +1974,15 @@
 				"lodash.isplainobject": "^4.0.6",
 				"lodash.isstring": "^4.0.1",
 				"lodash.once": "^4.0.0",
-				"ms": "^2.0.0",
-				"xtend": "^4.0.1"
+				"ms": "^2.1.1",
+				"semver": "^5.6.0"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+				}
 			}
 		},
 		"jsprim": {
@@ -2387,6 +2013,16 @@
 			"requires": {
 				"jwa": "^1.4.1",
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"levn": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
 			}
 		},
 		"load-json-file": {
@@ -2420,9 +2056,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"lodash.escaperegexp": {
 			"version": "4.1.2",
@@ -2479,6 +2115,12 @@
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
 			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
 		},
+		"lodash.set": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+			"dev": true
+		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -2523,16 +2165,16 @@
 			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 		},
 		"mime-db": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+			"integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
 		},
 		"mime-types": {
-			"version": "2.1.26",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+			"version": "2.1.29",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+			"integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
 			"requires": {
-				"mime-db": "1.43.0"
+				"mime-db": "1.46.0"
 			}
 		},
 		"minimatch": {
@@ -2550,14 +2192,32 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"mustache": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/mustache/-/mustache-3.2.1.tgz",
-			"integrity": "sha512-RERvMFdLpaFfSRIEe632yDm5nsd0SDKn8hGmcUwswnyiE5mtdZLDybtHAz6hjJhawokF0hXvGLtx9mrQfm6FkA=="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.1.0.tgz",
+			"integrity": "sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ=="
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"negotiator": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
 			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+		},
+		"nock": {
+			"version": "13.0.11",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-13.0.11.tgz",
+			"integrity": "sha512-sKZltNkkWblkqqPAsjYW0bm3s9DcHRPiMOyKO/PkfJ+ANHZ2+LA2PLe22r4lLrKgXaiSaDQwW3qGsJFtIpQIeQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash.set": "^4.3.2",
+				"propagate": "^2.0.0"
+			}
 		},
 		"node-fetch": {
 			"version": "2.6.0",
@@ -2635,6 +2295,29 @@
 				"ee-first": "1.1.1"
 			}
 		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"optionator": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+			"dev": true,
+			"requires": {
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.3"
+			}
+		},
 		"p-limit": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -2658,6 +2341,15 @@
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
 			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 			"dev": true
+		},
+		"parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0"
+			}
 		},
 		"parse-json": {
 			"version": "2.2.0",
@@ -2686,6 +2378,18 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
 			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
 		"path-parse": {
@@ -2735,10 +2439,28 @@
 				"find-up": "^2.1.0"
 			}
 		},
+		"prelude-ls": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"dev": true
+		},
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
 			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+		},
+		"progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true
+		},
+		"propagate": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+			"integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+			"dev": true
 		},
 		"proxy-addr": {
 			"version": "2.0.6",
@@ -2750,9 +2472,9 @@
 			}
 		},
 		"psl": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-			"integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
 		},
 		"punycode": {
 			"version": "2.1.1",
@@ -2802,9 +2524,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
-			"integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
 			"dev": true
 		},
 		"request": {
@@ -2846,6 +2568,12 @@
 				}
 			}
 		},
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true
+		},
 		"resolve": {
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
@@ -2855,10 +2583,25 @@
 				"path-parse": "^1.0.6"
 			}
 		},
+		"resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"dev": true
+		},
 		"retry-axios": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.2.tgz",
 			"integrity": "sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ=="
+		},
+		"rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
 		},
 		"rsa-pem-from-mod-exp": {
 			"version": "0.8.4",
@@ -2943,6 +2686,58 @@
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
 			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
 		},
+		"shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "^3.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true
+		},
+		"slice-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				}
+			}
+		},
 		"spdx-correct": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -2975,6 +2770,12 @@
 			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
 			"dev": true
 		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
 		"sshpk": {
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -2996,6 +2797,17 @@
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
 		},
+		"string-width": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+			"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+			"dev": true,
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.0"
+			}
+		},
 		"string.prototype.trimleft": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
@@ -3016,10 +2828,25 @@
 				"function-bind": "^1.1.1"
 			}
 		},
+		"strip-ansi": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^5.0.0"
+			}
+		},
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
 			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
+		},
+		"strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true
 		},
 		"strip-outer": {
@@ -3029,6 +2856,53 @@
 			"requires": {
 				"escape-string-regexp": "^1.0.2"
 			}
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"table": {
+			"version": "6.0.7",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
+			"integrity": "sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==",
+			"dev": true,
+			"requires": {
+				"ajv": "^7.0.2",
+				"lodash": "^4.17.20",
+				"slice-ansi": "^4.0.0",
+				"string-width": "^4.2.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "7.2.1",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.1.tgz",
+					"integrity": "sha512-+nu0HDv7kNSOua9apAVc979qd932rrZeb3WOvoiD31A/p1mIE5/9bN2027pE2rOPYEdS3UHzsvof4hY+lM9/WQ==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"json-schema-traverse": "^1.0.0",
+						"require-from-string": "^2.0.2",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true
+				}
+			}
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"toidentifier": {
 			"version": "1.0.0",
@@ -3053,9 +2927,14 @@
 			}
 		},
 		"tslib": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"tunnel": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -3070,6 +2949,21 @@
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
+		"type-check": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "^1.2.1"
+			}
+		},
+		"type-fest": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"dev": true
+		},
 		"type-is": {
 			"version": "1.6.18",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -3080,9 +2974,9 @@
 			}
 		},
 		"underscore": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-			"integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
+			"integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ=="
 		},
 		"universalify": {
 			"version": "0.1.2",
@@ -3095,9 +2989,9 @@
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
 		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -3124,6 +3018,12 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
 			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+		},
+		"v8-compile-cache": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+			"dev": true
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -3158,6 +3058,21 @@
 				"wrap-fn": "^0.1.0"
 			}
 		},
+		"which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"word-wrap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"dev": true
+		},
 		"wrap-fn": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
@@ -3166,10 +3081,16 @@
 				"co": "3.1.0"
 			}
 		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
 		"ws": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+			"integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
 		},
 		"xml2js": {
 			"version": "0.4.23",
@@ -3186,9 +3107,9 @@
 			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
 		},
 		"xmldom": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-			"integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g=="
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+			"integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
 		},
 		"xpath.js": {
 			"version": "1.1.0",

--- a/packages/botbuilder-adapter-hangouts/package.json
+++ b/packages/botbuilder-adapter-hangouts/package.json
@@ -35,9 +35,11 @@
   },
   "dependencies": {
     "botbuilder": "^4.10.1",
-    "googleapis": "^34.0.0",
     "botkit": "^4.10.0",
-    "debug": "^4.1.0"
+    "cross-fetch": "^3.0.6",
+    "debug": "^4.1.0",
+    "googleapis": "^34.0.0",
+    "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {
     "eslint": "^7.7.0",
@@ -45,6 +47,7 @@
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.0.1"
+    "eslint-plugin-standard": "^4.0.1",
+    "nock": "^13.0.11"
   }
 }

--- a/packages/botbuilder-adapter-hangouts/readme.md
+++ b/packages/botbuilder-adapter-hangouts/readme.md
@@ -37,7 +37,7 @@ Developers can then bind to Botkit's event emitting system using `controller.on`
 
 ```javascript
 const adapter = new HangoutsAdapter({
-    token: process.env.GOOGLE_TOKEN,
+    project_number: process.env.GOOGLE_PROJECT_NUMBER,
     google_auth_params: {
         credentials: process.env.GOOGLE_CREDS
     }
@@ -59,7 +59,7 @@ Alternately, developers may choose to use `HangoutsAdapter` with BotBuilder. Wit
 
 ```javascript
 const adapter = new HangoutsAdapter({
-    token: process.env.GOOGLE_TOKEN,
+    project_number: process.env.GOOGLE_PROJECT_NUMBER,
     google_auth_params: {
         credentials: process.env.GOOGLE_CREDS
     }

--- a/packages/botbuilder-adapter-hangouts/src/index.ts
+++ b/packages/botbuilder-adapter-hangouts/src/index.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './hangouts_adapter';
+export * from './request_validator';

--- a/packages/botbuilder-adapter-hangouts/src/request_validator.ts
+++ b/packages/botbuilder-adapter-hangouts/src/request_validator.ts
@@ -1,0 +1,72 @@
+import fetch from 'cross-fetch';
+import { decode, verify } from 'jsonwebtoken';
+
+const issuer = 'chat@system.gserviceaccount.com';
+
+export class RequestValidator {
+    private url: string;
+    private expiresAt: Date;
+
+    private certificates: {[key: string]: string};
+
+    public constructor() {
+        this.url = `https://www.googleapis.com/service_accounts/v1/metadata/x509/${ issuer }`;
+        this.expiresAt = new Date();
+    }
+
+    /**
+     * Verifies that the token from the request infact was issued by Google.
+     * If we are unable to verify a token for any reason (malformed, expired, invalid) we
+     * return false.
+     * TODO: Replace this with an official implementation from googleapis if it becomes available.
+     * @param request A request object from Restify or Express
+     * @param audience The intended audience of the jwt token. i.e. project number
+     */
+    public async isValid(request: any, audience: string): Promise<boolean> {
+        if (!('authorization' in request.headers)) return false;
+
+        try {
+            const token = request.get('authorization').match(/bearer (.*)/i)[1];
+            const decodedToken: any = decode(token, { complete: true });
+            const certificate = await this.getCertificate(decodedToken?.header?.kid);
+            const verifiedToken: any = verify(token, certificate);
+            return verifiedToken?.aud === audience && verifiedToken?.iss === issuer;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    /**
+     * Gets the certificate associated with the provided kid from the google certificates
+     * endpoint.
+     *
+     * @param kid The kid associated with the certificate we with to retrieve.
+     */
+    private async getCertificate(kid: string): Promise<string> {
+        if (this.hasExpired()) {
+            await this.refresh();
+        }
+
+        return this.certificates[kid];
+    }
+
+    /**
+     * Refresh the local certificates cache with fresh certificates from google.
+     */
+    private async refresh(): Promise<void> {
+        const response = await fetch(this.url);
+        this.certificates = JSON.parse(await response.text());
+
+        if (response.headers.has('expires')) {
+            this.expiresAt = new Date(response.headers.get('expires'));
+        }
+    }
+
+    /**
+     * Determines if the certificates we've cached are about to expire forcing
+     * us to refresh them.
+     */
+    private hasExpired(): boolean {
+        return this.expiresAt.getDate() < (new Date()).getDate() + 1;
+    }
+}

--- a/packages/botbuilder-adapter-hangouts/tests/HangoutsAdapter.tests.js
+++ b/packages/botbuilder-adapter-hangouts/tests/HangoutsAdapter.tests.js
@@ -2,7 +2,6 @@ const assert = require('assert');
 const { HangoutsAdapter } = require('../');
 
 describe('HangoutsAdapter', function() {
-
     let adapter;
 
     // beforeEach(function () {
@@ -11,12 +10,11 @@ describe('HangoutsAdapter', function() {
     //     });
     // });
 
-    it('should not construct without required parameters', function () {
-        assert.throws(function () { let adapter = new HangoutsAdapter({}) }, 'Foo');
+    it('should not require construction parameters', function() {
+        assert.doesNotThrow(() => new HangoutsAdapter({}), 'Foo');
     });
 
     // it('should create a HangoutsAdapter object', function () {
     //     assert((adapter instanceof HangoutsAdapter), 'Adapter is wrong type');
     // });
-
 });

--- a/packages/botbuilder-adapter-hangouts/tests/RequestValidator.tests.js
+++ b/packages/botbuilder-adapter-hangouts/tests/RequestValidator.tests.js
@@ -1,0 +1,297 @@
+const { RequestValidator } = require('../');
+
+const assert = require('assert');
+const httpMocks = require('node-mocks-http');
+const { sign } = require('jsonwebtoken');
+const nock = require('nock');
+
+const certificate = `-----BEGIN CERTIFICATE-----
+MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+-----END CERTIFICATE-----`;
+
+const key = `-----BEGIN RSA PRIVATE KEY-----
+MIIJKQIBAAKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrck2dNYMNPjcOK
+ABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZyTKUb4/GUgaf
+RQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBXRrX0Dq4XyApN
+ku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6q4Ag/u5rl8NJ
+fXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2uB3KiO4JrUYv
+t2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4SvMq1xtLg2bNo
+PC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o6T2pGZrwbQui
+FGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4Qyo9KqjMIPwn
+XZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiFz2FAHwfopwaH
+35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1SpvQ41/ueBjl
+unExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3Zsez95kCAwEA
+AQKCAgBymEHxouau4z6MUlisaOn/Ej0mVi/8S1JrqakgDB1Kj6nTRzhbOBsWKJBR
+PzTrIv5aIqYtvJwQzrDyGYcHMaEpNpg5Rz716jPGi5hAPRH+7pyHhO/Watv4bvB+
+lCjO+O+v12+SDC1U96+CaQUFLQSw7H/7vfH4UsJmhvX0HWSSWFzsZRCiklOgl1/4
+vlNgB7MU/c7bZLyor3ZuWQh8Q6fgRSQj0kp1T/78RrwDl8r7xG4gW6vj6F6m+9bg
+ro5Zayu3qxqJhWVvR3OPvm8pVa4hIJR5J5Jj3yZNOwdOX/Saiv6tEx7MvB5bGQlC
+6co5SIEPPZ/FNC1Y/PNOWrb/Q4GW1AScdICZu7wIkKzWAJCo59A8Luv5FV8vm4R2
+4JkyB6kXcVfowrjYXqDF/UX0ddDLLGF96ZStte3PXX8PQWY89FZuBkGw6NRZInHi
+xinN2V8cm7Cw85d9Ez2zEGB4KC7LI+JgLQtdg3XvbdfhOi06eGjgK2mwfOqT8Sq+
+v9POIJXTNEI3fi3dB86af/8OXRtOrAa1mik2msDI1Goi7cKQbC3fz/p1ISQCptvs
+YvNwstDDutkA9o9araQy5b0LC6w5k+CSdVNbd8O2EUd0OBOUjblHKvdZ3Voz8EDF
+ywYimmNGje1lK8nh2ndpja5q3ipDs1hKg5UujoGfei2gn0ch5QKCAQEA8O+IHOOu
+T/lUgWspophE0Y1aUJQPqgK3EiKB84apwLfz2eAPSBff2dCN7Xp6s//u0fo41LE5
+P0ds/5eu9PDlNF6HH5H3OYpV/57v5O2OSBQdB/+3TmNmQGYJCSzouIS3YNOUPQ1z
+FFvRateN91BW7wKFHr0+M4zG6ezfutAQywWNoce7oGaYTT8z/yWXqmFidDqng5w5
+6d8t40ScozIVacGug+lRi8lbTC+3Tp0r+la66h49upged3hFOvGXIOybvYcE98K2
+GpNl9cc4q6O1WLdR7QC91ZNflKOKE8fALLZ/stEXL0p2bixbSnbIdxOEUch/iQhM
+chxlsRFLjxV1dwKCAQEA60X6LyefIlXzU3PA+gIRYV0g8FOxzxXfvqvYeyOGwDaa
+p/Ex50z76jIJK8wlW5Ei7U6xsxxw3E9DLH7Sf3H4KiGouBVIdcv9+IR0LcdYPR9V
+oCQ1Mm5a7fjnm/FJwTokdgWGSwmFTH7/jGcNHZ8lumlRFCj6VcLT/nRxM6dgIXSo
+w1D9QGC9V+e6KOZ6VR5xK0h8pOtkqoGrbFLu26GPBSuguPJXt0fwJt9PAG+6VvxJ
+89NLML/n+g2/jVKXhfTT1Mbb3Fx4lnbLnkP+JrvYIaoQ1PZNggILYCUGJJTLtqOT
+gkg1S41/X8EFg671kAB6ZYPbd5WnL14Xp0a9MOB/bwKCAQEA6WVAl6u/al1/jTdA
+R+/1ioHB4Zjsa6bhrUGcXUowGy6XnJG+e/oUsS2kr04cm03sDaC1eOSNLk2Euzw3
+EbRidI61mtGNikIF+PAAN+YgFJbXYK5I5jjIDs5JJohIkKaP9c5AJbxnpGslvLg/
+IDrFXBc22YY9QTa4YldCi/eOrP0eLIANs95u3zXAqwPBnh1kgG9pYsbuGy5Fh4kp
+q7WSpLYo1kQo6J8QQAdhLVh4B7QIsU7GQYGm0djCR81Mt2o9nCW1nEUUnz32YVay
+ASM/Q0eip1I2kzSGPLkHww2XjjjkD1cZfIhHnYZ+kO3sV92iKo9tbFOLqmbz48l7
+RoplFQKCAQEA6i+DcoCL5A+N3tlvkuuQBUw/xzhn2uu5BP/kwd2A+b7gfp6Uv9lf
+P6SCgHf6D4UOMQyN0O1UYdb71ESAnp8BGF7cpC97KtXcfQzK3+53JJAWGQsxcHts
+Q0foss6gTZfkRx4EqJhXeOdI06aX5Y5ObZj7PYf0dn0xqyyYqYPHKkYG3jO1gelJ
+T0C3ipKv3h4pI55Jg5dTYm0kBvUeELxlsg3VM4L2UNdocikBaDvOTVte+Taut12u
+OLaKns9BR/OFD1zJ6DSbS5n/4A9p4YBFCG1Rx8lLKUeDrzXrQWpiw+9amunpMsUr
+rlJhfMwgXjA7pOR1BjmOapXMEZNWKlqsPQKCAQByVDxIwMQczUFwQMXcu2IbA3Z8
+Czhf66+vQWh+hLRzQOY4hPBNceUiekpHRLwdHaxSlDTqB7VPq+2gSkVrCX8/XTFb
+SeVHTYE7iy0Ckyme+2xcmsl/DiUHfEy+XNcDgOutS5MnWXANqMQEoaLW+NPLI3Lu
+V1sCMYTd7HN9tw7whqLg18wB1zomSMVGT4DkkmAzq4zSKI1FNYp8KA3OE1Emwq+0
+wRsQuawQVLCUEP3To6kYOwTzJq7jhiUK6FnjLjeTrNQSVdoqwoJrlTAHgXVV3q7q
+v3TGd3xXD9yQIjmugNgxNiwAZzhJs/ZJy++fPSJ1XQxbd9qPghgGoe/ff6G7
+-----END RSA PRIVATE KEY-----`;
+
+const invalidCertificate = `-----BEGIN CERTIFICATE-----
+MIIGJzCCBA+gAwIBAgIBAzANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTA1NDUzWhcNMjIwNDI1MTA1
+NDUzWjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWNhcm9s
+MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+9w0BAQEFAAOCAg8AMIICCgKCAgEA18CnxulIxFNAs3bZLzcoPaPEQtB2zQibUOMc
+UeUUcvoroLEGI/PBrZJ8ef4VVNHlZ2La7YGqfuKxUKn72CkJ2oRNPPRuE6sL1e6A
+YzJ9V6+DPBwn7exn1v0cEy1Av9Hav3q2Z36wdTttYZ3MbBqX8Vben4DTFmC7im9G
+m740dcNM0vHI8z6YKDDkyy0lYWJIvi7c7ZCTrnS3+klDZSCsjv5SbACOUT62msZP
+RBx7hBe9XPY26UyRiW9OrawQQcXFZYogyPcno+qsW3QJmSeIYMdEaRgMMhp38kdT
+RuMSxWmVRRWaFGB2IKe1jFG/WlcZWseovAvEMMoL5tD4xKiE2SSikvaE8hPqpJOX
+/u132C91eiw5iDxEVgrvElfVno81jn+E5xrRGY0j27XOxX/hiG0E1gHe8HI+UZUd
+TzC2MgoPhLUANOS/gHEQYhTBMlqppt7CWOhS62ZauF7CBnymajPyHopBB1O7a0GS
+WYV5BKnfVkzgYh6Yh5UHsRBJNJyQTAuDJSefASf70MRuUMz1AkcsRZox5c59ho/b
+/YPqpgBJcRREoY6duqSkz50VIC1ndkKBY6J2Tksitd492PjgQ3+jEPBz+27hajeZ
+3IejBUwp9WMUm+ujOpsrtFH1BQPeQeXLGo5260eTU5BxxY+GX54LTTOcPIiKkJ+Q
+pjWQgfECAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFLVdDU9V9nUaI7P1jLxr
+WraWbK7gMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+DQEBBQUAA4ICAQC/P+cWorqxz9Z584TtpRA+YEIO1RrG6bE5hlou3a62txYzMxc+
+g/eh97QbCXSPmw2OTMeh1mZsAjq18nKqyeSzxp1uwEjcOSEwGKBvywm+3g9jgwQy
+c6e8QjS3odwhIQiGZbwuxXiu+/6r+4uFv2Hg4qpSXx4NGSITlHq0vVwwjUMitOkT
+Yn4+9eJ6KjvaH1dKXbhsTPVuNLm9tB/ciNAoIKIMMeh/OiO4YEjITuECYq4A+9Cl
+dsvq89d1DZ5WSMEuRMcMnwOzrJbFoqAGnivD67UEFTN5Sp4olB0oUJjj67V0aX9p
+vGFy0YrM+4m+UTSBEXv6is/nv4GRNBoRY5JB62J9eipaK6OFNls5CEBrDby37TZC
+YEXuDCfxQTie25mPD/8b6gKYnxkhM8qiR4nLHalMlLY9suK/HfcSjQH/d9ZyZXDK
+gI6iLXgMsp2EOlD56I6FA1jrCtNb01XQvX3eyFuA6g5T1jWGYBDtvQb0WRVkdUy9
+L/uK+sHQwtloCSuakcQAsWV9bajCQtHX8XGu25Yz56kpJ/OJjcishxT6pc/sthum
+A5PX739JsNUi/p5aG+H/6eNx+ukJP7QaM646YCfS5i8S9DJUvim+/BSlKi2ZiOCd
+0MYH4Xb7lmAOTNmTvSYpKo9J2fZ9erw0MYSBTyjh6F7PRbHBiivgUnJfGQ==
+-----END CERTIFICATE-----`;
+
+const algorithm = 'RS256';
+
+describe('RequestValidator', () => {
+    let validator;
+
+    beforeEach(() => {
+        validator = new RequestValidator();
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    describe('isValid', () => {
+        it('should not be valid when the request does not have an authorization header', async () => {
+            const request = httpMocks.createRequest();
+            assert.strictEqual(await validator.isValid(request, ''), false);
+        });
+
+        it('should not be valid when there are no certificates', async () => {
+            const request = httpMocks.createRequest({
+                headers: {
+                    authorization: `Bearer ${ sign({}, key, { algorithm }) }`
+                }
+            });
+            assert.strictEqual(await validator.isValid(request, ''), false);
+        });
+
+        it('should not be valid when there is no public certificate corresponding to the kid', async () => {
+            nock('https://www.googleapis.com/service_accounts/v1/metadata/x509')
+                .get('/chat@system.gserviceaccount.com')
+                .reply(200, JSON.stringify({
+                    not_kid: certificate
+                }));
+
+            const request = httpMocks.createRequest({
+                headers: {
+                    authorization: `Bearer ${ sign({}, key, { algorithm, header: { kid: 'kid' } }) }`
+                }
+            });
+            assert.strictEqual(await validator.isValid(request, ''), false);
+        });
+
+        it('should not be valid when the certificate cannot verify the token', async () => {
+            nock('https://www.googleapis.com/service_accounts/v1/metadata/x509')
+                .get('/chat@system.gserviceaccount.com')
+                .reply(200, JSON.stringify({
+                    kid: invalidCertificate
+                }));
+
+            const request = httpMocks.createRequest({
+                headers: {
+                    authorization: `Bearer ${ sign({}, key, { algorithm, audience: 'audience', issuer: 'chat@system.gserviceaccount.com', header: { kid: 'kid' } }) }`
+                }
+            });
+            assert.strictEqual(await validator.isValid(request, 'audience'), false);
+        });
+
+        it('should not be valid when the token has expired', async () => {
+            nock('https://www.googleapis.com/service_accounts/v1/metadata/x509')
+                .get('/chat@system.gserviceaccount.com')
+                .reply(200, JSON.stringify({
+                    kid: certificate
+                }));
+
+            const request = httpMocks.createRequest({
+                headers: {
+                    authorization: `Bearer ${ sign({}, key, { algorithm, audience: 'audience', issuer: 'chat@system.gserviceaccount.com', expiresIn: '0', header: { kid: 'kid' } }) }`
+                }
+            });
+            assert.strictEqual(await validator.isValid(request, 'audience'), false);
+        });
+
+        it('should not be valid when the audience does not match', async () => {
+            nock('https://www.googleapis.com/service_accounts/v1/metadata/x509')
+                .get('/chat@system.gserviceaccount.com')
+                .reply(200, JSON.stringify({
+                    kid: certificate
+                }));
+
+            const request = httpMocks.createRequest({
+                headers: {
+                    authorization: `Bearer ${ sign({}, key, { algorithm, audience: 'wrong_audience', issuer: 'chat@system.gserviceaccount.com', expiresIn: '0', header: { kid: 'kid' } }) }`
+                }
+            });
+            assert.strictEqual(await validator.isValid(request, 'audience'), false);
+        });
+
+        it('should not be valid when the issuer does not match', async () => {
+            nock('https://www.googleapis.com/service_accounts/v1/metadata/x509')
+                .get('/chat@system.gserviceaccount.com')
+                .reply(200, JSON.stringify({
+                    kid: certificate
+                }));
+
+            const request = httpMocks.createRequest({
+                headers: {
+                    authorization: `Bearer ${ sign({}, key, { algorithm, audience: 'audience', issuer: 'wrong_issuer', expiresIn: '0', header: { kid: 'kid' } }) }`
+                }
+            });
+            assert.strictEqual(await validator.isValid(request, 'audience'), false);
+        });
+
+        it('should be valid when the request is valid', async () => {
+            nock('https://www.googleapis.com/service_accounts/v1/metadata/x509')
+                .get('/chat@system.gserviceaccount.com')
+                .reply(200, JSON.stringify({
+                    kid: certificate
+                }));
+
+            const request = httpMocks.createRequest({
+                headers: {
+                    authorization: `Bearer ${ sign({}, key, { algorithm, audience: 'audience', issuer: 'chat@system.gserviceaccount.com', header: { kid: 'kid' } }) }`
+                }
+            });
+            assert.strictEqual(await validator.isValid(request, 'audience'), true);
+        });
+
+        it('should refresh the certificates if they have expired', async () => {
+            nock('https://www.googleapis.com/service_accounts/v1/metadata/x509')
+                .get('/chat@system.gserviceaccount.com')
+                .reply(200, JSON.stringify({
+                    kid: certificate
+                }))
+                .get('/chat@system.gserviceaccount.com')
+                .reply(200, JSON.stringify({
+                    kid: invalidCertificate
+                }));
+
+            const request = httpMocks.createRequest({
+                headers: {
+                    authorization: `Bearer ${ sign({}, key, { algorithm, audience: 'audience', issuer: 'chat@system.gserviceaccount.com', header: { kid: 'kid' } }) }`
+                }
+            });
+
+            assert.strictEqual(await validator.isValid(request, 'audience'), true);
+
+            // Fails with the second request where the certificate is no longer available
+            assert.strictEqual(await validator.isValid(request, 'audience'), false);
+        });
+
+        it('should not refresh the certificates if they have not expired', async () => {
+            nock('https://www.googleapis.com/service_accounts/v1/metadata/x509')
+                .get('/chat@system.gserviceaccount.com')
+                .reply(200, JSON.stringify({
+                    kid: certificate
+                }),
+                { expires: new Date((new Date()).getDate() + 1000) })
+                .get('/chat@system.gserviceaccount.com') // We never make this request
+                .reply(200, JSON.stringify({
+                    kid: invalidCertificate
+                }));
+
+            const request = httpMocks.createRequest({
+                headers: {
+                    authorization: `Bearer ${ sign({}, key, { algorithm, audience: 'audience', issuer: 'chat@system.gserviceaccount.com', header: { kid: 'kid' } }) }`
+                }
+            });
+
+            assert.strictEqual(await validator.isValid(request, 'audience'), true);
+
+            // Succeeds since the initial certificate has not yet expired
+            assert.strictEqual(await validator.isValid(request, 'audience'), true);
+        });
+    });
+});


### PR DESCRIPTION
Fixes: #1722

# Description

Updates the HangoutAdapter to drop the token based verification process for Google Chat messages. This upgrades the verification process to leverage the authorization token as described in the developer how-tos (https://developers.google.com/hangouts/chat/how-tos/bots-develop#verifying_bot_authenticity).

~I've included automated tests with this PR to verify the new functionality, however I was not able to to install my fork into a local project to test. If anyone could provide some guidance on how I could install my fork into a local project to verify my changes I would appreciate it.~

I managed to test this using a local npm registry. Messages with a bearer token that can be verified are processed by the hangouts adapter, those without are not.