### PR TITLE
Enhanced FB Workplace Compatibility and added Workplace Group Thread support

### DIFF
--- a/packages/botbuilder-adapter-facebook/package.json
+++ b/packages/botbuilder-adapter-facebook/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "botbuilder-adapter-facebook",
-  "version": "1.0.12",
+  "name": "acn-botbuilder-adapter-facebook",
+  "version": "1.0.13",
   "description": "Connect Botkit or BotBuilder to Facebook Messenger",
   "main": "lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/packages/botbuilder-adapter-facebook/package.json
+++ b/packages/botbuilder-adapter-facebook/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "acn-botbuilder-adapter-facebook",
+  "name": "@marco.maldonado22/botbuilder-adapter-facebook",
   "version": "1.0.13",
   "description": "Connect Botkit or BotBuilder to Facebook Messenger",
   "main": "lib/index.js",

--- a/packages/botbuilder-adapter-facebook/package.json
+++ b/packages/botbuilder-adapter-facebook/package.json
@@ -26,13 +26,13 @@
     "chatbots",
     "azure"
   ],
-  "homepage": "https://github.com/howdyai/botkit/blob/master/packages/botbuilder-adapter-facebook#readme",
+  "homepage": "https://github.com/marcopolo39/botkit/blob/master/packages/botbuilder-adapter-facebook#readme",
   "bugs": {
-    "url": "https://github.com/howdyai/botkit/issues"
+    "url": "https://github.com/marcopolo39/botkit/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/howdyai/botkit.git"
+    "url": "https://github.com/marcopolo39/botkit.git"
   },
   "dependencies": {
     "botbuilder": "^4.15.0",

--- a/packages/botbuilder-adapter-facebook/src/facebook_adapter.ts
+++ b/packages/botbuilder-adapter-facebook/src/facebook_adapter.ts
@@ -385,6 +385,9 @@ export class FacebookAdapter extends BotAdapter {
         //  in case of Checkbox Plug-in sender.id is not present, instead we should look at optin.user_ref
         if (!message.sender && message.optin && message.optin.user_ref) {
             message.sender = { id: message.optin.user_ref };
+        } else if (!message.sender){
+            // Ignore message in case where message sender does not exist. FB Workplace sends messages automatically in some cases and botkit cannot read them causing it to throw an error
+            return
         }
 
         const activity: Activity = {


### PR DESCRIPTION
- Fixed an issue where bot would receive random requests from workplace which would cause the bot to crash. 
- Added support for workplace threads by extracting thread from incoming request and replacing user id to thread_id in outgoing request