### PR TITLE
Correct interruption and string pattern trigger to Exact String Match

### DIFF
--- a/packages/botkit/src/core.ts
+++ b/packages/botkit/src/core.ts
@@ -865,7 +865,7 @@ export class Botkit {
      */
     private async testTrigger(trigger: BotkitTrigger, message: BotkitMessage): Promise<boolean> {
         if (trigger.type === 'string') {
-            const test = new RegExp(trigger.pattern as string, 'i');
+            const test = new RegExp('^' + trigger.pattern + '$' as string, 'i');
             if (message.text && message.text.match(test)) {
                 return true;
             }


### PR DESCRIPTION
Very small change in core testTrigger but critical for precise bot dialog :

Problem :
`const test = new RegExp(trigger.pattern as string, 'i');` is always broad and do not let exact matching control

Solution :
`const test = new RegExp('^' + trigger.pattern + '$', 'i');` is the correction

Application :
As example that change correct Exact String Match functionality of Botkit CMS which is wrongly broad

![botkit pull](https://user-images.githubusercontent.com/6458346/114358654-d0206a00-9b7b-11eb-86b8-7742ed6ac22b.png)
