### PR TITLE
Add direct_mention support to Webex Teams adapter

### DIFF
--- a/packages/botbuilder-adapter-webex/src/webex_adapter.ts
+++ b/packages/botbuilder-adapter-webex/src/webex_adapter.ts
@@ -506,7 +506,8 @@ export class WebexAdapter extends BotAdapter {
             if (activity.from.id === this.identity.id) {
                 activity.channelData.botkitEventType = 'self_message';
                 activity.type = ActivityTypes.Event;
-            } else if(activity.channelData.mentionedPeople.includes(this.identity.id)) {
+             } else if (activity.channelData.mentionedPeople && 
+                        activity.channelData.mentionedPeople.includes(this.identity.id)) {
                 // this is someone trying to talk to the bot
                 activity.channelData.botkitEventType = 'direct_mention';
             } else {

--- a/packages/botbuilder-adapter-webex/src/webex_adapter.ts
+++ b/packages/botbuilder-adapter-webex/src/webex_adapter.ts
@@ -506,6 +506,9 @@ export class WebexAdapter extends BotAdapter {
             if (activity.from.id === this.identity.id) {
                 activity.channelData.botkitEventType = 'self_message';
                 activity.type = ActivityTypes.Event;
+            } else if(activity.channelData.mentionedPeople.includes(this.identity.id)) {
+                // this is someone trying to talk to the bot
+                activity.channelData.botkitEventType = 'direct_mention';
             } else {
                 // change the event type of messages sent in 1:1s
                 if (activity.channelData.roomType === 'direct') {


### PR DESCRIPTION
I submitted an issue about this here: #2221 

This is the code I was able to use to get my bot working and responding to the ```direct_mention``` event type. I'd be happy to expand on this if there are edge cases that aren't covered by this or if there are tweaks that need to be made. 