### PR TITLE
Slack Adapter - Prioritize User.id as From.Id

### DIFF
--- a/packages/botbuilder-adapter-slack/src/slack_adapter.ts
+++ b/packages/botbuilder-adapter-slack/src/slack_adapter.ts
@@ -540,7 +540,7 @@ export class SlackAdapter extends BotAdapter {
                         thread_ts: event.thread_ts,
                         team: event.team.id
                     },
-                    from: { id: event.bot_id ? event.bot_id : event.user.id },
+                    from: { id: event.user.id ?? event.bot_id },
                     recipient: { id: null },
                     channelData: event,
                     type: ActivityTypes.Event,


### PR DESCRIPTION
Parity: https://github.com/microsoft/botbuilder-dotnet/pull/5393

## Description
When the user presses a button in slack, the one sending the payload to the bot is the user not the bot.

## Specific Changes
- Swapped the priority of the id to pick to populate activity.from.id