### PR TITLE
Change Polyfill.io URL to Cloudflare alternative

### DIFF
--- a/packages/botbuilder-adapter-web/client/index.html
+++ b/packages/botbuilder-adapter-web/client/index.html
@@ -1,7 +1,7 @@
 <html>
     <head>
         <title>Botkit Anywhere</title>
-        <script src="https://cdn.polyfill.io/v3/polyfill.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.10/handlebars.min.js"></script>
         <script src="https://cdn.rawgit.com/showdownjs/showdown/1.7.4/dist/showdown.min.js"></script>
         <link rel="stylesheet" href="/css/styles.css" />


### PR DESCRIPTION
Changes import of compromised domain `polyfill.io` utilized in Supply Chain Attacks: https://sansec.io/research/polyfill-supply-chain-attack to cloudflare alternative