### PR TITLE
Suppress Codesign Validation Injection

### DIFF
--- a/build/botkit-ci.yml
+++ b/build/botkit-ci.yml
@@ -12,6 +12,9 @@ pool:
 trigger: none # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
+variables:
+  runCodesignValidationInjection: false
+
 steps:
 - task: NodeTool@0
   inputs:

--- a/build/botkit-daily.yml
+++ b/build/botkit-daily.yml
@@ -130,7 +130,7 @@ steps:
   displayName: 'Generate Software Bill of Materials (SBOM)'
   inputs:
     BuildDropPath: '$(Build.ArtifactStagingDirectory)/drop'
-    PackageName: 'Microsoft Botkit'
+    PackageName: 'Botkit'
     PackageVersion: $(PackageVersion)
 
 - task: PublishBuildArtifacts@1

--- a/build/botkit-daily.yml
+++ b/build/botkit-daily.yml
@@ -14,6 +14,7 @@ pr: none # pr trigger is set in ADO
 
 variables:
   Packaging.EnableSBOMSigning: true
+  runCodesignValidationInjection: false
 #  PackageVersion: 4.16.0-dev.{DateStamp}.$(Build.BuildId) Define this in Azure to be settable at queue time.
 
 steps:


### PR DESCRIPTION
This is not relevant to Botkit and adds time to the builds.